### PR TITLE
Implement error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,14 +463,14 @@ Example:
 impl ConfigBlock for Template {
     type Config = TemplateConfig;
 
-    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Self {
-        Template {
+    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Result<Self> {
+        Ok(Template {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
-            text: TextWidget::new(config.clone()).with_text("Template"),
+            text: TextWidget::new(config.clone()).with_text("Template")?,
             tx_update_request: tx_update_request,
             config: config,
-        }
+        })
     }
 }
 ```
@@ -481,13 +481,13 @@ This is required in addition to the `ConfigBlock` trait and is used to interact 
 
 This trait defines the following features:
 
-### `fn update(&mut self) -> Option<Duration>` (Required if you don't want a static block)
+### `fn update(&mut self) -> Result<Option<Duration>>` (Required if you don't want a static block)
 
 Use this function to update the internal state of your block, for example during periodic updates. Return the duration until your block wants to be updated next. For example, a clock could request only to be updated every 60 seconds by returning Some(Duration::new(60, 0)) every time. If you return None, this function will not be called again automatically.
 
 Example:
 ```rust
-fn update(&mut self) -> Option<Duration> {
+fn update(&mut self) -> Result<Option<Duration>> {
       self.time.set_text(format!("{}", Local::now().format(&self.format)));
       Some(self.update_interval.clone())
 }
@@ -516,20 +516,22 @@ fn id(&self) -> &str {
 ```
 
 
-### `fn click(&mut self, event: &I3BarEvent)` (Optional)
+### `fn click(&mut self, event: &I3BarEvent) -> Result<()>` (Optional)
 
-Here you can react to the user clicking your block. The i3barEvent instance contains all fields to describe the click action, including mouse button and location down to the pixel. You may also update the internal state here. **Note that this event is sent to every block on every click**. *To filter, use the event.name property, which corresponds to the name property on widgets!*
+Here you can react to the user clicking your block. The I3BarEvent instance contains all fields to describe the click action, including mouse button and location down to the pixel. You may also update the internal state here. **Note that this event is sent to every block on every click**. *To filter, use the event.name property, which corresponds to the name property on widgets!*
 
 Example:
 ```rust
-if event.name.is_some() {
-            let action = match &event.name.clone().unwrap() as &str {
-                  "play" => "PlayPause",
-                  "next" => "Next",
-                  "prev" => "Previous",
-                  _ => ""
-            };
-      }
+fn click(&mut self, event: &I3BarEvent) -> Result<()> {
+    if event.name.is_some() {
+        let action = match &event.name.clone().unwrap() as &str {
+              "play" => "PlayPause",
+              "next" => "Next",
+              "prev" => "Previous",
+              _ => ""
+        };
+    }
+    Ok(())
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ impl ConfigBlock for Template {
         Ok(Template {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
-            text: TextWidget::new(config.clone()).with_text("Template")?,
+            text: TextWidget::new(config.clone()).with_text("Template"),
             tx_update_request: tx_update_request,
             config: config,
         })

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,4 +1,5 @@
 use config::Config;
+use errors::*;
 use scheduler::Task;
 use std::sync::mpsc::Sender;
 use std::time::Duration;
@@ -7,8 +8,8 @@ use widget::I3BarWidget;
 
 pub trait Block {
     /// Updates the internal state of a Block
-    fn update(&mut self) -> Option<Duration> {
-        None
+    fn update(&mut self) -> Result<Option<Duration>> {
+        Ok(None)
     }
     /// Returns the view of the block, comprised of widgets
     fn view(&self) -> Vec<&I3BarWidget>;
@@ -16,7 +17,9 @@ pub trait Block {
     #[allow(unused_variables)]
     /// This function is called on every block for every click.
     /// Filter events by using the event.name property (matches the ButtonWidget name)
-    fn click(&mut self, event: &I3BarEvent) {}
+    fn click(&mut self, event: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
 
     /// This function returns a unique id.
     fn id(&self) -> &str;
@@ -25,5 +28,7 @@ pub trait Block {
 pub trait ConfigBlock: Block {
     type Config;
 
-    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Self;
+    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Result<Self>
+    where
+        Self: Sized;
 }

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -101,9 +101,9 @@ impl Block for Battery
 
         // Don't need to display a percentage when the battery is full
         if current_percentage != 100 && state != "Full" {
-            self.output.set_text(format!("{}%", current_percentage))?;
+            self.output.set_text(format!("{}%", current_percentage));
         } else {
-            self.output.set_text(String::from(""))?;
+            self.output.set_text(String::from(""));
         }
 
         self.output.set_icon(match state.as_str() {
@@ -111,14 +111,14 @@ impl Block for Battery
             "Discharging" => "bat_discharging",
             "Charging" => "bat_charging",
             _ => "bat"
-        })?;
+        });
 
         self.output.set_state(match current_percentage {
             0 ... 15 => State::Critical,
             15 ... 30 => State::Warning,
             30 ... 60 => State::Info,
             _ => State::Good
-        })?;
+        });
 
         Ok(Some(self.update_interval.clone()))
     }

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -43,7 +43,7 @@ impl ConfigBlock for Cpu {
     type Config = CpuConfig;
 
     fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
-        let text = TextWidget::new(config).with_icon("cpu")?;
+        let text = TextWidget::new(config).with_icon("cpu");
         Ok(Cpu {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
@@ -108,9 +108,9 @@ impl Block for Cpu
             30 ... 60 => State::Info,
             60 ... 90 => State::Warning,
             _ => State::Critical
-        })?;
+        });
 
-        self.utilization.set_text(format!("{:02}%", utilization))?;
+        self.utilization.set_text(format!("{:02}%", utilization));
 
         Ok(Some(self.update_interval.clone()))
     }

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -5,6 +5,7 @@ use scheduler::Task;
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
+use errors::*;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
 use input::I3BarEvent;
@@ -41,23 +42,24 @@ impl CpuConfig {
 impl ConfigBlock for Cpu {
     type Config = CpuConfig;
 
-    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
-        let text = TextWidget::new(config).with_icon("cpu");
-        return Cpu {
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
+        let text = TextWidget::new(config).with_icon("cpu")?;
+        Ok(Cpu {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
             utilization: text,
             prev_idle: 0,
             prev_non_idle: 0,
-        }
+        })
     }
 }
 
 
 impl Block for Cpu
 {
-    fn update(&mut self) -> Option<Duration> {
-        let f = File::open("/proc/stat").expect("Your system doesn't support /proc/stat");
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let f = File::open("/proc/stat")
+            .block_error("cpu", "Your system doesn't support /proc/stat")?;
         let f = BufReader::new(f);
 
         let mut utilization = 0;
@@ -106,16 +108,18 @@ impl Block for Cpu
             30 ... 60 => State::Info,
             60 ... 90 => State::Warning,
             _ => State::Critical
-        });
+        })?;
 
-        self.utilization.set_text(format!("{:02}%", utilization));
+        self.utilization.set_text(format!("{:02}%", utilization))?;
 
-        Some(self.update_interval.clone())
+        Ok(Some(self.update_interval.clone()))
     }
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.utilization]
     }
