### PR TITLE
Fix calculation of CPU usage for the case where it is 100%.

### DIFF
--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -72,7 +72,7 @@ impl Block for Cpu
 
                 // This check is needed because the new values may be reset, for
                 // example after hibernation.
-                if prev_total < total || self.prev_idle < idle {
+                if prev_total < total && self.prev_idle <= idle {
                     total_delta = total - prev_total;
                     idle_delta = idle - self.prev_idle;
                 }

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -72,7 +72,7 @@ impl Block for Cpu
 
                 // This check is needed because the new values may be reset, for
                 // example after hibernation.
-                if prev_total < total && self.prev_idle < idle {
+                if prev_total < total || self.prev_idle < idle {
                     total_delta = total - prev_total;
                     idle_delta = idle - self.prev_idle;
                 }


### PR DESCRIPTION
In that case, the idle time will not increase between samples, so
using && would result in displaying 0% CPU usage.