### PR TITLE
Update pacman update count on `click`

### DIFF
--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 use std::process::Command;
 use std::env;
-use std::ffi::OsString;
+use std::ffi::OsString; 
 
 use block::Block;
 use input::I3barEvent;

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::ffi::OsString;
 
 use block::Block;
+use input::I3barEvent;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
 
@@ -90,5 +91,14 @@ impl Block for Pacman
     }
     fn id(&self) -> &str {
         &self.id
+    }
+
+    fn click(&mut self, event: &I3barEvent) {
+        if event.name
+            .as_ref()
+            .map(|s| s == "pacman")
+            .unwrap_or(false) && event.button == 1 /* left mouse button */ {
+            self.update();
+        }
     }
 }


### PR DESCRIPTION
Simple addition to the pacman block: update the package count on a left click. (This does not conflict with the changes in #37).