-    fn click(&mut self, _: &I3BarEvent) {}
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
     fn id(&self) -> &str {
         &self.id
     }

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -97,7 +97,7 @@ impl Block for Custom {
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
             .unwrap_or_else(|e| e.description().to_owned());
 
-        self.output.set_text(output)?;
+        self.output.set_text(output);
 
         Ok(Some(self.update_interval.clone()))
     }

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -155,7 +155,7 @@ impl ConfigBlock for DiskSpace {
         Ok(DiskSpace {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
-            disk_space: TextWidget::new(config).with_text("DiskSpace")?,
+            disk_space: TextWidget::new(config).with_text("DiskSpace"),
             alias: block_config.alias,
             path: block_config.path,
             info_type: InfoType::from_str(&block_config.info_type),
@@ -183,10 +183,10 @@ impl Block for DiskSpace {
             //InfoType::Total | InfoType::Used => unimplemented!(),
         }
 
-        self.disk_space.set_text(format!("{0} {1:.2} {2}", self.alias, converted, self.unit.name()))?;
+        self.disk_space.set_text(format!("{0} {1:.2} {2}", self.alias, converted, self.unit.name()));
 
         let state = self.compute_state(result);
-        self.disk_space.set_state(state)?;
+        self.disk_space.set_state(state);
 
         Ok(Some(self.update_interval.clone()))
     }

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -104,7 +104,7 @@ impl Block for FocusedWindow
     fn update(&mut self) -> Result<Option<Duration>> {
         let mut string = (*self.title.lock().block_error("focused_window", "failed to acquire lock")?).clone();
         string.truncate(self.max_width);
-        self.text.set_text(string)?;
+        self.text.set_text(string);
         Ok(None)
     }
     fn view(&self) -> Vec<&I3BarWidget> {

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use errors::*;
 use widgets::text::TextWidget;
 use widget::I3BarWidget;
 use input::I3BarEvent;
@@ -44,7 +45,7 @@ impl FocusedWindowConfig {
 impl ConfigBlock for FocusedWindow {
     type Config = FocusedWindowConfig;
 
-    fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Self {
+    fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
         let id = Uuid::new_v4().simple().to_string();
         let id_clone = id.clone();
 
@@ -88,28 +89,30 @@ impl ConfigBlock for FocusedWindow {
             }
         });
 
-        FocusedWindow {
+        Ok(FocusedWindow {
             id,
             text: TextWidget::new(config),
             max_width: block_config.max_width,
             title
-        }
+        })
     }
 }
 
 
 impl Block for FocusedWindow
 {
-    fn update(&mut self) -> Option<Duration> {
-        let mut string = (*self.title.lock().unwrap()).clone();
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let mut string = (*self.title.lock().block_error("focused_window", "failed to acquire lock")?).clone();
         string.truncate(self.max_width);
-        self.text.set_text(string);
-        None
+        self.text.set_text(string)?;
+        Ok(None)
     }
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
-    fn click(&mut self, _: &I3BarEvent) {}
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
     fn id(&self) -> &str {
         &self.id
     }

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
+use errors::*;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
 use input::I3BarEvent;
@@ -46,10 +47,10 @@ impl LoadConfig {
 impl ConfigBlock for Load {
     type Config = LoadConfig;
 
-    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
-        let text = TextWidget::new(config).with_icon("cogs").with_state(State::Info);
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
+        let text = TextWidget::new(config).with_icon("cogs")?.with_state(State::Info)?;
 
-        let f = File::open("/proc/cpuinfo").expect("Your system doesn't support /proc/cpuinfo");
+        let f = File::open("/proc/cpuinfo").block_error("load", "Your system doesn't support /proc/cpuinfo")?;
         let f = BufReader::new(f);
 
         let mut logical_cores = 0;
@@ -58,30 +59,30 @@ impl ConfigBlock for Load {
             // TODO: Does this value always represent the correct number of logical cores?
             if line.starts_with("siblings") {
                 let split: Vec<&str> = (&line).split(" ").collect();
-                logical_cores = split[1].parse::<u32>().expect("Invalid Cpu info format!");
+                logical_cores = split[1].parse::<u32>().block_error("load", "Invalid Cpu info format!")?;
                 break;
             }
         }
 
-        Load {
+        Ok(Load {
             id: Uuid::new_v4().simple().to_string(),
             logical_cores: logical_cores,
             update_interval: block_config.interval,
-            format: FormatTemplate::from_string(block_config.format).expect("Invalid format specified for load"),
+            format: FormatTemplate::from_string(block_config.format).block_error("load", "Invalid format specified for load")?,
             text: text
-        }
+        })
     }
 }
 
 impl Block for Load
 {
-    fn update(&mut self) -> Option<Duration> {
+    fn update(&mut self) -> Result<Option<Duration>> {
         let mut f = OpenOptions::new()
             .read(true)
             .open("/proc/loadavg")
-            .expect("Your system does not support reading the load average from /proc/loadavg");
+            .block_error("load", "Your system does not support reading the load average from /proc/loadavg")?;
         let mut loadavg = String::new();
-        f.read_to_string(&mut loadavg).expect("Failed to read the load average of your system!");
+        f.read_to_string(&mut loadavg).block_error("load", "Failed to read the load average of your system!")?;
 
         let split: Vec<&str> = (&loadavg).split(" ").collect();
 
@@ -89,23 +90,25 @@ impl Block for Load
                           "{5m}" => split[1],
                           "{15m}" => split[2]);
 
-        let used_perc = values["{1m}"].parse::<f32>().unwrap() / self.logical_cores as f32;
+        let used_perc = values["{1m}"].parse::<f32>().block_error("load", "failed to parse float percentage")? / self.logical_cores as f32;
         self.text.set_state(
             match  used_perc {
                 0. ... 0.3 => State::Idle,
                 0.3 ... 0.6 => State::Info,
                 0.6 ... 0.9 => State::Warning,
                 _ => State::Critical
-        });
+        })?;
 
-        self.text.set_text(self.format.render_static_str(&values));
+        self.text.set_text(self.format.render_static_str(&values)?)?;
 
-        Some(self.update_interval.clone())
+        Ok(Some(self.update_interval.clone()))
     }
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
-    fn click(&mut self, _: &I3BarEvent) {}
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
     fn id(&self) -> &str {
         &self.id
     }

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -48,7 +48,7 @@ impl ConfigBlock for Load {
     type Config = LoadConfig;
 
     fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
-        let text = TextWidget::new(config).with_icon("cogs")?.with_state(State::Info)?;
+        let text = TextWidget::new(config).with_icon("cogs").with_state(State::Info);
 
         let f = File::open("/proc/cpuinfo").block_error("load", "Your system doesn't support /proc/cpuinfo")?;
         let f = BufReader::new(f);
@@ -97,9 +97,9 @@ impl Block for Load
                 0.3 ... 0.6 => State::Info,
                 0.6 ... 0.9 => State::Warning,
                 _ => State::Critical
-        })?;
+        });
 
-        self.text.set_text(self.format.render_static_str(&values)?)?;
+        self.text.set_text(self.format.render_static_str(&values)?);
 
         Ok(Some(self.update_interval.clone()))
     }

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -350,14 +350,14 @@ impl Memory {
                     x if x as f64 > self.warning.0 => State::Warning,
                     _ => State::Idle,
                 }
