### PR TITLE
fix bar crash if a temperature sensor gives a negative value

### DIFF
--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -31,7 +31,7 @@ impl Temperature {
                 id,
             }
         }
-        
+
     }
 }
 
@@ -56,7 +56,9 @@ impl Block for Temperature
                     .collect::<Vec<_>>();
 
                 if rest[1].starts_with("input") {
-                    temperatures.push(rest[2].parse::<u64>().unwrap());
+                    if let Some(t) = rest[2].parse::<u64>().ok() {
+                        temperatures.push(t);
+                    }
                 }
             }
         }

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -61,10 +61,10 @@ impl Block for Temperature
                             temperatures.push(t);
                         }
                         Ok(t) => {
-                            printeln!("Temperature ({}) outside range of -100 C to 150 C", t);
+                            eprintln!("Temperature ({}) outside range of -100 C to 150 C", t);
                         }
                         Err(e) => {
-                            printeln!("Temperature not a i64!:\n{}", e);
+                            eprintln!("Temperature not a i64!:\n{}", e);
                         }
                     }
                 }

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -45,7 +45,7 @@ impl Block for Temperature
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
             .unwrap_or_else(|e| e.description().to_owned());
 
-        let mut temperatures: Vec<u64> = Vec::new();
+        let mut temperatures: Vec<i64> = Vec::new();
 
         for line in output.lines() {
             if line.starts_with("  temp") {
@@ -56,17 +56,25 @@ impl Block for Temperature
                     .collect::<Vec<_>>();
 
                 if rest[1].starts_with("input") {
-                    if let Some(t) = rest[2].parse::<u64>().ok() {
-                        temperatures.push(t);
+                    match rest[2].parse::<i64>() {
+                        Ok(t) if t > -101 && t < 151 => {
+                            temperatures.push(t);
+                        }
+                        Ok(t) => {
+                            printeln!("Temperature ({}) outside range of -100 C to 150 C", t);
+                        }
+                        Err(e) => {
+                            printeln!("Temperature not a i64!:\n{}", e);
+                        }
                     }
                 }
             }
         }
 
         if !temperatures.is_empty() {
-            let max: u64 = *temperatures.iter().max().unwrap();
-            let avg: u64 = (temperatures.iter().sum::<u64>() as f64 /
-                temperatures.len() as f64).round() as u64;
+            let max: i64 = *temperatures.iter().max().unwrap();
+            let avg: i64 = (temperatures.iter().sum::<i64>() as f64 /
+                temperatures.len() as f64).round() as i64;
 
             self.output = format!("{}° avg, {}° max", avg, max);
             if !self.collapsed {

--- a/src/util.rs
+++ b/src/util.rs
@@ -190,7 +190,7 @@ macro_rules! get_f64_default {
 }
 
 // any uses should be replaced with eprintln! once it is on stable
-macro_rules! eprinteln {
+macro_rules! eprintln {
     ($fmt:expr, $($arg:tt)*) => {
         use ::std::io::Write;
         writeln!(&mut ::std::io::stderr(), $fmt, $($arg)*);

--- a/src/util.rs
+++ b/src/util.rs
@@ -189,7 +189,13 @@ macro_rules! get_f64_default {
     ($config:expr, $name:expr, $default:expr) => {$config[$name].as_f64().unwrap_or($default)};
 }
 
-
+// any uses should be replaced with eprintln! once it is on stable
+macro_rules! printeln {
+    ($fmt:expr, $($arg:tt)*) => {
+        use ::std::io::Write;
+        writeln!(&mut ::std::io::stderr(), $fmt, $($arg)*);
+    };
+}
 
 macro_rules! get_bool {
     ($config:expr, $name:expr) => {$config[$name].as_bool().expect(&format!("Required argument {} not found in block config!", $name))};

--- a/src/util.rs
+++ b/src/util.rs
@@ -190,7 +190,7 @@ macro_rules! get_f64_default {
 }
 
 // any uses should be replaced with eprintln! once it is on stable
-macro_rules! printeln {
+macro_rules! eprinteln {
     ($fmt:expr, $($arg:tt)*) => {
         use ::std::io::Write;
         writeln!(&mut ::std::io::stderr(), $fmt, $($arg)*);


### PR DESCRIPTION
One of my sensors seems to not be working and gives -128 as the input.. that is obviously wrong but it crashes the program. So, I made it ignore any issues with the number parsing in the temperature. Maybe an error should be raised somewhere for awareness but it shouldn't kill everything.