### PR TITLE
Cleanup i3barevent, introduce `enum MouseButton`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["XYunknown <developement@kai-greshake.de>"]
 
 [dependencies]
 chrono = "0.2"
-serde = "0.9"
-serde_derive = "0.9"
-serde_json = "0.9"
+serde = "^1.0"
+serde_derive = "^1.0"
+serde_json = "^1.0"
 clap = "2.23.2"
 uuid = { version = "0.4", features = ["v4"] }
 dbus = "0.5.2"

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ fn id(&self) -> &str {
 ```
 
 
-### `fn click(&mut self, event: &I3barEvent)` (Optional)
+### `fn click(&mut self, event: &I3BarEvent)` (Optional)
 
 Here you can react to the user clicking your block. The i3barEvent instance contains all fields to describe the click action, including mouse button and location down to the pixel. You may also update the internal state here. **Note that this event is sent to every block on every click**. *To filter, use the event.name property, which corresponds to the name property on widgets!*
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a WiP replacement for i3status, aiming to provide the most feature-compl
 - click actions
 - blocks can trigger updates asynchronously, which allows for things like dbus signaling, to avoid periodic refreshing of data that rarely changes (example: music block)
 
-# Requirements
+# Requirements 
 i3, rustc and cargo. Only tested on Arch Linux. If you want to use the font icons on Arch, install ttf-font-awesome from the AUR.
 
 # How to use it

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,6 +1,6 @@
 
 use std::time::Duration;
-use input::I3barEvent;
+use input::I3BarEvent;
 use widget::I3BarWidget;
 
 pub trait Block {
@@ -14,7 +14,7 @@ pub trait Block {
     #[allow(unused_variables)]
     /// This function is called on every block for every click.
     /// Filter events by using the event.name property (matches the ButtonWidget name)
-    fn click(&mut self, event: &I3barEvent) {}
+    fn click(&mut self, event: &I3BarEvent) {}
 
     /// This function returns a unique id.
     fn id(&self) -> &str;

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use block::Block;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
-use input::I3barEvent;
+use input::I3BarEvent;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 
@@ -96,7 +96,7 @@ impl Block for Battery
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.output]
     }
-    fn click(&mut self, _: &I3barEvent) {}
+    fn click(&mut self, _: &I3BarEvent) {}
     fn id(&self) -> &str {
         &self.id
     }

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use block::Block;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
-use input::I3barEvent;
+use input::I3BarEvent;
 
 use std::io::BufReader;
 use std::io::prelude::*;
@@ -99,7 +99,7 @@ impl Block for Cpu
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.utilization]
     }
-    fn click(&mut self, _: &I3barEvent) {}
+    fn click(&mut self, _: &I3BarEvent) {}
     fn id(&self) -> &str {
         &self.id
     }

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc::Sender;
 use block::Block;
 use widgets::button::ButtonWidget;
 use widget::I3BarWidget;
-use input::I3barEvent;
+use input::I3BarEvent;
 use scheduler::Task;
 
 use serde_json::Value;
@@ -83,7 +83,7 @@ impl Block for Custom {
         vec![&self.output]
     }
 
-    fn click(&mut self, event: &I3barEvent) {
+    fn click(&mut self, event: &I3BarEvent) {
         if let Some(ref name) = event.name {
             if name != &self.id {
                 return

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 use std::path::Path;
 
 use block::Block;
-use input::I3barEvent;
+use input::I3BarEvent;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
 
@@ -139,7 +139,7 @@ impl Block for DiskSpace {
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.disk_space]
     }
-    fn click(&mut self, _: &I3barEvent) {}
+    fn click(&mut self, _: &I3BarEvent) {}
     fn id(&self) -> &str {
         &self.id
     }

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use block::Block;
 use widgets::text::TextWidget;
 use widget::I3BarWidget;
-use input::I3barEvent;
+use input::I3BarEvent;
 use scheduler::Task;
 
 use serde_json::Value;
@@ -95,7 +95,7 @@ impl Block for FocusedWindow
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
-    fn click(&mut self, _: &I3barEvent) {}
+    fn click(&mut self, _: &I3BarEvent) {}
     fn id(&self) -> &str {
         &self.id
     }

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use block::Block;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
-use input::I3barEvent;
+use input::I3BarEvent;
 use util::FormatTemplate;
 
 use std::io::BufReader;
@@ -81,7 +81,7 @@ impl Block for Load
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
-    fn click(&mut self, _: &I3barEvent) {}
+    fn click(&mut self, _: &I3BarEvent) {}
     fn id(&self) -> &str {
         &self.id
     }

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -74,7 +74,7 @@ use std::sync::mpsc::Sender;
 use std::fs::File;
 use std::io::{BufReader, BufRead};
 use block::Block;
-use input::I3barEvent;
+use input::I3BarEvent;
 use std::str::FromStr;
 use serde_json::Value;
 use uuid::Uuid;
@@ -432,7 +432,7 @@ impl Block for Memory
     }
 
 
-    fn click(&mut self, event: &I3barEvent) {
+    fn click(&mut self, event: &I3BarEvent) {
 
         if_debug!({
             let mut f = OpenOptions::new().create(true).append(true).open("/tmp/i3log").unwrap();

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -74,7 +74,7 @@ use std::sync::mpsc::Sender;
 use std::fs::File;
 use std::io::{BufReader, BufRead};
 use block::Block;
-use input::I3BarEvent;
+use input::{I3BarEvent, MouseButton};
 use std::str::FromStr;
 use serde_json::Value;
 use uuid::Uuid;
@@ -440,7 +440,7 @@ impl Block for Memory
         });
 
         if let Some(ref s) = event.name {
-            if self.clickable && event.button == 1 && *s == "memory".to_string() {
+            if self.clickable && event.button == MouseButton::LeftClick && *s == "memory".to_string() {
                 self.switch();
                 self.update();
                 self.tx_update_request.send(Task {

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -4,7 +4,7 @@ use std::thread;
 use std::boxed::Box;
 
 use scheduler::Task;
-use input::I3barEvent;
+use input::I3BarEvent;
 use block::Block;
 use widgets::rotatingtext::RotatingTextWidget;
 use widgets::button::ButtonWidget;
@@ -140,7 +140,7 @@ impl Block for Music
     }
 
 
-    fn click(&mut self, event: &I3barEvent) {
+    fn click(&mut self, event: &I3BarEvent) {
         if event.name.is_some() {
             let action = match &event.name.clone().unwrap() as &str {
                 "play" => "PlayPause",

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use block::Block;
 use widgets::button::ButtonWidget;
 use widget::{I3BarWidget, State};
-use input::I3barEvent;
+use input::I3BarEvent;
 
 use serde_json::Value;
 use uuid::Uuid;
@@ -85,7 +85,7 @@ impl Block for Sound
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
-    fn click(&mut self, e: &I3barEvent) {
+    fn click(&mut self, e: &I3BarEvent) {
         if let Some(ref name) = e.name {
             if name.as_str() == self.id {
                 Command::new("amixer")

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 use block::Block;
 use widgets::button::ButtonWidget;
 use widget::{I3BarWidget, State};
-use input::I3barEvent;
+use input::I3BarEvent;
 
 use serde_json::Value;
 use uuid::Uuid;
@@ -95,7 +95,7 @@ impl Block for Temperature
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
-    fn click(&mut self, e: &I3barEvent) {
+    fn click(&mut self, e: &I3BarEvent) {
         if let Some(ref name) = e.name {
             if name.as_str() == self.id {
                 self.collapsed = !self.collapsed;

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc::Sender;
 use block::Block;
 use widgets::text::TextWidget;
 use widget::I3BarWidget;
-use input::I3barEvent;
+use input::I3BarEvent;
 use scheduler::Task;
 
 use serde_json::Value;
@@ -47,7 +47,7 @@ impl Block for Template
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
-    fn click(&mut self, _: &I3barEvent) {}
+    fn click(&mut self, _: &I3BarEvent) {}
     fn id(&self) -> &str {
         &self.id
     }

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 use block::Block;
 use widgets::button::ButtonWidget;
 use widget::I3BarWidget;
-use input::I3barEvent;
+use input::I3BarEvent;
 
 use serde_json::Value;
 use uuid::Uuid;
@@ -63,7 +63,7 @@ impl Block for Toggle
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
-    fn click(&mut self, e: &I3barEvent) {
+    fn click(&mut self, e: &I3BarEvent) {
         if let Some(ref name) = e.name {
             if name.as_str() == self.id {
                 let cmd = match self.toggled {

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -7,7 +7,7 @@ use util::FormatTemplate;
 use block::Block;
 use widgets::button::ButtonWidget;
 use widget::I3BarWidget;
-use input::I3barEvent;
+use input::I3BarEvent;
 
 use serde_json::Value;
 use uuid::Uuid;
@@ -185,7 +185,7 @@ impl Block for Xrandr
         vec![&self.text]
     }
 
-    fn click(&mut self, e: &I3barEvent) {
+    fn click(&mut self, e: &I3BarEvent) {
         if let Some(ref name) = e.name {
             if name.as_str() == self.id {
                 if self.current_idx < self.monitors.len() - 1 {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,19 +1,30 @@
-extern crate serde_json;
-
+use serde::{de, Deserializer};
+use serde_json;
+use std::fmt;
 use std::io;
 use std::option::Option;
 use std::string::*;
 use std::sync::mpsc::Sender;
 use std::thread;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MouseButton {
+    LeftClick,
+    RightClick,
+    MiddleClick,
+    WheelUp,
+    WheelDown,
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct I3BarEvent {
     pub name: Option<String>,
     pub instance: Option<String>,
     pub x: u64,
     pub y: u64,
-    // Button Codes: 1 -> Left, 2 -> Middle, 3 -> Right
-    pub button: u64,
+
+    #[serde(deserialize_with = "deserialize_mousebutton")]
+    pub button: MouseButton,
 }
 
 pub fn process_events(sender: Sender<I3BarEvent>) {
@@ -29,4 +40,35 @@ pub fn process_events(sender: Sender<I3BarEvent>) {
             sender.send(e).unwrap();
         }
     });
+}
+
+fn deserialize_mousebutton<'de, D>(deserializer: D) -> Result<MouseButton, D::Error>
+where
+    D: Deserializer<'de>
+{
+    struct MouseButtonVisitor;
+
+    impl<'de> de::Visitor<'de> for MouseButtonVisitor {
+        type Value = MouseButton;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("u64")
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error
+        {
+            Ok(match value {
+                   1 => MouseButton::LeftClick,
+                   2 => MouseButton::RightClick,
+                   3 => MouseButton::MiddleClick,
+                   4 => MouseButton::WheelUp,
+                   5 => MouseButton::WheelDown,
+                   _ => return Err(de::Error::custom("unknown mouse button")),
+               })
+        }
+    }
+
+    deserializer.deserialize_any(MouseButtonVisitor)
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::Sender;
 use std::thread;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct I3barEvent {
+pub struct I3BarEvent {
     pub name: Option<String>,
     pub instance: Option<String>,
     pub x: u64,
@@ -16,7 +16,7 @@ pub struct I3barEvent {
     pub button: u64,
 }
 
-pub fn process_events(sender: Sender<I3barEvent>) {
+pub fn process_events(sender: Sender<I3BarEvent>) {
     thread::spawn(move || loop {
         let mut input = String::new();
         io::stdin().read_line(&mut input).unwrap();
@@ -24,7 +24,7 @@ pub fn process_events(sender: Sender<I3barEvent>) {
         if input.starts_with(",") {
             let input = input.split_off(1);
 
-            let e: I3barEvent = serde_json::from_str(&input).unwrap();
+            let e: I3BarEvent = serde_json::from_str(&input).unwrap();
 
             sender.send(e).unwrap();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 
 #[macro_use]
 extern crate serde_derive;
+extern crate serde;
 
 #[macro_use]
 extern crate serde_json;

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ use std::ops::DerefMut;
 use block::Block;
 
 use blocks::create_block;
-use input::{process_events, I3barEvent};
+use input::{process_events, I3BarEvent};
 use scheduler::{UpdateScheduler, Task};
 use themes::get_theme;
 use icons::get_icons;
@@ -156,7 +156,7 @@ fn main() {
     print!("{{\"version\": 1, \"click_events\": true}}\n[");
 
     // We wait for click events in a seperate thread, to avoid blocking to wait for stdin
-    let (tx, rx_clicks): (Sender<I3barEvent>, Receiver<I3barEvent>) = mpsc::channel();
+    let (tx, rx_clicks): (Sender<I3BarEvent>, Receiver<I3BarEvent>) = mpsc::channel();
     process_events(tx);
 
     loop {


### PR DESCRIPTION
This PR does two things:

* Rename `I3barEvent` to `I3BarEvent` to be consistent with the capitalization of `I3BarWidget`.
* Change the type of `I3BarEvent::button` from `u64` to an enum `MouseButton` which makes matching in an event a lot easier and a lot more readable.

    This has been achieved through:

    * updating serde to 1.0 (not strictly required),
    * removing the `Serialize` derive from `I3BarEvent` (since we only go the one direction anyway),
    * implementing a custom deserializer for the `I3BarEvent::button` field.

This is related to #36 and probably supersedes it. (cc @Drogglbecher @greshake)