-            )?,
+            ),
             Memtype::SWAP => self.output.1.set_state(
                 match swap_used.percent(swap_total) {
                     x if x as f64 > self.critical.1 => State::Critical,
                     x if x as f64 > self.warning.1 => State::Warning,
                     _ => State::Idle,
                 }
-            )?
+            )
         };
 
         if_debug!({
@@ -393,7 +393,7 @@ impl ConfigBlock for Memory {
     fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
         let memtype: String = block_config.display_type;
         let icons: bool = block_config.icons;
-        let widget = ButtonWidget::new(config, "memory").with_text("")?;
+        let widget = ButtonWidget::new(config, "memory").with_text("");
         let memory = Memory {
             name: Uuid::new_v4().simple().to_string(),
             memtype: match memtype.as_ref() {
@@ -403,7 +403,7 @@ impl ConfigBlock for Memory {
             },
             output:
             if icons {
-                (widget.clone().with_icon("memory_mem")?, widget.with_icon("memory_swap")?)
+                (widget.clone().with_icon("memory_mem"), widget.with_icon("memory_swap"))
             } else {
                 (widget.clone(), widget)
             }
@@ -502,8 +502,8 @@ impl Block for Memory
         let output_text = self.format_insert_values(mem_state)?;
 
         match self.memtype {
-            Memtype::MEMORY => self.output.0.set_text(output_text)?,
-            Memtype::SWAP => self.output.1.set_text(output_text)?,
+            Memtype::MEMORY => self.output.0.set_text(output_text),
+            Memtype::SWAP => self.output.1.set_text(output_text),
         }
 
         if_debug!({

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -79,9 +79,9 @@ use std::str::FromStr;
 use uuid::Uuid;
 use std::fmt;
 
-
 use config::Config;
 use de::deserialize_duration;
+use errors::*;
 use widgets::button::ButtonWidget;
 use widget::{State,I3BarWidget};
 use scheduler::Task;
@@ -297,7 +297,7 @@ impl MemoryConfig {
 }
 
 impl Memory {
-    fn format_insert_values(&mut self, mem_state: Memstate) -> String {
+    fn format_insert_values(&mut self, mem_state: Memstate) -> Result<String> {
 
         let mem_total = Unit::KiB(mem_state.mem_total());
         let mem_free = Unit::KiB(mem_state.mem_free());
@@ -350,25 +350,30 @@ impl Memory {
                     x if x as f64 > self.warning.0 => State::Warning,
                     _ => State::Idle,
                 }
-            ),
+            )?,
             Memtype::SWAP => self.output.1.set_state(
                 match swap_used.percent(swap_total) {
                     x if x as f64 > self.critical.1 => State::Critical,
                     x if x as f64 > self.warning.1 => State::Warning,
                     _ => State::Idle,
                 }
-            )
+            )?
         };
 
         if_debug!({
-            let mut f = OpenOptions::new().create(true).append(true).open("/tmp/i3log").unwrap();
-            writeln!(f, "Inserted values: {:?}", self.values).unwrap();
+            let mut f = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open("/tmp/i3log")
+                .block_error("memory", "can't open /tmp/i3log")?;
+            writeln!(f, "Inserted values: {:?}", self.values)
+                .block_error("memory", "failed to write to /tmp/i3log")?;
         });
 
-        match self.memtype {
+        Ok(match self.memtype {
             Memtype::MEMORY => self.format.0.render(&self.values),
             Memtype::SWAP => self.format.1.render(&self.values)
-        }
+        })
     }
 
 
@@ -385,10 +390,10 @@ impl Memory {
 impl ConfigBlock for Memory {
     type Config = MemoryConfig;
 
-    fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Self {
+    fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
         let memtype: String = block_config.display_type;
         let icons: bool = block_config.icons;
-        let widget = ButtonWidget::new(config, "memory").with_text("");
+        let widget = ButtonWidget::new(config, "memory").with_text("")?;
         let memory = Memory {
             name: Uuid::new_v4().simple().to_string(),
             memtype: match memtype.as_ref() {
@@ -398,21 +403,21 @@ impl ConfigBlock for Memory {
             },
             output:
             if icons {
-                (widget.clone().with_icon("memory_mem"), widget.with_icon("memory_swap"))
+                (widget.clone().with_icon("memory_mem")?, widget.with_icon("memory_swap")?)
             } else {
                 (widget.clone(), widget)
             }
             ,
             clickable: block_config.clickable,
-            format: (FormatTemplate::from_string(block_config.format_mem).unwrap(),
-                     FormatTemplate::from_string(block_config.format_swap).unwrap()),
+            format: (FormatTemplate::from_string(block_config.format_mem)?,
+                     FormatTemplate::from_string(block_config.format_swap)?),
             update_interval: block_config.interval,
             tx_update_request: tx,
             values: HashMap::<String, String>::new(),
             warning: (block_config.warning_mem, block_config.warning_swap),
             critical: (block_config.critical_mem, block_config.critical_swap),
         };
-        memory
+        Ok(memory)
 
     }
 }
@@ -424,10 +429,10 @@ impl Block for Memory
         &self.name
     }
 
-    fn update(&mut self) -> Option<Duration> {
+    fn update(&mut self) -> Result<Option<Duration>> {
 
-        let f = File::open("/proc/meminfo").expect("/proc/meminfo does not exist. \
-                                                    Are we on a linux system?");
+        let f = File::open("/proc/meminfo")
+            .block_error("memory", "/proc/meminfo does not exist")?;
         let f = BufReader::new(f);
 
         let mut mem_state = Memstate::new();
@@ -435,9 +440,15 @@ impl Block for Memory
 
         for line in f.lines() {
             if_debug!({
-            let mut f = OpenOptions::new().create(true).append(true).open("/tmp/i3log").unwrap();
-            writeln!(f, "Updated: {:?}", mem_state).unwrap();
-        });
+                let mut f = OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open("/tmp/i3log")
+                    .block_error("memory", "can't open /tmp/i3log")?;
+                writeln!(f, "Updated: {:?}", mem_state)
+                    .block_error("memory", "failed to write to /tmp/i3log")?;
+            });
+
             // stop reading if all values are already present
             if mem_state.done() {
                 break
@@ -452,35 +463,35 @@ impl Block for Memory
 
             match line[0] {
                 "MemTotal:" => {
-                    mem_state.mem_total = (u64::from_str(line[1]).unwrap(), true);
+                    mem_state.mem_total = (u64::from_str(line[1]).block_error("memory", "failed to parse mem_total")?, true);
                     continue;
                 }
                 "MemFree:" => {
-                    mem_state.mem_free = (u64::from_str(line[1]).unwrap(), true);
+                    mem_state.mem_free = (u64::from_str(line[1]).block_error("memory", "failed to parse mem_free")?, true);
                     continue;
                 }
                 "Buffers:" => {
-                    mem_state.buffers = (u64::from_str(line[1]).unwrap(), true);
+                    mem_state.buffers = (u64::from_str(line[1]).block_error("memory", "failed to parse buffers")?, true);
                     continue;
                 }
                 "Cached:" => {
-                    mem_state.cached = (u64::from_str(line[1]).unwrap(), true);
+                    mem_state.cached = (u64::from_str(line[1]).block_error("memory", "failed to parse cached")?, true);
                     continue;
                 }
                 "SReclaimable:" => {
-                    mem_state.s_reclaimable = (u64::from_str(line[1]).unwrap(), true);
+                    mem_state.s_reclaimable = (u64::from_str(line[1]).block_error("memory", "failed to parse s_reclaimable")?, true);
                     continue;
                 }
                 "Shmem:" => {
-                    mem_state.shmem = (u64::from_str(line[1]).unwrap(), true);
+                    mem_state.shmem = (u64::from_str(line[1]).block_error("memory", "failed to parse shmem")?, true);
                     continue;
                 }
                 "SwapTotal:" => {
-                    mem_state.swap_total = (u64::from_str(line[1]).unwrap(), true);
+                    mem_state.swap_total = (u64::from_str(line[1]).block_error("memory", "failed to parse swap_total")?, true);
                     continue;
                 }
                 "SwapFree:" => {
-                    mem_state.swap_free = (u64::from_str(line[1]).unwrap(), true);
+                    mem_state.swap_free = (u64::from_str(line[1]).block_error("memory", "failed to parse swap_free")?, true);
                     continue;
                 }
                 _ => { continue; }
@@ -488,40 +499,50 @@ impl Block for Memory
         }
 
         // Now, create the string to be shown
-        let output_text = self.format_insert_values(mem_state);
+        let output_text = self.format_insert_values(mem_state)?;
 
         match self.memtype {
-            Memtype::MEMORY => self.output.0.set_text(output_text),
-            Memtype::SWAP => self.output.1.set_text(output_text),
+            Memtype::MEMORY => self.output.0.set_text(output_text)?,
+            Memtype::SWAP => self.output.1.set_text(output_text)?,
         }
 
         if_debug!({
-            let mut f = OpenOptions::new().create(true).append(true).open("/tmp/i3log").unwrap();
-            writeln!(f, "Updated: {:?}", self).unwrap();
+            let mut f = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open("/tmp/i3log")
+                .block_error("memory", "failed to open /tmp/i3log")?;
+            writeln!(f, "Updated: {:?}", self)
+                .block_error("memory", "failed to write to /tmp/i3log")?;
         });
-        Some(self.update_interval.clone())
+        Ok(Some(self.update_interval.clone()))
     }
 
 
-    fn click(&mut self, event: &I3BarEvent) {
+    fn click(&mut self, event: &I3BarEvent) -> Result<()> {
 
         if_debug!({
-            let mut f = OpenOptions::new().create(true).append(true).open("/tmp/i3log").unwrap();
-            writeln!(f, "Click received: {:?}", event).unwrap();
+            let mut f = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open("/tmp/i3log")
+                .block_error("memory", "failed to open /tmp/i3log")?;
+            writeln!(f, "Click received: {:?}", event)
+                .block_error("memory", "failed to write to /tmp/i3log")?;
         });
 
         if let Some(ref s) = event.name {
             if self.clickable && event.button == MouseButton::Left && *s == "memory".to_string() {
                 self.switch();
-                self.update();
+                self.update()?;
                 self.tx_update_request.send(Task {
                     id: self.name.clone(),
                     update_time: Instant::now()
-                }).ok();
+                })?;
             }
         }
 
-
+        Ok(())
     }
 
     fn view(&self) -> Vec<&I3BarWidget> {

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -44,7 +44,7 @@ use toml::value::Value;
 macro_rules! block {
     ($block_type:ident, $block_config:expr, $config:expr, $tx_update_request:expr) => {{
         let block_config: <$block_type as ConfigBlock>::Config = <$block_type as ConfigBlock>::Config::deserialize($block_config)
-            .internal_error("blocks", "failed to deserialize block config")?;
+            .configuration_error("failed to deserialize block config")?;
         Ok(Box::new($block_type::new(block_config, $config, $tx_update_request)?) as Box<Block>)
     }}
 }

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -96,13 +96,13 @@ impl ConfigBlock for Music {
             match &*button {
                 "play" =>
                     play = Some(ButtonWidget::new(config.clone(), "play")
-                        .with_icon("music_play")?.with_state(State::Info)?),
+                        .with_icon("music_play").with_state(State::Info)),
                 "next" =>
                     next = Some(ButtonWidget::new(config.clone(), "next")
-                        .with_icon("music_next")?.with_state(State::Info)?),
+                        .with_icon("music_next").with_state(State::Info)),
                 "prev" =>
                     prev = Some(ButtonWidget::new(config.clone(), "prev")
-                        .with_icon("music_prev")?.with_state(State::Info)?),
+                        .with_icon("music_prev").with_state(State::Info)),
                 x => Err(BlockError("music".to_owned(), format!("unknown music button identifier: '{}'", x)))?
             };
         }
@@ -113,8 +113,8 @@ impl ConfigBlock for Music {
                                                   Duration::new(0, 500000000),
                                                   block_config.max_width,
                                                   config.clone())
-                              .with_icon("music")?
-                              .with_state(State::Info)?,
+                              .with_icon("music")
+                              .with_state(State::Info),
             prev: prev,
             play: play,
             next: next,
@@ -143,26 +143,26 @@ impl Block for Music
             let data = c.get("org.mpris.MediaPlayer2.Player", "Metadata");
 
             if data.is_err() {
-                self.current_song.set_text(String::from(""))?;
+                self.current_song.set_text(String::from(""));
                 self.player_avail = false;
             } else {
                 let metadata = data.unwrap();
 
                 let (title, artist) = extract_from_metadata(metadata).unwrap_or((String::new(), String::new()));
 
-                self.current_song.set_text(format!("{} | {}", title, artist))?;
+                self.current_song.set_text(format!("{} | {}", title, artist));
                 self.player_avail = true;
             }
             if let Some(ref mut play) = self.play {
                 let data = c.get("org.mpris.MediaPlayer2.Player", "PlaybackStatus");
                 match data {
-                    Err(_) => play.set_icon("music_play")?,
+                    Err(_) => play.set_icon("music_play"),
                     Ok(data) => {
                         let state = data.0;
                         if state.as_str().map(|s| s != "Playing").unwrap_or(false) {
-                            play.set_icon("music_play")?
+                            play.set_icon("music_play")
                         } else {
-                            play.set_icon("music_pause")?
+                            play.set_icon("music_pause")
                         }
                     }
                 }

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -46,7 +46,7 @@ impl ConfigBlock for Pacman {
         Ok(Pacman {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
-            output: TextWidget::new(config).with_icon("update")?,
+            output: TextWidget::new(config).with_icon("update"),
         })
     }
 }
@@ -121,11 +121,11 @@ impl Block for Pacman
 {
     fn update(&mut self) -> Result<Option<Duration>> {
         let count = get_update_count()?;
-        self.output.set_text(format!("{}", count))?;
+        self.output.set_text(format!("{}", count));
         self.output.set_state(match count {
             0 => State::Idle,
             _ => State::Info
-        })?;
+        });
         Ok(Some(self.update_interval.clone()))
 
     }

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -131,18 +131,18 @@ impl Sound {
         device.get_info()?;
 
         if device.muted {
-            self.text.set_icon("volume_empty")?;
+            self.text.set_icon("volume_empty");
             self.text.set_text(self.config.icons.get("volume_muted")
-                     .block_error("sound", "cannot find icon")?.to_owned())?;
-            self.text.set_state(State::Warning)?;
+                     .block_error("sound", "cannot find icon")?.to_owned());
+            self.text.set_state(State::Warning);
         } else {
             self.text.set_icon(match device.volume {
                 0 ... 20 => "volume_empty",
                 20 ... 70 => "volume_half",
                 _ => "volume_full"
-            })?;
-            self.text.set_text(format!("{:02}%", device.volume))?;
-            self.text.set_state(State::Info)?;
+            });
+            self.text.set_text(format!("{:02}%", device.volume));
+            self.text.set_state(State::Info);
         }
 
         Ok(())
@@ -160,7 +160,7 @@ impl ConfigBlock for Sound {
         }
 
         let mut sound = Sound {
-            text: ButtonWidget::new(config.clone(), &id).with_icon("volume_empty")?,
+            text: ButtonWidget::new(config.clone(), &id).with_icon("volume_empty"),
             id: id,
             devices: Vec::new(),
             update_interval: block_config.interval,

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -6,6 +6,7 @@ use scheduler::Task;
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
+use errors::*;
 use widgets::button::ButtonWidget;
 use widget::{I3BarWidget, State};
 use input::{I3BarEvent, MouseButton};
@@ -19,71 +20,73 @@ struct SoundDevice {
 }
 
 impl SoundDevice {
-    fn new(name: &str) -> Self {
+    fn new(name: &str) -> Result<Self> {
         let mut sd = SoundDevice {
             name: String::from(name),
             volume: 0,
             muted: false,
         };
-        sd.get_info();
-        sd
+        sd.get_info()?;
+
+        Ok(sd)
     }
 
-    fn get_info(&mut self) -> bool {
+    fn get_info(&mut self) -> Result<()> {
         let output = Command::new("sh")
             .args(&["-c", format!("amixer get {}", self.name).as_str()])
             .output()
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned());
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+            .block_error("sound", "could not run amixer to get sound info")?;
 
-        if let Ok(output) = output {
-            if let Some(last_line) = (&output).lines()
-                                              .into_iter()
-                                              .last() {
+        let last_line = &output.lines()
+                            .into_iter()
+                            .last()
+                            .block_error("sound", "could not get sound info")?;
 
-                let last = last_line.split_whitespace()
-                                    .into_iter()
-                                    .filter(|x| x.starts_with('[') && !x.contains("dB"))
-                                    .map(|s| s.trim_matches(FILTER))
-                                    .collect::<Vec<&str>>();
+        let last = last_line.split_whitespace()
+                            .into_iter()
+                            .filter(|x| x.starts_with('[') && !x.contains("dB"))
+                            .map(|s| s.trim_matches(FILTER))
+                            .collect::<Vec<&str>>();
 
-                if let Some(vol_raw) = last.get(0) {
-                    if let Ok(vol) = vol_raw.parse::<u32>() {
-                        self.volume = vol;
-                    }
-                }
+        self.volume = last.get(0)
+                          .block_error("sound", "could not get volume")?
+                          .parse::<u32>()
+                          .block_error("sound", "could not parse volume to u32")?;
 
-                if let Some(mute_raw) = last.get(1) {
-                    self.muted = match *mute_raw {
-                        "on" => false,
-                        "off" => true,
-                        _ => false
-                    };
-                    return true;
-                }
-            }
-        }
-        false
+        self.muted = last.get(1)
+                         .map(|muted| match *muted {
+                             "off" => true,
+                             "on" | _ => false,
+                         })
+                         .unwrap_or(false);
+
+        Ok(())
     }
 
-    fn set_volume(&mut self, step: i32) {
-       if Command::new("sh")
-            .args(&["-c", format!("amixer set {} {}%",
-                                  self.name,
-                                  (self.volume as i32 + step) as u32).as_str()])
-            .output().is_ok() {
+    fn set_volume(&mut self, step: i32) -> Result<()> {
+       Command::new("sh")
+           .args(&["-c", format!("amixer set {} {}%",
+                                 self.name,
+                                 (self.volume as i32 + step) as u32).as_str()])
+           .output()
+           .block_error("sound", "failed to set volume")?;
 
-            self.volume = (self.volume as i32 + step) as u32;
-        }
+        self.volume = (self.volume as i32 + step) as u32;
+
+        Ok(())
     }
 
-    fn toggle(&mut self) {
-        if Command::new("sh")
-              .args(&["-c", format!("amixer set {} toggle",
-                                    self.name).as_str()])
-              .output().is_ok() {
+    fn toggle(&mut self) -> Result<()> {
+        Command::new("sh")
+            .args(&["-c", format!("amixer set {} toggle",
+                                  self.name).as_str()])
+            .output()
+            .block_error("sound", "failed to toggle mute")?;
 
-            self.muted = !self.muted;
-        }
+        self.muted = !self.muted;
+
+        Ok(())
     }
 }
 
@@ -122,36 +125,34 @@ impl SoundConfig {
 }
 
 impl Sound {
-    fn display(&mut self) {
-        if let Some(device) = self.devices.get_mut(self.current_idx) {
-            if device.get_info() {
-                if device.muted {
-                    self.text.set_icon("volume_empty");
-                    self.text.set_text(self.config.icons["volume_muted"].as_str().to_owned());
-                    self.text.set_state(State::Warning);
-                } else {
-                    self.text.set_icon(match device.volume {
-                        0 ... 20 => "volume_empty",
-                        20 ... 70 => "volume_half",
-                        _ => "volume_full"
-                    });
-                    self.text.set_text(format!("{:02}%", device.volume));
-                    self.text.set_state(State::Info);
-                }
-            } else {
-                // TODO: Do proper error handling here instead of hiding in a corner
-                self.text.set_icon("");
-                self.text.set_text("".to_owned());
-                self.text.set_state(State::Idle);
-            }
+    fn display(&mut self) -> Result<()> {
+        let mut device = self.devices.get_mut(self.current_idx)
+            .block_error("sound", "failed to get device")?;
+        device.get_info()?;
+
+        if device.muted {
+            self.text.set_icon("volume_empty")?;
+            self.text.set_text(self.config.icons.get("volume_muted")
+                     .block_error("sound", "cannot find icon")?.to_owned())?;
+            self.text.set_state(State::Warning)?;
+        } else {
+            self.text.set_icon(match device.volume {
+                0 ... 20 => "volume_empty",
+                20 ... 70 => "volume_half",
+                _ => "volume_full"
+            })?;
+            self.text.set_text(format!("{:02}%", device.volume))?;
+            self.text.set_state(State::Info)?;
         }
+
+        Ok(())
     }
 }
 
 impl ConfigBlock for Sound {
     type Config = SoundConfig;
 
-    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
         let id = Uuid::new_v4().simple().to_string();
         let mut step_width = block_config.step_width;
         if step_width > 50 {
@@ -159,7 +160,7 @@ impl ConfigBlock for Sound {
         }
 
         let mut sound = Sound {
-            text: ButtonWidget::new(config.clone(), &id).with_icon("volume_empty"),
+            text: ButtonWidget::new(config.clone(), &id).with_icon("volume_empty")?,
             id: id,
             devices: Vec::new(),
             update_interval: block_config.interval,
@@ -167,10 +168,9 @@ impl ConfigBlock for Sound {
             current_idx: 0,
             config: config,
         };
-        sound.devices.push(SoundDevice::new("Master"));
-        sound
+        sound.devices.push(SoundDevice::new("Master")?);
+        Ok(sound)
     }
-
 }
 
 // To filter [100%] output from amixer into 100
@@ -178,39 +178,38 @@ const FILTER: &[char] = &['[', ']', '%'];
 
 impl Block for Sound
 {
-    fn update(&mut self) -> Option<Duration> {
-        self.display();
-        Some(self.update_interval.clone())
+    fn update(&mut self) -> Result<Option<Duration>> {
+        self.display()?;
+        Ok(Some(self.update_interval.clone()))
     }
 
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
 
-    fn click(&mut self, e: &I3BarEvent) {
+    fn click(&mut self, e: &I3BarEvent) -> Result<()> {
         if let Some(ref name) = e.name {
             if name.as_str() == self.id {
-                if let Some(device) = self.devices.get_mut(self.current_idx) {
+                { // Additional scope to not keep mutably borrowed device for too long
+                    let mut device = self.devices.get_mut(self.current_idx)
+                        .block_error("sound", "failed to get device")?;
+
                     match e.button {
-                        MouseButton::Right => {
-                            device.toggle();
+                        MouseButton::Right => device.toggle()?,
+                        MouseButton::WheelUp => if device.volume <= (100 - self.step_width) {
+                            device.set_volume(self.step_width as i32)?;
                         },
-                        MouseButton::WheelUp => {
-                            if device.volume <= (100 - self.step_width) {
-                                device.set_volume(self.step_width as i32);
-                            }
+                        MouseButton::WheelDown => if device.volume >= self.step_width {
+                            device.set_volume(- (self.step_width as i32))?;
                         },
-                        MouseButton::WheelDown => {
-                            if device.volume >= self.step_width {
-                                device.set_volume(- (self.step_width as i32));
-                            }
-                        },
-                        _ => {}
+                        _ => {},
                     }
                 }
-                self.display();
+                self.display()?;
             }
         }
+
+        Ok(())
     }
 
     fn id(&self) -> &str {

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -51,7 +51,7 @@ impl ConfigBlock for Temperature {
         let id = Uuid::new_v4().simple().to_string();
         Ok(Temperature {
             update_interval: block_config.interval,
-            text: ButtonWidget::new(config, &id).with_icon("thermometer")?,
+            text: ButtonWidget::new(config, &id).with_icon("thermometer"),
             output: String::new(),
             collapsed: block_config.collapsed,
             id,
@@ -103,7 +103,7 @@ impl Block for Temperature
 
             self.output = format!("{}° avg, {}° max", avg, max);
             if !self.collapsed {
-                self.text.set_text(self.output.clone())?;
+                self.text.set_text(self.output.clone());
             }
 
             self.text.set_state(match max {
@@ -112,7 +112,7 @@ impl Block for Temperature
                 45 ... 60 => State::Info,
                 60 ... 80 => State::Warning,
                 _ => State::Critical
-            })?;
+            });
         }
 
         Ok(Some(self.update_interval.clone()))
@@ -125,9 +125,9 @@ impl Block for Temperature
             if name.as_str() == self.id {
                 self.collapsed = !self.collapsed;
                 if self.collapsed {
-                    self.text.set_text(String::new())?;
+                    self.text.set_text(String::new());
                 } else {
-                    self.text.set_text(self.output.clone())?;
+                    self.text.set_text(self.output.clone());
                 }
             }
         }

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -1,9 +1,10 @@
 use std::time::Duration;
 use std::sync::mpsc::Sender;
 
-use config::Config;
 use block::{Block, ConfigBlock};
+use config::Config;
 use de::deserialize_duration;
+use errors::*;
 use widgets::text::TextWidget;
 use widget::I3BarWidget;
 use input::I3BarEvent;
@@ -41,26 +42,28 @@ impl TemplateConfig {
 impl ConfigBlock for Template {
     type Config = TemplateConfig;
 
-    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Self {
-        Template {
+    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Result<Self> {
+        Ok(Template {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
-            text: TextWidget::new(config.clone()).with_text("Template"),
+            text: TextWidget::new(config.clone()).with_text("Template")?,
             tx_update_request: tx_update_request,
             config: config,
-        }
+        })
     }
 }
 
 impl Block for Template
 {
-    fn update(&mut self) -> Option<Duration> {
-        Some(self.update_interval.clone())
+    fn update(&mut self) -> Result<Option<Duration>> {
+        Ok(Some(self.update_interval.clone()))
     }
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
-    fn click(&mut self, _: &I3BarEvent) {}
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
     fn id(&self) -> &str {
         &self.id
     }

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -46,7 +46,7 @@ impl ConfigBlock for Template {
         Ok(Template {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
-            text: TextWidget::new(config.clone()).with_text("Template")?,
+            text: TextWidget::new(config.clone()).with_text("Template"),
             tx_update_request: tx_update_request,
             config: config,
         })

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -50,7 +50,7 @@ impl ConfigBlock for Time {
         Ok(Time {
             id: Uuid::new_v4().simple().to_string(),
             format: block_config.format,
-            time: TextWidget::new(config).with_text("")?.with_icon("time")?,
+            time: TextWidget::new(config).with_text("").with_icon("time"),
             update_interval: block_config.interval,
         })
     }
@@ -58,7 +58,7 @@ impl ConfigBlock for Time {
 
 impl Block for Time {
     fn update(&mut self) -> Result<Option<Duration>> {
-        self.time.set_text(format!("{}", Local::now().format(&self.format)))?;
+        self.time.set_text(format!("{}", Local::now().format(&self.format)));
         Ok(Some(self.update_interval.clone()))
     }
 

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
+use errors::*;
 use self::chrono::offset::local::Local;
 use scheduler::Task;
 use std::sync::mpsc::Sender;
@@ -45,20 +46,20 @@ impl TimeConfig {
 impl ConfigBlock for Time {
     type Config = TimeConfig;
 
-    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
-        Time {
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
+        Ok(Time {
             id: Uuid::new_v4().simple().to_string(),
             format: block_config.format,
-            time: TextWidget::new(config).with_text("").with_icon("time"),
+            time: TextWidget::new(config).with_text("")?.with_icon("time")?,
             update_interval: block_config.interval,
-        }
+        })
     }
 }
 
 impl Block for Time {
-    fn update(&mut self) -> Option<Duration> {
-        self.time.set_text(format!("{}", Local::now().format(&self.format)));
-        Some(self.update_interval.clone())
+    fn update(&mut self) -> Result<Option<Duration>> {
+        self.time.set_text(format!("{}", Local::now().format(&self.format)))?;
+        Ok(Some(self.update_interval.clone()))
     }
 
     fn view(&self) -> Vec<&I3BarWidget> {

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -50,8 +50,7 @@ impl ConfigBlock for Toggle {
     fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
         let id = Uuid::new_v4().simple().to_string();
         Ok(Toggle {
-            text: ButtonWidget::new(config, &id)
-                .with_text(&block_config.text)?,
+            text: ButtonWidget::new(config, &id).with_text(&block_config.text),
             command_on: block_config.command_on,
             command_off: block_config.command_off,
             command_state: block_config.command_state,
@@ -75,7 +74,7 @@ impl Block for Toggle
         self.text.set_icon(match output.trim_left() {
             "" => {self.toggled = false; "toggle_off"},
             _ => {self.toggled = true; "toggle_on"}
-        })?;
+        });
 
         Ok(self.update_interval)
     }
@@ -88,12 +87,12 @@ impl Block for Toggle
                 let cmd = match self.toggled {
                     true => {
                         self.toggled = false;
-                        self.text.set_icon("toggle_off")?;
+                        self.text.set_icon("toggle_off");
                         &self.command_off
                     },
                     false => {
                         self.toggled = true;
-                        self.text.set_icon("toggle_on")?;
+                        self.text.set_icon("toggle_on");
                         &self.command_on
                     }
                 };

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -9,6 +9,7 @@ use util::FormatTemplate;
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
+use errors::*;
 use widgets::button::ButtonWidget;
 use widget::I3BarWidget;
 use input::{I3BarEvent, MouseButton};
@@ -102,13 +103,14 @@ macro_rules! unwrap_or_continue {
 }
 
 impl Xrandr {
-    fn get_active_monitors() -> Option<Vec<String>> {
+
+    fn get_active_monitors() -> Result<Option<Vec<String>>> {
         let active_montiors_cli = String::from_utf8(
             Command::new("sh")
                 .args(&["-c", "xrandr --listactivemonitors | grep \\/"])
-                .output().expect("There was a problem collecting active xrandr monitors.")
+                .output().block_error("xrandr", "couldn't collect active xrandr monitors")?
                 .stdout)
-            .expect("There was a problem while parsing xrandr monitors.");
+            .block_error("xrandr", "couldn't parse xrandr monitor list")?;
         let monitors: Vec<&str> = active_montiors_cli.split('\n').collect();
         let mut active_monitors: Vec<String> = Vec::new();
         for monitor in monitors {
@@ -119,21 +121,22 @@ impl Xrandr {
             }
         }
         if !active_monitors.is_empty() {
-            return Some(active_monitors);
+            Ok(Some(active_monitors))
+        } else {
+            Ok(None)
         }
-        None
     }
 
-    fn get_monitor_metrics(monitor_names: &Vec<String>) -> Option<Vec<Monitor>> {
+    fn get_monitor_metrics(monitor_names: &Vec<String>) -> Result<Option<Vec<Monitor>>> {
         let mut monitor_metrics: Vec<Monitor> = Vec::new();
         let grep_arg = format!("xrandr --verbose | grep -w '{} connected\\|Brightness'",
                                monitor_names.join(" connected\\|"));
         let monitor_info_cli = String::from_utf8(
             Command::new("sh")
                 .args(&["-c", grep_arg.as_str()])
-                .output().expect("There was a problem collecting monitor info.")
+                .output().block_error("xrandr", "couldn't collect xrandr monitor info")?
                 .stdout)
-            .expect("There was a problem while parsing monitor info.");
+            .block_error("xrandr", "couldn't parse xrandr monitor info")?;
 
         let monitor_infos: Vec<&str> = monitor_info_cli.split('\n').collect();
         for i in 0..monitor_infos.len() {
@@ -151,7 +154,7 @@ impl Xrandr {
                                                     .collect::<Vec<&str>>()
                                                     .get(1) {
                     brightness = (f32::from_str(brightness_raw.trim())
-                                      .expect("Unable to parse brightness string to int.") * 100.0)
+                                      .block_error("xrandr", "unable to parse brightness")? * 100.0)
                                  .floor() as u32;
                 }
             }
@@ -169,19 +172,20 @@ impl Xrandr {
             }
         }
         if !monitor_metrics.is_empty() {
-            return Some(monitor_metrics);
+            Ok(Some(monitor_metrics))
+        } else {
+            Ok(None)
         }
-        None
     }
 
-    fn display(&mut self) {
+    fn display(&mut self) -> Result<()> {
         if let Some(m) = self.monitors.get(self.current_idx) {
             let brightness_str = m.brightness.to_string();
             let values = map!("{display}" => m.name.clone(),
                               "{brightness}" => brightness_str,
                               "{resolution}" => m.resolution.clone());
 
-            self.text.set_icon("xrandr");
+            self.text.set_icon("xrandr")?;
             let format_str: &str;
             if self.resolution {
                 if self.icons {
@@ -198,23 +202,25 @@ impl Xrandr {
             }
 
             if let Ok(fmt_template) = FormatTemplate::from_string(String::from(format_str)) {
-                self.text.set_text(fmt_template.render_static_str(&values));
+                self.text.set_text(fmt_template.render_static_str(&values)?)?;
             }
         }
+
+        Ok(())
     }
 }
 
 impl ConfigBlock for Xrandr {
     type Config = XrandrConfig;
 
-    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
         let id = Uuid::new_v4().simple().to_string();
         let mut step_width = block_config.step_width;
         if step_width > 50 {
             step_width = 50;
         }
-        Xrandr {
-            text: ButtonWidget::new(config.clone(), &id).with_icon("xrandr"),
+        Ok(Xrandr {
+            text: ButtonWidget::new(config.clone(), &id).with_icon("xrandr")?,
             id: id,
             update_interval: block_config.interval,
             current_idx: 0,
@@ -223,26 +229,28 @@ impl ConfigBlock for Xrandr {
             step_width: step_width,
             monitors: Vec::new(),
             config: config,
-        }
+        })
     }
 }
+
 impl Block for Xrandr
 {
-    fn update(&mut self) -> Option<Duration> {
-        if let Some(am) = Xrandr::get_active_monitors() {
-            if let Some(mm) = Xrandr::get_monitor_metrics(&am) {
+    fn update(&mut self) -> Result<Option<Duration>> {
+        if let Some(am) = Xrandr::get_active_monitors()? {
+            if let Some(mm) = Xrandr::get_monitor_metrics(&am)? {
                 self.monitors = mm;
-                self.display();
+                self.display()?;
             }
         }
-        Some(self.update_interval.clone())
+
+        Ok(Some(self.update_interval.clone()))
     }
 
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
 
-    fn click(&mut self, e: &I3BarEvent) {
+    fn click(&mut self, e: &I3BarEvent) -> Result<()> {
         if let Some(ref name) = e.name {
             if name.as_str() == self.id {
                 match e.button {
@@ -269,9 +277,11 @@ impl Block for Xrandr
                     }
                     _ => {}
                 }
-                self.display();
+                self.display()?;
             }
         }
+
+        Ok(())
     }
 
     fn id(&self) -> &str {

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -185,7 +185,7 @@ impl Xrandr {
                               "{brightness}" => brightness_str,
                               "{resolution}" => m.resolution.clone());
 
-            self.text.set_icon("xrandr")?;
+            self.text.set_icon("xrandr");
             let format_str: &str;
             if self.resolution {
                 if self.icons {
@@ -202,7 +202,7 @@ impl Xrandr {
             }
 
             if let Ok(fmt_template) = FormatTemplate::from_string(String::from(format_str)) {
-                self.text.set_text(fmt_template.render_static_str(&values)?)?;
+                self.text.set_text(fmt_template.render_static_str(&values)?);
             }
         }
 
@@ -220,7 +220,7 @@ impl ConfigBlock for Xrandr {
             step_width = 50;
         }
         Ok(Xrandr {
-            text: ButtonWidget::new(config.clone(), &id).with_icon("xrandr")?,
+            text: ButtonWidget::new(config.clone(), &id).with_icon("xrandr"),
             id: id,
             update_interval: block_config.interval,
             current_idx: 0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 use themes::{self, Theme};
 
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Config {
     #[serde(default = "icons::default", deserialize_with = "deserialize_icons")]
     pub icons: Map<String, String>,
@@ -16,6 +16,16 @@ pub struct Config {
     pub theme: Theme,
     #[serde(rename = "block", deserialize_with = "deserialize_blocks")]
     pub blocks: Vec<(String, value::Value)>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            icons: icons::default(),
+            theme: themes::default(),
+            blocks: Vec::new(),
+        }
+    }
 }
 
 fn deserialize_blocks<'de, D>(deserializer: D) -> Result<Vec<(String, value::Value)>, D::Error>

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 pub use std::error::Error as StdError;
 use std::fmt;
 
-pub use self::Error::{BlockError, InternalError};
+pub use self::Error::{BlockError, ConfigurationError, InternalError};
 
 /// Result type returned from functions that can have our `Error`s.
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -11,6 +11,7 @@ pub trait ResultExtBlock<T, E> {
 }
 
 pub trait ResultExtInternal<T, E> {
+    fn configuration_error(self, message: &str) -> Result<T>;
     fn internal_error(self, context: &str, message: &str) -> Result<T>;
 }
 
@@ -24,6 +25,10 @@ impl<T, E> ResultExtInternal<T, E> for ::std::result::Result<T, E>
 where
     E: fmt::Display + fmt::Debug
 {
+    fn configuration_error(self, message: &str) -> Result<T> {
+        self.map_err(|e| ConfigurationError(message.to_owned(), (format!("{}", e), format!("{:?}", e))))
+    }
+
     fn internal_error(self, context: &str, message: &str) -> Result<T> {
         self.map_err(|e| InternalError(context.to_owned(), message.to_owned(), Some((format!("{}", e), format!("{:?}", e)))))
     }
@@ -48,6 +53,7 @@ impl<T> OptionExt<T> for ::std::option::Option<T>
 /// A set of errors that can occur during the runtime of i3status-rs.
 pub enum Error {
     BlockError(String, String),
+    ConfigurationError(String, (String, String)),
     InternalError(String, String, Option<(String, String)>),
 }
 
@@ -55,6 +61,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             BlockError(ref block, ref message) => f.write_str(&format!("Error in block '{}': {}", block, message)),
+            ConfigurationError(ref message, _) => f.write_str(&format!("Configuration error: {}", message)),
             InternalError(ref context, ref message, _) => f.write_str(&format!("Internal error in context '{}': {}", context, message)),
         }
     }
@@ -64,6 +71,7 @@ impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             BlockError(ref block, ref message) => f.write_str(&format!("Error in block '{}': {}", block, message)),
+            ConfigurationError(ref message, (ref cause, _)) => f.write_str(&format!("Configuration error: {}.\nCause: {}", message, cause)),
             InternalError(ref context, ref message, Some((ref cause, _))) => f.write_str(&format!("Internal error in context '{}': {}.\nCause: {}", context, message, cause)),
             InternalError(ref context, ref message, None) => f.write_str(&format!("Internal error in context '{}': {}", context, message)),
         }
@@ -74,6 +82,7 @@ impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
             BlockError(_, _) => "Block error occured in block '{}'",
+            ConfigurationError(_, _) => "Configuration error occured",
             InternalError(_, _, _) => "Internal error occured",
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,78 @@
+pub use std::error::Error as StdError;
+use std::fmt;
+
+pub use self::Error::{BlockError, InternalError};
+
+/// Result type returned from functions that can have our `Error`s.
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+pub trait ResultExt<T, E> {
+    fn block_error(self, block: &str, message: &str) -> Result<T>;
+    fn internal_error(self, context: &str, message: &str) -> Result<T>;
+}
+
+impl<T, E> ResultExt<T, E> for ::std::result::Result<T, E> {
+    fn block_error(self, block: &str, message: &str) -> Result<T> {
+        self.map_err(|_| BlockError(block.to_owned(), message.to_owned()))
+    }
+
+    fn internal_error(self, context: &str, message: &str) -> Result<T> {
+        self.map_err(|_| InternalError(context.to_owned(), message.to_owned()))
+    }
+}
+
+pub trait OptionExt<T> {
+    fn block_error(self, block: &str, message: &str) -> Result<T>;
+    fn internal_error(self, context: &str, message: &str) -> Result<T>;
+}
+
+impl<T> OptionExt<T> for ::std::option::Option<T>
+{
+    fn block_error(self, block: &str, message: &str) -> Result<T> {
+        self.ok_or_else(|| BlockError(block.to_owned(), message.to_owned()))
+    }
+
+    fn internal_error(self, context: &str, message: &str) -> Result<T> {
+        self.ok_or_else(|| InternalError(context.to_owned(), message.to_owned()))
+    }
+}
+
+/// A set of errors that can occur during the runtime of i3status-rs.
+#[derive(Debug)]
+pub enum Error {
+    BlockError(String, String),
+    InternalError(String, String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BlockError(ref block, ref message) => f.write_str(&format!("Error in block '{}': {}", block, message)),
+            InternalError(ref context, ref message) => f.write_str(&format!("Internal error in context '{}': {}", context, message)),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match *self {
+            BlockError(_, _) => "Block error occured",
+            InternalError(_, _) => "Internal error occured",
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            _ => None,
+        }
+    }
+}
+
+impl<T> From<::std::sync::mpsc::SendError<T>> for Error
+where
+    T: fmt::Display
+{
+    fn from(err: ::std::sync::mpsc::SendError<T>) -> Error {
+        InternalError("unknown".to_owned(), format!("send error for '{}'", err.0))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,8 +191,8 @@ fn main() {
         }
 
         let error_widget = TextWidget::new(Default::default())
-            .with_state(State::Critical).expect("failed to set widget state")
-            .with_text(&format!("{}", e)).expect("failed to set widget text");
+            .with_state(State::Critical)
+            .with_text(&format!("{}", e));
         let error_rendered = error_widget.get_rendered();
         println!("{}", serde_json::to_string(&[error_rendered]).expect("failed to serialize error message"));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,14 +185,15 @@ fn main() {
     let exit_on_error = matches.is_present("exit-on-error");
 
     // Run and match for potential error
-    if let Err(e) = run(matches) {
+    if let Err(error) = run(matches) {
         if exit_on_error {
+            eprintln!("{:?}", error);
             ::std::process::exit(1);
         }
 
         let error_widget = TextWidget::new(Default::default())
             .with_state(State::Critical)
-            .with_text(&format!("{}", e));
+            .with_text(&format!("{}", error));
         let error_rendered = error_widget.get_rendered();
         println!("{}", serde_json::to_string(&[error_rendered]).expect("failed to serialize error message"));
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,32 +1,34 @@
 use block::Block;
 use config::Config;
+use errors::*;
 use std::collections::HashMap;
 use serde::de::DeserializeOwned;
 use serde_json::value::Value;
 use toml;
 use regex::Regex;
 use std::prelude::v1::String;
-use std;
 use std::fmt::Display;
 use std::fs::File;
 use std::io::BufReader;
 use std::io::prelude::*;
 
-pub fn deserialize_file<T>(file: &str) -> T
+pub fn deserialize_file<T>(file: &str) -> Result<T>
 where
     T: DeserializeOwned
 {
     let mut contents = String::new();
-    let mut file = BufReader::new(File::open(file).expect("failed to open file"));
-    file.read_to_string(&mut contents).expect("failed to read file");
-    toml::from_str(&contents).expect("failed to parse TOML from file contents")
+    let mut file = BufReader::new(File::open(file).internal_error("util", "failed to open file")?);
+    file.read_to_string(&mut contents).internal_error("util", "failed to read file")?;
+    toml::from_str(&contents).internal_error("util", "failed to parse TOML from file contents")
 }
 
-pub fn get_file(name: &str) -> String {
+pub fn get_file(name: &str) -> Result<String> {
     let mut file_contents = String::new();
-    let mut file = File::open(name).expect(&format!("Unable to open {}", name));
-    file.read_to_string(&mut file_contents).expect(&format!("Unable to read {}", name));
-    file_contents
+    let mut file = File::open(name)
+        .internal_error("util", &format!("Unable to open {}", name))?;
+    file.read_to_string(&mut file_contents)
+        .internal_error("util", &format!("Unable to read {}", name))?;
+    Ok(file_contents)
 }
 
 
@@ -69,7 +71,7 @@ impl PrintState {
     }
 }
 
-pub fn print_blocks(order: &Vec<String>, block_map: &HashMap<String, &mut Block>, config: &Config) {
+pub fn print_blocks(order: &Vec<String>, block_map: &HashMap<String, &mut Block>, config: &Config) -> Result<()> {
     let mut state = PrintState {
         has_predecessor: false,
         last_bg: None,
@@ -77,10 +79,10 @@ pub fn print_blocks(order: &Vec<String>, block_map: &HashMap<String, &mut Block>
 
     print!("[");
     for block_id in order {
-        let ref block = *(block_map.get(block_id).unwrap());
+        let ref block = *(block_map.get(block_id).internal_error("util", "couldn't get block by id")?);
         let widgets = block.view();
         let first = widgets[0];
-        let color = first.get_rendered()["background"].as_str().unwrap();
+        let color = first.get_rendered()["background"].as_str().internal_error("util", "couldn't get background color")?;
 
         let sep_fg = if config.theme.separator_fg == "auto" {
             color
@@ -110,11 +112,13 @@ pub fn print_blocks(order: &Vec<String>, block_map: &HashMap<String, &mut Block>
         for widget in widgets.iter().skip(1) {
             print!("{}{}", if state.has_predecessor { "," } else { "" },
                    widget.to_string());
-            state.set_last_bg(String::from(widget.get_rendered()["background"].as_str().unwrap()));
+            state.set_last_bg(String::from(widget.get_rendered()["background"].as_str().internal_error("util", "couldn't get background color")?));
             state.set_predecessor(true);
         }
     }
     println!("],");
+
+    Ok(())
 }
 
 
@@ -127,11 +131,11 @@ pub enum FormatTemplate {
 
 
 impl FormatTemplate {
-    pub fn from_string(s: String) -> Result<FormatTemplate,std::string::FromUtf8Error> {
+    pub fn from_string(s: String) -> Result<FormatTemplate> {
         let s_as_bytes = s.clone().into_bytes();
 
         //valid var tokens: {} containing any amount of alphanumericals
-        let re = Regex::new(r"\{[a-zA-Z0-9]+?\}").unwrap();
+        let re = Regex::new(r"\{[a-zA-Z0-9]+?\}").internal_error("util", "invalid regex")?;
 
         let mut token_vec: Vec<FormatTemplate> =vec![];
         let mut start: usize = 0;
@@ -139,13 +143,13 @@ impl FormatTemplate {
         for re_match in re.find_iter(&s) {
             if re_match.start() != start {
                 let str_vec : Vec<u8> =(&s_as_bytes)[start..re_match.start()].to_vec();
-                token_vec.push(FormatTemplate::Str(String::from_utf8(str_vec)?, None));
+                token_vec.push(FormatTemplate::Str(String::from_utf8(str_vec).internal_error("util", "failed to convert string from UTF8")?, None));
             }
             token_vec.push(FormatTemplate::Var(re_match.as_str().to_string(), None));
             start = re_match.end();
         }
         let str_vec : Vec<u8> = (&s_as_bytes)[start..].to_vec();
-        token_vec.push(FormatTemplate::Str(String::from_utf8(str_vec)?,None));
+        token_vec.push(FormatTemplate::Str(String::from_utf8(str_vec).internal_error("util", "failed to convert string from UTF8")?,None));
         let mut template: FormatTemplate = match token_vec.pop() {
             Some(token) => {token},
             _ => FormatTemplate::Str("".to_string(), None)
@@ -180,24 +184,26 @@ impl FormatTemplate {
         rendered
     }
 
-    pub fn render_static_str<T: Display>(&self, vars: &HashMap<&str, T>) -> String {
+    pub fn render_static_str<T: Display>(&self, vars: &HashMap<&str, T>) -> Result<String> {
         use self::FormatTemplate::*;
         let mut rendered = String::new();
         match *self {
             Str(ref s, ref next) => {
                 rendered.push_str(&s);
                 if let Some(ref next) = *next {
-                    rendered.push_str(&*next.render_static_str(vars));
+                    rendered.push_str(&*next.render_static_str(vars)?);
                 };
             }
             Var(ref key, ref next) => {
-                rendered.push_str(&format!("{}", vars.get(&**key).expect(&format!("Unknown placeholder in format string: {}", key))));
+                rendered.push_str(&format!("{}",
+                                           vars.get(&**key)
+                                               .internal_error("util", &format!("Unknown placeholder in format string: {}", key))?));
                 if let Some(ref next) = *next {
-                    rendered.push_str(&*next.render_static_str(vars));
+                    rendered.push_str(&*next.render_static_str(vars)?);
                 };
             }
         };
-        rendered
+        Ok(rendered)
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,7 +19,7 @@ where
     let mut contents = String::new();
     let mut file = BufReader::new(File::open(file).internal_error("util", "failed to open file")?);
     file.read_to_string(&mut contents).internal_error("util", "failed to read file")?;
-    toml::from_str(&contents).internal_error("util", "failed to parse TOML from file contents")
+    toml::from_str(&contents).configuration_error("failed to parse TOML from file contents")
 }
 
 pub fn get_file(name: &str) -> Result<String> {

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -1,5 +1,4 @@
 use config::Config;
-use errors::*;
 use widget::State;
 use serde_json::value::Value;
 use super::super::widget::I3BarWidget;
@@ -34,40 +33,40 @@ impl ButtonWidget {
         }
     }
 
-    pub fn with_icon(mut self, name: &str) -> Result<Self> {
+    pub fn with_icon(mut self, name: &str) -> Self {
         self.icon = self.config.icons.get(name).cloned();
-        self.update()?;
-        Ok(self)
+        self.update();
+        self
     }
 
-    pub fn with_text(mut self, content: &str) -> Result<Self> {
+    pub fn with_text(mut self, content: &str) -> Self {
         self.content = Some(String::from(content));
-        self.update()?;
-        Ok(self)
+        self.update();
+        self
     }
 
-    pub fn with_state(mut self, state: State) -> Result<Self> {
+    pub fn with_state(mut self, state: State) -> Self {
         self.state = state;
-        self.update()?;
-        Ok(self)
+        self.update();
+        self
     }
 
-    pub fn set_text(&mut self, content: String) -> Result<()> {
+    pub fn set_text(&mut self, content: String) {
         self.content = Some(content);
-        self.update()
+        self.update();
     }
 
-    pub fn set_icon(&mut self, name: &str) -> Result<()> {
+    pub fn set_icon(&mut self, name: &str) {
         self.icon = self.config.icons.get(name).cloned();
-        self.update()
+        self.update();
     }
 
-    pub fn set_state(&mut self, state: State) -> Result<()> {
+    pub fn set_state(&mut self, state: State) {
         self.state = state;
-        self.update()
+        self.update();
     }
 
-    fn update(&mut self) -> Result<()> {
+    fn update(&mut self) {
         let (key_bg, key_fg) = self.state.theme_keys(&self.config.theme);
 
         self.rendered = json!({
@@ -82,7 +81,6 @@ impl ButtonWidget {
         });
 
         self.cached_output = Some(self.rendered.to_string());
-        Ok(())
     }
 }
 

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -1,4 +1,5 @@
 use config::Config;
+use errors::*;
 use widget::State;
 use serde_json::value::Value;
 use super::super::widget::I3BarWidget;
@@ -33,40 +34,40 @@ impl ButtonWidget {
         }
     }
 
-    pub fn with_icon(mut self, name: &str) -> Self {
+    pub fn with_icon(mut self, name: &str) -> Result<Self> {
         self.icon = self.config.icons.get(name).cloned();
-        self.update();
-        self
+        self.update()?;
+        Ok(self)
     }
 
-    pub fn with_text(mut self, content: &str) -> Self {
+    pub fn with_text(mut self, content: &str) -> Result<Self> {
         self.content = Some(String::from(content));
-        self.update();
-        self
+        self.update()?;
+        Ok(self)
     }
 
-    pub fn with_state(mut self, state: State) -> Self {
+    pub fn with_state(mut self, state: State) -> Result<Self> {
         self.state = state;
-        self.update();
-        self
+        self.update()?;
+        Ok(self)
     }
 
-    pub fn set_text(&mut self, content: String) {
+    pub fn set_text(&mut self, content: String) -> Result<()> {
         self.content = Some(content);
-        self.update();
+        self.update()
     }
 
-    pub fn set_icon(&mut self, name: &str) {
+    pub fn set_icon(&mut self, name: &str) -> Result<()> {
         self.icon = self.config.icons.get(name).cloned();
-        self.update();
+        self.update()
     }
 
-    pub fn set_state(&mut self, state: State) {
+    pub fn set_state(&mut self, state: State) -> Result<()> {
         self.state = state;
-        self.update();
+        self.update()
     }
 
-    fn update(&mut self) {
+    fn update(&mut self) -> Result<()> {
         let (key_bg, key_fg) = self.state.theme_keys(&self.config.theme);
 
         self.rendered = json!({
@@ -81,6 +82,7 @@ impl ButtonWidget {
         });
 
         self.cached_output = Some(self.rendered.to_string());
+        Ok(())
     }
 }
 

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -45,19 +45,19 @@ impl RotatingTextWidget {
         }
     }
 
-    pub fn with_icon(mut self, name: &str) -> Result<Self> {
+    pub fn with_icon(mut self, name: &str) -> Self {
         self.icon = self.config.icons.get(name).cloned();
-        self.update()?;
-        Ok(self)
+        self.update();
+        self
     }
 
-    pub fn with_state(mut self, state: State) -> Result<Self> {
+    pub fn with_state(mut self, state: State) -> Self {
         self.state = state;
-        self.update()?;
-        Ok(self)
+        self.update();
+        self
     }
 
-    pub fn with_text(mut self, content: &str) -> Result<Self> {
+    pub fn with_text(mut self, content: &str) -> Self {
         self.content = String::from(content);
         self.rotation_pos = 0;
         if self.content.len() > self.width {
@@ -65,21 +65,21 @@ impl RotatingTextWidget {
         } else {
             self.next_rotation = None;
         }
-        self.update()?;
-        Ok(self)
+        self.update();
+        self
     }
 
-    pub fn set_state(&mut self, state: State) -> Result<()> {
+    pub fn set_state(&mut self, state: State) {
         self.state = state;
-        self.update()
+        self.update();
     }
 
-    pub fn set_icon(&mut self, name: &str) -> Result<()> {
+    pub fn set_icon(&mut self, name: &str) {
         self.icon = self.config.icons.get(name).cloned();
-        self.update()
+        self.update();
     }
 
-    pub fn set_text(&mut self, content: String) -> Result<()> {
+    pub fn set_text(&mut self, content: String) {
         if self.content != content{
             self.content = content;
             self.rotation_pos = 0;
@@ -109,7 +109,7 @@ impl RotatingTextWidget {
         }
     }
 
-    fn update(&mut self) -> Result<()> {
+    fn update(&mut self) {
         let (key_bg, key_fg) = self.state.theme_keys(&self.config.theme);
 
         self.rendered = json!({
@@ -125,7 +125,6 @@ impl RotatingTextWidget {
         });
 
         self.cached_output = Some(self.rendered.to_string());
-        Ok(())
     }
 
     pub fn next(&mut self) -> Result<(bool, Option<Duration>)> {
@@ -137,13 +136,13 @@ impl RotatingTextWidget {
                     if self.rotation_pos < self.content.len() {
                         self.rotation_pos += 1;
                         self.next_rotation = Some(Instant::now() + self.rotation_speed);
-                        self.update()?;
+                        self.update();
                         Ok((true, Some(self.rotation_speed)))
                     } else {
                         self.rotation_pos = 0;
                         self.rotating = false;
                         self.next_rotation = Some(Instant::now() + self.rotation_interval);
-                        self.update()?;
+                        self.update();
                         Ok((true, Some(self.rotation_interval)))
                     }
                 } else {

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -1,5 +1,4 @@
 use config::Config;
-use errors::*;
 use widget::State;
 use serde_json::value::Value;
 use super::super::widget::I3BarWidget;
@@ -32,40 +31,40 @@ impl TextWidget {
         }
     }
 
-    pub fn with_icon(mut self, name: &str) -> Result<Self> {
+    pub fn with_icon(mut self, name: &str) -> Self {
         self.icon = self.config.icons.get(name).cloned();
-        self.update()?;
-        Ok(self)
+        self.update();
+        self
     }
 
-    pub fn with_text(mut self, content: &str) -> Result<Self> {
+    pub fn with_text(mut self, content: &str) -> Self {
         self.content = Some(String::from(content));
-        self.update()?;
-        Ok(self)
+        self.update();
+        self
     }
 
-    pub fn with_state(mut self, state: State) -> Result<Self> {
+    pub fn with_state(mut self, state: State) -> Self {
         self.state = state;
-        self.update()?;
-        Ok(self)
+        self.update();
+        self
     }
 
-    pub fn set_text(&mut self, content: String) -> Result<()> {
+    pub fn set_text(&mut self, content: String) {
         self.content = Some(content);
-        self.update()
+        self.update();
     }
 
-    pub fn set_icon(&mut self, name: &str) -> Result<()> {
+    pub fn set_icon(&mut self, name: &str) {
         self.icon = self.config.icons.get(name).cloned();
-        self.update()
+        self.update();
     }
 
-    pub fn set_state(&mut self, state: State) -> Result<()> {
+    pub fn set_state(&mut self, state: State) {
         self.state = state;
-        self.update()
+        self.update();
     }
 
-    fn update(&mut self) -> Result<()> {
+    fn update(&mut self) {
         let (key_bg, key_fg) = self.state.theme_keys(&self.config.theme);
 
         self.rendered = json!({
@@ -79,8 +78,6 @@ impl TextWidget {
         });
 
         self.cached_output = Some(self.rendered.to_string());
-
-        Ok(())
     }
 }
 

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -1,4 +1,5 @@
 use config::Config;
+use errors::*;
 use widget::State;
 use serde_json::value::Value;
 use super::super::widget::I3BarWidget;
@@ -31,40 +32,40 @@ impl TextWidget {
         }
     }
 
-    pub fn with_icon(mut self, name: &str) -> Self {
+    pub fn with_icon(mut self, name: &str) -> Result<Self> {
         self.icon = self.config.icons.get(name).cloned();
-        self.update();
-        self
+        self.update()?;
+        Ok(self)
     }
 
-    pub fn with_text(mut self, content: &str) -> Self {
+    pub fn with_text(mut self, content: &str) -> Result<Self> {
         self.content = Some(String::from(content));
-        self.update();
-        self
+        self.update()?;
+        Ok(self)
     }
 
-    pub fn with_state(mut self, state: State) -> Self {
+    pub fn with_state(mut self, state: State) -> Result<Self> {
         self.state = state;
-        self.update();
-        self
+        self.update()?;
+        Ok(self)
     }
 
-    pub fn set_text(&mut self, content: String) {
+    pub fn set_text(&mut self, content: String) -> Result<()> {
         self.content = Some(content);
-        self.update();
+        self.update()
     }
 
-    pub fn set_icon(&mut self, name: &str) {
+    pub fn set_icon(&mut self, name: &str) -> Result<()> {
         self.icon = self.config.icons.get(name).cloned();
-        self.update();
+        self.update()
     }
 
-    pub fn set_state(&mut self, state: State) {
+    pub fn set_state(&mut self, state: State) -> Result<()> {
         self.state = state;
-        self.update();
+        self.update()
     }
 
-    fn update(&mut self) {
+    fn update(&mut self) -> Result<()> {
         let (key_bg, key_fg) = self.state.theme_keys(&self.config.theme);
 
         self.rendered = json!({
@@ -78,6 +79,8 @@ impl TextWidget {
         });
 
         self.cached_output = Some(self.rendered.to_string());
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
(Regarding #42, cc @greshake @jheyens.)

So, this turned out to be a pretty big PR, given that almost everything had to be touched to support the `Result` type and the associated error-handling.

I'll try to summary the biggest changes/additions to maybe ease the burden a bit.

## Summary (by files)

* `src/errors.rs`

    * Added supporting code for error handling. This includes:

        * An `enum Error` containing two types of errors: `BlockError` and `InternalError`
        * A custom `Result` type which allows omitting of our `Error`
        * Two trait extensions (`ResultExt`, `OptionExt`) which add:
        
            ```rust
            fn block_error(self, block: &str, message: &str) -> Result<T>;
            fn internal_error(self, block: &str, message: &str) -> Result<T>;
            ```

            to both `Option` and `Result`, allowing easy error handling.

        * An implementation for `std::fmt::Display` for conversion to string (used in `main.rs` to actually output an error).

* `src/main.rs`

    * Renamed `main` to `run`
    * Added another `main` method which executes `run` and catches errors which might occur directly in `main`.
    * Moved CLI matching to the new `main`
    * Added CLI flag `--exit-on-error` to exit if an error occurs, rather than outputting to i3bar.
    * Replaced every relevant `.unwrap` and `.expect` by `.internal_error` to have full error handling

* `src/block.rs`

    * Updated `trait Block` to include the `Result` type

* `src/blocks/*.rs`

    * Updated all blocks to match changed `trait Block`
    * Replaced every relevant `.unwrap` and `.expect` by `.block_error` to have full error handling

* `README.md`

    * Updated to reflect the new requirements regarding having a `Result` type

* `src/{icons,themes}.rs`

    * Updated to use `Result` type

* `src/scheduler.rs`

   * Updated to use `Result`
   * Implemented `std::fmt::Display` for `Task` to allow for additional error printing.

* `src/util.rs`

   * Updated to use `Result`

* `src/widgets/*.rs`

   * Updated to use `Result`

## Open tasks, points for discussion

* [x]  Currently both error-types, internal and block, get handled the same way: output to i3bar, then idle until the process gets killed.

    We should determine if we want to handle internal errors differently in anyway to block errors. If not, I'd still vote to keep the distinction between the two for future-proofing, in case we ever want to be able to differentiate between an error that has occured in a block and one that didn't.

    ~~**Note:** Right now the causing error is not retained, for neither internal nor block errors. I would like to implement this to keep the cause for extended debug information, but I am currently at a bit of a roadblock.~~

* [x]  I have not implemented a click-handler yet to allow automatic exporting/posting/... of an error that has occured.

    I think we should first decide on what exactly we want to do, such that it is not too complicated for both the user and the implementation.