### PR TITLE
Deserialize blocks configs into structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ icons = "awesome"
 block = "disk_space"
 path = "/"
 alias = "/"
-type = "available"
+info_type = "available"
 unit = "GB"
 interval = 20
 
 [[block]]
 block = "memory"
-type = "memory"
+display_type = "memory"
 format_mem = "{Mup}%"
 format_swap = "{SUp}%"
 
@@ -134,7 +134,7 @@ block = "memory"
 
 format_mem = "{Mum}MB/{MTm}MB({Mup}%)"
 format_swap = "{SUm}MB/{STm}MB({SUp}%)"
-type = "memory"
+display_type = "memory"
 icons = true
 clickable = true
 interval = 5
@@ -150,7 +150,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 format_mem | Format string for Memory view. All format values are described below. | No | {MFm}MB/{MTm}MB({Mp}%)
 format_swap | Format string for Swap view. | No | {SFm}MB/{STm}MB({Sp}%)
-type | Default view displayed on startup. Options are <br/> memory, swap | No | memory
+display_type | Default view displayed on startup. Options are <br/> memory, swap | No | memory
 icons | Whether the format string should be prepended with Icons. Options are <br/> true, false | No | true
 clickable | Whether the view should switch between memory and swap on click. Options are <br/> true, false | No | true
 interval | The delay in seconds between an update. If `clickable`, an update is triggered on click. Integer values only. | No | 5
@@ -211,7 +211,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 player | Name of the music player.Must be the same name the player<br/> is registered with the MediaPlayer2 Interface.  | Yes | -
 max_width | Max width of the block in characters, not including the buttons | No | 21
-marquee | Bool to specify if a marquee style rotation should be used every<br/>10s if the title + artist is longer than max-width | No | true
+marquee | Bool to specify if a marquee style rotation should be used every<br/>10s if the title + artist is longer than max_width | No | true
 buttons | Array of control buttons to be displayed. Options are<br/>prev (previous title), play (play/pause) and next (next title) | No | []
 
 ## Load
@@ -350,7 +350,7 @@ block = "disk_space"
 
 path = "/"
 alias = "/"
-type = "available"
+info_type = "available"
 unit = "GB"
 interval = 20
 ```
@@ -361,7 +361,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 path | Path to collect information from | No | /
 alias | Alias that is displayed for path | No | /
-type | Currently supported options are available and free | No | available
+info_type | Currently supported options are available and free | No | available
 unit | Unit that is used to display disk space. Options are MB, MiB, GB and GiB | No | GB
 interval | Update interval in seconds | No | 20
 
@@ -412,14 +412,14 @@ Creates a block which displays the title of the currently focused window. Uses p
 [[block]]
 block = "focused_window"
 
-max-width = 21
+max_width = 21
 ```
 
 **Options**
 
 Key | Values | Required | Default
 ----|--------|----------|--------
-max-width | Truncates titles if longer than max-width | No | 21
+max_width | Truncates titles if longer than max_width | No | 21
 
 ## Xrandr
 Creates a block which shows screen information (name, brightness, resolution). With a click you can toggle through your active screens and with wheel up and down you can adjust the selected screens brighntess.

--- a/example_config.toml
+++ b/example_config.toml
@@ -11,7 +11,7 @@ interval = 20
 
 [[block]]
 block = "memory"
-type = "memory"
+display_type = "memory"
 format_mem = "{Mup}%"
 format_swap = "{SUp}%"
 

--- a/example_icon.toml
+++ b/example_icon.toml
@@ -18,7 +18,7 @@ interval = 20
 
 [[block]]
 block = "memory"
-type = "memory"
+display_type = "memory"
 format_mem = "{Mup}%"
 format_swap = "{SUp}%"
 

--- a/example_theme.toml
+++ b/example_theme.toml
@@ -16,7 +16,7 @@ interval = 20
 
 [[block]]
 block = "memory"
-type = "memory"
+display_type = "memory"
 format_mem = "{Mup}%"
 format_swap = "{SUp}%"
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,4 +1,6 @@
-
+use config::Config;
+use scheduler::Task;
+use std::sync::mpsc::Sender;
 use std::time::Duration;
 use input::I3BarEvent;
 use widget::I3BarWidget;
@@ -18,4 +20,10 @@ pub trait Block {
 
     /// This function returns a unique id.
     fn id(&self) -> &str;
+}
+
+pub trait ConfigBlock: Block {
+    type Config;
+
+    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Self;
 }

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
+use std::sync::mpsc::Sender;
+use scheduler::Task;
 
-use block::Block;
+use block::{Block, ConfigBlock};
 use config::Config;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
@@ -8,7 +10,6 @@ use input::I3BarEvent;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 
-use toml::value::Value;
 use uuid::Uuid;
 
 //TODO: Add remaining time
@@ -42,14 +43,16 @@ impl BatteryConfig {
     }
 }
 
-impl Battery {
-    pub fn new(block_config: Value, config: Config) -> Battery {
+impl ConfigBlock for Battery {
+    type Config = BatteryConfig;
+
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
         Battery {
             id: Uuid::new_v4().simple().to_string(),
             max_charge: 0,
-            update_interval: Duration::new(get_u64_default!(block_config, "interval", 10), 0),
+            update_interval: block_config.interval,
             output: TextWidget::new(config),
-            device_path: format!("/sys/class/power_supply/BAT{}/", get_u64_default!(block_config, "device", 0)),
+            device_path: format!("/sys/class/power_supply/BAT{}/", block_config.device),
         }
     }
 }

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -20,6 +20,28 @@ pub struct Battery {
     device_path: String
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct BatteryConfig {
+    /// Update interval in seconds
+    #[serde(default = "BatteryConfig::default_interval")]
+    pub interval: Duration,
+
+    /// Which BAT device in /sys/class/power_supply/ to read from.
+    #[serde(default = "BatteryConfig::default_device")]
+    pub device: usize,
+}
+
+impl BatteryConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(10)
+    }
+
+    fn default_device() -> usize {
+        0
+    }
+}
+
 impl Battery {
     pub fn new(block_config: Value, config: Config) -> Battery {
         Battery {

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -4,6 +4,7 @@ use scheduler::Task;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_duration;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
 use input::I3BarEvent;
@@ -25,7 +26,7 @@ pub struct Battery {
 #[serde(deny_unknown_fields)]
 pub struct BatteryConfig {
     /// Update interval in seconds
-    #[serde(default = "BatteryConfig::default_interval")]
+    #[serde(default = "BatteryConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Which BAT device in /sys/class/power_supply/ to read from.

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -22,6 +22,20 @@ pub struct Cpu {
     update_interval: Duration,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct CpuConfig {
+    /// Update interval in seconds
+    #[serde(default = "CpuConfig::default_interval")]
+    pub interval: Duration,
+}
+
+impl CpuConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(1)
+    }
+}
+
 impl Cpu {
     pub fn new(block_config: Value, config: Config) -> Cpu {
         let text = TextWidget::new(config).with_icon("cpu");

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -4,6 +4,7 @@ use scheduler::Task;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_duration;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
 use input::I3BarEvent;
@@ -27,7 +28,7 @@ pub struct Cpu {
 #[serde(deny_unknown_fields)]
 pub struct CpuConfig {
     /// Update interval in seconds
-    #[serde(default = "CpuConfig::default_interval")]
+    #[serde(default = "CpuConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 }
 

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
+use std::sync::mpsc::Sender;
+use scheduler::Task;
 
-use block::Block;
+use block::{Block, ConfigBlock};
 use config::Config;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
@@ -10,7 +12,6 @@ use std::io::BufReader;
 use std::io::prelude::*;
 use std::fs::{File};
 
-use toml::value::Value;
 use uuid::Uuid;
 
 
@@ -36,12 +37,14 @@ impl CpuConfig {
     }
 }
 
-impl Cpu {
-    pub fn new(block_config: Value, config: Config) -> Cpu {
+impl ConfigBlock for Cpu {
+    type Config = CpuConfig;
+
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
         let text = TextWidget::new(config).with_icon("cpu");
         return Cpu {
             id: Uuid::new_v4().simple().to_string(),
-            update_interval: Duration::new(get_u64_default!(block_config, "interval", 1), 0),
+            update_interval: block_config.interval,
             utilization: text,
             prev_idle: 0,
             prev_non_idle: 0,

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -25,6 +25,29 @@ pub struct Custom {
     tx_update_request: Sender<Task>,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct CustomConfig {
+    /// Update interval in seconds
+    #[serde(default = "CustomConfig::default_interval")]
+    pub interval: Duration,
+
+    /// Shell Command to execute & display
+    pub command: Option<String>,
+
+    /// Command to execute when the button is clicked
+    pub on_click: Option<String>,
+
+    /// Commands to execute and change when the button is clicked
+    pub cycle: Option<Vec<String>>,
+}
+
+impl CustomConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
 impl Custom {
     pub fn new(block_config: Value, config: Config, tx: Sender<Task>) -> Custom {
         let mut custom = Custom {

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -7,6 +7,7 @@ use std::sync::mpsc::Sender;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_duration;
 use widgets::button::ButtonWidget;
 use widget::I3BarWidget;
 use input::I3BarEvent;
@@ -28,7 +29,7 @@ pub struct Custom {
 #[serde(deny_unknown_fields)]
 pub struct CustomConfig {
     /// Update interval in seconds
-    #[serde(default = "CustomConfig::default_interval")]
+    #[serde(default = "CustomConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Shell Command to execute & display

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -5,14 +5,13 @@ use std::iter::{Cycle, Peekable};
 use std::vec;
 use std::sync::mpsc::Sender;
 
-use block::Block;
+use block::{Block, ConfigBlock};
 use config::Config;
 use widgets::button::ButtonWidget;
 use widget::I3BarWidget;
 use input::I3BarEvent;
 use scheduler::Task;
 
-use toml::value::Value;
 use uuid::Uuid;
 
 pub struct Custom {
@@ -48,11 +47,13 @@ impl CustomConfig {
     }
 }
 
-impl Custom {
-    pub fn new(block_config: Value, config: Config, tx: Sender<Task>) -> Custom {
+impl ConfigBlock for Custom {
+    type Config = CustomConfig;
+
+    fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Self {
         let mut custom = Custom {
             id: Uuid::new_v4().simple().to_string(),
-            update_interval: Duration::new(get_u64_default!(block_config, "interval", 10), 0),
+            update_interval: block_config.interval,
             output: ButtonWidget::new(config.clone(), ""),
             command: None,
             on_click: None,
@@ -61,21 +62,18 @@ impl Custom {
         };
         custom.output = ButtonWidget::new(config, &custom.id);
 
-        if let Some(on_click) = block_config.get("on_click").and_then(|s| s.as_str()) {
+        if let Some(on_click) = block_config.on_click {
             custom.on_click = Some(on_click.to_string())
         };
 
-        if let Some(cycle) = block_config.get("cycle").and_then(|s| s.as_array()) {
+        if let Some(cycle) = block_config.cycle {
             custom.cycle = Some(cycle.into_iter()
-                                .map(|s| s.as_str().expect("'cycle' should be an array of strings").to_string())
-                                .collect::<Vec<_>>()
-                                .into_iter()
                                 .cycle()
                                 .peekable());
             return custom
         };
 
-        if let Some(command) = block_config.get("command").and_then(|s| s.as_str()) {
+        if let Some(command) = block_config.command {
             custom.command = Some(command.to_string())
         };
 

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -83,6 +83,52 @@ pub struct DiskSpace {
     unit: Unit,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct DiskSpaceConfig {
+    /// Path to collect information from
+    #[serde(default = "DiskSpaceConfig::default_path")]
+    pub path: String,
+
+    /// Alias that is displayed for path
+    #[serde(default = "DiskSpaceConfig::default_alias")]
+    pub alias: String,
+
+    /// Currently supported options are available and free
+    #[serde(default = "DiskSpaceConfig::default_info_type")]
+    pub info_type: String,
+
+    /// Unit that is used to display disk space. Options are MB, MiB, GB and GiB
+    #[serde(default = "DiskSpaceConfig::default_unit")]
+    pub unit: String,
+
+    /// Update interval in seconds
+    #[serde(default = "DiskSpaceConfig::default_interval")]
+    pub interval: Duration,
+}
+
+impl DiskSpaceConfig {
+    fn default_path() -> String {
+        "/".to_owned()
+    }
+
+    fn default_alias() -> String {
+        "/".to_owned()
+    }
+
+    fn default_info_type() -> String {
+        "available".to_owned()
+    }
+
+    fn default_unit() -> String {
+        "GB".to_owned()
+    }
+
+    fn default_interval() -> Duration {
+        Duration::from_secs(20)
+    }
+}
+
 impl DiskSpace {
     pub fn new(block_config: Value, config: Config) -> DiskSpace {
         DiskSpace {

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -5,6 +5,7 @@ use scheduler::Task;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_duration;
 use input::I3BarEvent;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
@@ -104,7 +105,7 @@ pub struct DiskSpaceConfig {
     pub unit: String,
 
     /// Update interval in seconds
-    #[serde(default = "DiskSpaceConfig::default_interval")]
+    #[serde(default = "DiskSpaceConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 }
 

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -27,6 +27,21 @@ pub struct FocusedWindow {
     id: String,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct FocusedWindowConfig {
+    /// Truncates titles if longer than max-width
+    #[serde(default = "FocusedWindowConfig::default_max_width")]
+    pub max_width: usize,
+}
+
+impl FocusedWindowConfig {
+    fn default_max_width() -> usize {
+        21
+    }
+}
+
+
 impl FocusedWindow {
     pub fn new(block_config: Value, config: Config, tx: Sender<Task>) -> FocusedWindow {
         let id = Uuid::new_v4().simple().to_string();

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -3,14 +3,13 @@ use std::sync::mpsc::Sender;
 use std::thread;
 use std::sync::{Arc, Mutex};
 
-use block::Block;
+use block::{Block, ConfigBlock};
 use config::Config;
 use widgets::text::TextWidget;
 use widget::I3BarWidget;
 use input::I3BarEvent;
 use scheduler::Task;
 
-use toml::value::Value;
 use uuid::Uuid;
 
 extern crate i3ipc;
@@ -42,8 +41,10 @@ impl FocusedWindowConfig {
 }
 
 
-impl FocusedWindow {
-    pub fn new(block_config: Value, config: Config, tx: Sender<Task>) -> FocusedWindow {
+impl ConfigBlock for FocusedWindow {
+    type Config = FocusedWindowConfig;
+
+    fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Self {
         let id = Uuid::new_v4().simple().to_string();
         let id_clone = id.clone();
 
@@ -90,7 +91,7 @@ impl FocusedWindow {
         FocusedWindow {
             id,
             text: TextWidget::new(config),
-            max_width: get_u64_default!(block_config, "max-width", 21) as usize,
+            max_width: block_config.max_width,
             title
         }
     }

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -22,6 +22,25 @@ pub struct Load {
     update_interval: Duration,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct LoadConfig {
+    #[serde(default = "LoadConfig::default_format")]
+    pub format: String,
+    #[serde(default = "LoadConfig::default_interval")]
+    pub interval: Duration,
+}
+
+impl LoadConfig {
+    fn default_format() -> String {
+        "{1m}".to_owned()
+    }
+
+    fn default_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+}
+
 impl Load {
     pub fn new(block_config: Value, config: Config) -> Load {
         let text = TextWidget::new(config).with_icon("cogs").with_state(State::Info);

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_duration;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
 use input::I3BarEvent;
@@ -28,7 +29,7 @@ pub struct Load {
 pub struct LoadConfig {
     #[serde(default = "LoadConfig::default_format")]
     pub format: String,
-    #[serde(default = "LoadConfig::default_interval")]
+    #[serde(default = "LoadConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 }
 

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -211,6 +211,91 @@ pub struct Memory {
     critical: (f64,f64)
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryConfig {
+    /// Format string for Memory view. All format values are described below.
+    #[serde(default = "MemoryConfig::default_format_mem")]
+    pub format_mem: String,
+
+    /// Format string for Swap view.
+    #[serde(default = "MemoryConfig::default_format_swap")]
+    pub format_swap: String,
+
+    /// Default view displayed on startup. Options are <br/> memory, swap
+    #[serde(default = "MemoryConfig::default_display_type")]
+    pub display_type: String,
+
+    /// Whether the format string should be prepended with Icons. Options are <br/> true, false
+    #[serde(default = "MemoryConfig::default_icons")]
+    pub icons: bool,
+
+    /// Whether the view should switch between memory and swap on click. Options are <br/> true, false
+    #[serde(default = "MemoryConfig::default_clickable")]
+    pub clickable: bool,
+
+    /// The delay in seconds between an update. If `clickable`, an update is triggered on click. Integer values only.
+    #[serde(default = "MemoryConfig::default_interval")]
+    pub interval: Duration,
+
+    /// Percentage of memory usage, where state is set to warning
+    #[serde(default = "MemoryConfig::default_warning_mem")]
+    pub warning_mem: f64,
+
+    /// Percentage of swap usage, where state is set to warning
+    #[serde(default = "MemoryConfig::default_warning_swap")]
+    pub warning_swap: f64,
+
+    /// Percentage of memory usage, where state is set to critical
+    #[serde(default = "MemoryConfig::default_critical_mem")]
+    pub critical_mem: f64,
+
+    /// Percentage of swap usage, where state is set to critical
+    #[serde(default = "MemoryConfig::default_critical_swap")]
+    pub critical_swap: f64,
+}
+
+impl MemoryConfig {
+    fn default_format_mem() -> String {
+        "{MFm}MB/{MTm}MB({Mp}%)".to_owned()
+    }
+
+    fn default_format_swap() -> String {
+        "{SFm}MB/{STm}MB({Sp}%)".to_owned()
+    }
+
+    fn default_display_type() -> String {
+        "memory".to_owned()
+    }
+
+    fn default_icons() -> bool {
+        true
+    }
+
+    fn default_clickable() -> bool {
+        true
+    }
+
+    fn default_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+
+    fn default_warning_mem() -> f64 {
+        80.0
+    }
+
+    fn default_warning_swap() -> f64 {
+        80.0
+    }
+
+    fn default_critical_mem() -> f64 {
+        95.0
+    }
+
+    fn default_critical_swap() -> f64 {
+        95.0
+    }
+}
 
 impl Memory {
     fn format_insert_values(&mut self, mem_state: Memstate) -> String {

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -81,6 +81,7 @@ use std::fmt;
 
 
 use config::Config;
+use de::deserialize_duration;
 use widgets::button::ButtonWidget;
 use widget::{State,I3BarWidget};
 use scheduler::Task;
@@ -233,7 +234,7 @@ pub struct MemoryConfig {
     pub clickable: bool,
 
     /// The delay in seconds between an update. If `clickable`, an update is triggered on click. Integer values only.
-    #[serde(default = "MemoryConfig::default_interval")]
+    #[serde(default = "MemoryConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Percentage of memory usage, where state is set to warning

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -36,8 +36,9 @@ use super::scheduler::Task;
 
 extern crate dbus;
 
-use toml::value::Value;
+use serde::de::Deserialize;
 use std::sync::mpsc::Sender;
+use toml::value::Value;
 
 macro_rules! boxed ( { $b:expr } => { Box::new($b) as Box<Block> }; );
 

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -31,7 +31,7 @@ use self::focused_window::*;
 use self::temperature::*;
 use self::xrandr::*;
 
-use super::block::Block;
+use super::block::{Block, ConfigBlock};
 use super::scheduler::Task;
 
 extern crate dbus;
@@ -41,6 +41,13 @@ use std::sync::mpsc::Sender;
 use toml::value::Value;
 
 macro_rules! boxed ( { $b:expr } => { Box::new($b) as Box<Block> }; );
+
+macro_rules! block {
+    ($block_type:ident, $block_config:expr, $config:expr, $tx_update_request:expr) => {{
+        let block_config: <$block_type as ConfigBlock>::Config = <$block_type as ConfigBlock>::Config::deserialize($block_config).unwrap();
+        Box::new($block_type::new(block_config, $config, $tx_update_request)) as Box<Block>
+    }}
+}
 
 pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_request: Sender<Task>) -> Box<Block> {
     match name {

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -40,8 +40,6 @@ use serde::de::Deserialize;
 use std::sync::mpsc::Sender;
 use toml::value::Value;
 
-macro_rules! boxed ( { $b:expr } => { Box::new($b) as Box<Block> }; );
-
 macro_rules! block {
     ($block_type:ident, $block_config:expr, $config:expr, $tx_update_request:expr) => {{
         let block_config: <$block_type as ConfigBlock>::Config = <$block_type as ConfigBlock>::Config::deserialize($block_config).unwrap();
@@ -49,23 +47,32 @@ macro_rules! block {
     }}
 }
 
-pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_request: Sender<Task>) -> Box<Block> {
-    match name {
-        "time" => boxed!(Time::new(block_config, config)),
-        "template" => boxed!(Template::new(block_config, config, tx_update_request)),
-        "music" => boxed!(Music::new(block_config, config, tx_update_request)),
-        "load" => boxed!(Load::new(block_config, config)),
-        "memory" => boxed!(Memory::new(block_config, config, tx_update_request)),
-        "cpu" => boxed!(Cpu::new(block_config, config)),
-        "pacman" => boxed!(Pacman::new(block_config, config)),
-        "battery" => boxed!(Battery::new(block_config, config)),
-        "custom" => boxed!(Custom::new(block_config, config, tx_update_request)),
-        "disk_space" => boxed!(DiskSpace::new(block_config, config)),
-        "toggle" => boxed!(Toggle::new(block_config, config)),
-        "sound" => boxed!(Sound::new(block_config, config)),
-        "temperature" => boxed!(Temperature::new(block_config, config)),
-        "focused_window" => boxed!(FocusedWindow::new(block_config, config, tx_update_request)),
-        "xrandr" => boxed!(Xrandr::new(block_config, config)),
-        _ => panic!("Not a registered block: {}", name),
+macro_rules! blocks {
+    ( $name:ident, $block_config:ident, $config:ident, $tx_update_request:ident ; $( $block_name:expr => $block_type:ident ),+ ) => {
+        match $name {
+            $(
+                $block_name => block!($block_type, $block_config, $config, $tx_update_request),
+             )*
+            _ => panic!("Not a registered block: {}", $name),
+        }
     }
+}
+
+pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_request: Sender<Task>) -> Box<Block> {
+    blocks!(name, block_config, config, tx_update_request;
+            "time" => Time,
+            "template" => Template,
+            "music" => Music,
+            "load" => Load,
+            "memory" => Memory,
+            "cpu" => Cpu,
+            "pacman" => Pacman,
+            "battery" => Battery,
+            "custom" => Custom,
+            "disk_space" => DiskSpace,
+            "toggle" => Toggle,
+            "sound" => Sound,
+            "temperature" => Temperature,
+            "focused_window" => FocusedWindow,
+            "xrandr" => Xrandr)
 }

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -28,6 +28,39 @@ pub struct Music {
     player: String,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct MusicConfig {
+    /// Name of the music player.Must be the same name the player<br/> is registered with the MediaPlayer2 Interface.
+    pub player: String,
+
+    /// Max width of the block in characters, not including the buttons
+    #[serde(default = "MusicConfig::default_max_width")]
+    pub max_width: usize,
+
+    /// Bool to specify if a marquee style rotation should be used every<br/>10s if the title + artist is longer than max-width
+    #[serde(default = "MusicConfig::default_marquee")]
+    pub marquee: bool,
+
+    /// Array of control buttons to be displayed. Options are<br/>prev (previous title), play (play/pause) and next (next title)
+    #[serde(default = "MusicConfig::default_buttons")]
+    pub buttons: Vec<String>,
+}
+
+impl MusicConfig {
+    fn default_max_width() -> usize {
+        21
+    }
+
+    fn default_marquee() -> bool {
+        true
+    }
+
+    fn default_buttons() -> Vec<String> {
+        vec![]
+    }
+}
+
 impl Music {
     pub fn new(block_config: Value, config: Config, send: Sender<Task>) -> Music {
         let id: String = Uuid::new_v4().simple().to_string();

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -6,14 +6,13 @@ use std::boxed::Box;
 use config::Config;
 use scheduler::Task;
 use input::I3BarEvent;
-use block::Block;
+use block::{Block, ConfigBlock};
 use widgets::rotatingtext::RotatingTextWidget;
 use widgets::button::ButtonWidget;
 use widget::{State, I3BarWidget};
 
 use blocks::dbus::{Connection, BusType, stdintf, ConnectionItem, Message, arg};
 use self::stdintf::OrgFreedesktopDBusProperties;
-use toml::value::Value;
 use uuid::Uuid;
 
 pub struct Music {
@@ -61,8 +60,10 @@ impl MusicConfig {
     }
 }
 
-impl Music {
-    pub fn new(block_config: Value, config: Config, send: Sender<Task>) -> Music {
+impl ConfigBlock for Music {
+    type Config = MusicConfig;
+
+    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Self {
         let id: String = Uuid::new_v4().simple().to_string();
         let id_copy = id.clone();
 
@@ -87,40 +88,37 @@ impl Music {
             }
         });
 
-        let buttons = block_config.get("buttons").and_then(|b| b.as_array());
         let mut play: Option<ButtonWidget> = None;
         let mut prev: Option<ButtonWidget> = None;
         let mut next: Option<ButtonWidget> = None;
-        if let Some(buttons) = buttons {
-            for button in buttons {
-                match button.as_str().expect("Music button identifiers must be Strings") {
-                    "play" =>
-                        play = Some(ButtonWidget::new(config.clone(), "play")
-                            .with_icon("music_play").with_state(State::Info)),
-                    "next" =>
-                        next = Some(ButtonWidget::new(config.clone(), "next")
-                            .with_icon("music_next").with_state(State::Info)),
-                    "prev" =>
-                        prev = Some(ButtonWidget::new(config.clone(), "prev")
-                            .with_icon("music_prev").with_state(State::Info)),
-                    x => panic!("Unknown Music button identifier! {}", x)
-                };
-            }
+        for button in block_config.buttons {
+            match &*button {
+                "play" =>
+                    play = Some(ButtonWidget::new(config.clone(), "play")
+                        .with_icon("music_play").with_state(State::Info)),
+                "next" =>
+                    next = Some(ButtonWidget::new(config.clone(), "next")
+                        .with_icon("music_next").with_state(State::Info)),
+                "prev" =>
+                    prev = Some(ButtonWidget::new(config.clone(), "prev")
+                        .with_icon("music_prev").with_state(State::Info)),
+                x => panic!("Unknown Music button identifier! {}", x)
+            };
         }
 
         Music {
             id: id_copy,
             current_song: RotatingTextWidget::new(Duration::new(10, 0),
                                                                Duration::new(0, 500000000),
-                                                               get_u64_default!(block_config, "max_width", 21) as usize,
+                                                               block_config.max_width,
                                                                config.clone()).with_icon("music").with_state(State::Info),
             prev: prev,
             play: play,
             next: next,
             dbus_conn: Connection::get_private(BusType::Session).unwrap(),
             player_avail: false,
-            player: get_str!(block_config, "player"),
-            marquee: get_bool_default!(block_config, "marquee", true),
+            player: block_config.player,
+            marquee: block_config.marquee,
         }
     }
 }

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -10,6 +10,7 @@ use scheduler::Task;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_duration;
 use input::{I3BarEvent, MouseButton};
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
@@ -27,7 +28,7 @@ pub struct Pacman {
 #[serde(deny_unknown_fields)]
 pub struct PacmanConfig {
     /// Update interval in seconds
-    #[serde(default = "PacmanConfig::default_interval")]
+    #[serde(default = "PacmanConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 }
 

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -5,14 +5,15 @@ use std::time::Duration;
 use std::process::Command;
 use std::env;
 use std::ffi::OsString;
+use std::sync::mpsc::Sender;
+use scheduler::Task;
 
-use block::Block;
+use block::{Block, ConfigBlock};
 use config::Config;
 use input::{I3BarEvent, MouseButton};
 use widgets::text::TextWidget;
 use widget::{I3BarWidget, State};
 
-use toml::value::Value;
 use uuid::Uuid;
 
 
@@ -36,11 +37,13 @@ impl PacmanConfig {
     }
 }
 
-impl Pacman {
-    pub fn new(block_config: Value, config: Config) -> Pacman {
+impl ConfigBlock for Pacman {
+    type Config = PacmanConfig;
+
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
         Pacman {
             id: Uuid::new_v4().simple().to_string(),
-            update_interval: Duration::new(get_u64_default!(block_config, "interval", 600), 0),
+            update_interval: block_config.interval,
             output: TextWidget::new(config).with_icon("update"),
         }
     }

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -22,6 +22,20 @@ pub struct Pacman {
     update_interval: Duration,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct PacmanConfig {
+    /// Update interval in seconds
+    #[serde(default = "PacmanConfig::default_interval")]
+    pub interval: Duration,
+}
+
+impl PacmanConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(60 * 10)
+    }
+}
+
 impl Pacman {
     pub fn new(block_config: Value, config: Config) -> Pacman {
         Pacman {

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -97,6 +97,28 @@ pub struct Sound {
     config: Config,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct SoundConfig {
+    /// Update interval in seconds
+    #[serde(default = "SoundConfig::default_interval")]
+    pub interval: Duration,
+
+    /// The steps volume is in/decreased for the selected audio device (When greater than 50 it gets limited to 50)
+    #[serde(default = "SoundConfig::default_step_width")]
+    pub step_width: u32,
+}
+
+impl SoundConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(2)
+    }
+
+    fn default_step_width() -> u32 {
+        5
+    }
+}
+
 impl Sound {
     pub fn new(block_config: Value, config: Config) -> Sound {
         let id = Uuid::new_v4().simple().to_string();

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -5,6 +5,7 @@ use scheduler::Task;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_duration;
 use widgets::button::ButtonWidget;
 use widget::{I3BarWidget, State};
 use input::{I3BarEvent, MouseButton};
@@ -102,7 +103,7 @@ pub struct Sound {
 #[serde(deny_unknown_fields)]
 pub struct SoundConfig {
     /// Update interval in seconds
-    #[serde(default = "SoundConfig::default_interval")]
+    #[serde(default = "SoundConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// The steps volume is in/decreased for the selected audio device (When greater than 50 it gets limited to 50)

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -1,14 +1,15 @@
 use std::time::Duration;
 use std::process::Command;
 use std::error::Error;
+use std::sync::mpsc::Sender;
+use scheduler::Task;
 
-use block::Block;
+use block::{Block, ConfigBlock};
 use config::Config;
 use widgets::button::ButtonWidget;
 use widget::{I3BarWidget, State};
 use input::I3BarEvent;
 
-use toml::value::Value;
 use uuid::Uuid;
 
 
@@ -42,14 +43,16 @@ impl TemperatureConfig {
     }
 }
 
-impl Temperature {
-    pub fn new(block_config: Value, config: Config) -> Temperature {
+impl ConfigBlock for Temperature {
+    type Config = TemperatureConfig;
+
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
         let id = Uuid::new_v4().simple().to_string();
         Temperature {
-            update_interval: Duration::new(get_u64_default!(block_config, "interval", 5), 0),
+            update_interval: block_config.interval,
             text: ButtonWidget::new(config, &id).with_icon("thermometer"),
             output: String::new(),
-            collapsed: get_bool_default!(block_config, "collapsed", true),
+            collapsed: block_config.collapsed,
             id,
         }
     }

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -6,6 +6,7 @@ use scheduler::Task;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_duration;
 use widgets::button::ButtonWidget;
 use widget::{I3BarWidget, State};
 use input::I3BarEvent;
@@ -25,7 +26,7 @@ pub struct Temperature {
 #[serde(deny_unknown_fields)]
 pub struct TemperatureConfig {
     /// Update interval in seconds
-    #[serde(default = "TemperatureConfig::default_interval")]
+    #[serde(default = "TemperatureConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Collapsed by default?

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -20,6 +20,28 @@ pub struct Temperature {
     update_interval: Duration,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TemperatureConfig {
+    /// Update interval in seconds
+    #[serde(default = "TemperatureConfig::default_interval")]
+    pub interval: Duration,
+
+    /// Collapsed by default?
+    #[serde(default = "TemperatureConfig::default_collapsed")]
+    pub collapsed: bool,
+}
+
+impl TemperatureConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+
+    fn default_collapsed() -> bool {
+        true
+    }
+}
+
 impl Temperature {
     pub fn new(block_config: Value, config: Config) -> Temperature {
         let id = Uuid::new_v4().simple().to_string();

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -2,13 +2,12 @@ use std::time::Duration;
 use std::sync::mpsc::Sender;
 
 use config::Config;
-use block::Block;
+use block::{Block, ConfigBlock};
 use widgets::text::TextWidget;
 use widget::I3BarWidget;
 use input::I3BarEvent;
 use scheduler::Task;
 
-use toml::value::Value;
 use uuid::Uuid;
 
 
@@ -38,18 +37,19 @@ impl TemplateConfig {
     }
 }
 
-impl Template {
-    pub fn new(block_config: Value, config: Config, tx: Sender<Task>) -> Template {
+impl ConfigBlock for Template {
+    type Config = TemplateConfig;
+
+    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Self {
         Template {
             id: Uuid::new_v4().simple().to_string(),
-            update_interval: Duration::new(get_u64_default!(block_config, "interval", 5), 0),
+            update_interval: block_config.interval,
             text: TextWidget::new(config.clone()).with_text("Template"),
-            tx_update_request: tx,
+            tx_update_request: tx_update_request,
             config: config,
         }
     }
 }
-
 
 impl Block for Template
 {

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -3,6 +3,7 @@ use std::sync::mpsc::Sender;
 
 use config::Config;
 use block::{Block, ConfigBlock};
+use de::deserialize_duration;
 use widgets::text::TextWidget;
 use widget::I3BarWidget;
 use input::I3BarEvent;
@@ -27,7 +28,7 @@ pub struct Template {
 #[serde(deny_unknown_fields)]
 pub struct TemplateConfig {
     /// Update interval in seconds
-    #[serde(default = "TemplateConfig::default_interval")]
+    #[serde(default = "TemplateConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 }
 

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -24,6 +24,20 @@ pub struct Template {
     tx_update_request: Sender<Task>,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TemplateConfig {
+    /// Update interval in seconds
+    #[serde(default = "TemplateConfig::default_interval")]
+    pub interval: Duration,
+}
+
+impl TemplateConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+}
+
 impl Template {
     pub fn new(block_config: Value, config: Config, tx: Sender<Task>) -> Template {
         Template {

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -2,12 +2,13 @@ extern crate chrono;
 
 use std::time::Duration;
 
-use block::Block;
+use block::{Block, ConfigBlock};
 use config::Config;
 use self::chrono::offset::local::Local;
+use scheduler::Task;
+use std::sync::mpsc::Sender;
 use widgets::text::TextWidget;
 use widget::{I3BarWidget};
-use toml::value::Value;
 use uuid::Uuid;
 
 
@@ -40,17 +41,18 @@ impl TimeConfig {
     }
 }
 
-impl Time {
-    pub fn new(block_config: Value, config: Config) -> Time {
+impl ConfigBlock for Time {
+    type Config = TimeConfig;
+
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
         Time {
             id: Uuid::new_v4().simple().to_string(),
-            format: get_str_default!(block_config, "format", "%a %d/%m %R"),
+            format: block_config.format,
             time: TextWidget::new(config).with_text("").with_icon("time"),
-            update_interval: Duration::new(get_u64_default!(block_config, "interval", 5), 0),
+            update_interval: block_config.interval,
         }
     }
 }
-
 
 impl Block for Time {
     fn update(&mut self) -> Option<Duration> {

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -18,6 +18,28 @@ pub struct Time {
     format: String
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TimeConfig {
+    /// Format string.<br/> See [chrono docs](https://docs.rs/chrono/0.3.0/chrono/format/strftime/index.html#specifiers) for all options.
+    #[serde(default = "TimeConfig::default_format")]
+    pub format: String,
+
+    /// Update interval in seconds
+    #[serde(default = "TimeConfig::default_interval")]
+    pub interval: Duration,
+}
+
+impl TimeConfig {
+    fn default_format() -> String {
+        "%a %d/%m %R".to_owned()
+    }
+
+    fn default_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+}
+
 impl Time {
     pub fn new(block_config: Value, config: Config) -> Time {
         Time {

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_duration;
 use self::chrono::offset::local::Local;
 use scheduler::Task;
 use std::sync::mpsc::Sender;
@@ -27,7 +28,7 @@ pub struct TimeConfig {
     pub format: String,
 
     /// Update interval in seconds
-    #[serde(default = "TimeConfig::default_interval")]
+    #[serde(default = "TimeConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 }
 

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -22,6 +22,22 @@ pub struct Toggle {
     id: String,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ToggleConfig {
+    /// Update interval in seconds
+    pub interval: Option<Duration>,
+
+    /// Shell Command to enable the toggle
+    pub command_on: Option<String>,
+
+    /// Shell Command to disable the toggle
+    pub command_off: Option<String>,
+
+    /// Shell Command to determine toggle state. <br/>Empty output => off. Any output => on.
+    pub command_state: Option<String>,
+}
+
 impl Toggle {
     pub fn new(block_config: Value, config: Config) -> Toggle {
         let id = Uuid::new_v4().simple().to_string();

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -6,6 +6,7 @@ use scheduler::Task;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_opt_duration;
 use widgets::button::ButtonWidget;
 use widget::I3BarWidget;
 use input::I3BarEvent;
@@ -27,6 +28,7 @@ pub struct Toggle {
 #[serde(deny_unknown_fields)]
 pub struct ToggleConfig {
     /// Update interval in seconds
+    #[serde(default, deserialize_with = "deserialize_opt_duration")]
     pub interval: Option<Duration>,
 
     /// Shell Command to enable the toggle

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -29,13 +29,16 @@ pub struct ToggleConfig {
     pub interval: Option<Duration>,
 
     /// Shell Command to enable the toggle
-    pub command_on: Option<String>,
+    pub command_on: String,
 
     /// Shell Command to disable the toggle
-    pub command_off: Option<String>,
+    pub command_off: String,
 
     /// Shell Command to determine toggle state. <br/>Empty output => off. Any output => on.
-    pub command_state: Option<String>,
+    pub command_state: String,
+
+    /// Text to display in i3bar for this block
+    pub text: String,
 }
 
 impl Toggle {

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -8,6 +8,7 @@ use util::FormatTemplate;
 
 use block::{Block, ConfigBlock};
 use config::Config;
+use de::deserialize_duration;
 use widgets::button::ButtonWidget;
 use widget::I3BarWidget;
 use input::{I3BarEvent, MouseButton};
@@ -57,7 +58,7 @@ pub struct Xrandr {
 #[serde(deny_unknown_fields)]
 pub struct XrandrConfig {
     /// Update interval in seconds
-    #[serde(default = "XrandrConfig::default_interval")]
+    #[serde(default = "XrandrConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Show icons for brightness and resolution (needs awesome fonts support)

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -1,16 +1,17 @@
 use std::time::Duration;
 use std::process::Command;
 use std::str::FromStr;
+use std::sync::mpsc::Sender;
+use scheduler::Task;
 
 use util::FormatTemplate;
 
-use block::Block;
+use block::{Block, ConfigBlock};
 use config::Config;
 use widgets::button::ButtonWidget;
 use widget::I3BarWidget;
 use input::{I3BarEvent, MouseButton};
 
-use toml::value::Value;
 use uuid::Uuid;
 
 struct Monitor {
@@ -100,25 +101,6 @@ macro_rules! unwrap_or_continue {
 }
 
 impl Xrandr {
-    pub fn new(block_config: Value, config: Config) -> Xrandr {
-        let id = Uuid::new_v4().simple().to_string();
-        let mut step_width = get_u64_default!(block_config, "step_width", 5) as u32;
-        if step_width > 50 {
-            step_width = 50;
-        }
-        Xrandr {
-            text: ButtonWidget::new(config.clone(), &id).with_icon("xrandr"),
-            id: id,
-            update_interval: Duration::new(get_u64_default!(block_config, "interval", 5), 0),
-            current_idx: 0,
-            icons: get_bool_default!(block_config, "icons", true),
-            resolution: get_bool_default!(block_config, "resolution", false),
-            step_width: step_width,
-            monitors: Vec::new(),
-            config: config,
-        }
-    }
-
     fn get_active_monitors() -> Option<Vec<String>> {
         let active_montiors_cli = String::from_utf8(
             Command::new("sh")
@@ -221,6 +203,28 @@ impl Xrandr {
     }
 }
 
+impl ConfigBlock for Xrandr {
+    type Config = XrandrConfig;
+
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Self {
+        let id = Uuid::new_v4().simple().to_string();
+        let mut step_width = block_config.step_width;
+        if step_width > 50 {
+            step_width = 50;
+        }
+        Xrandr {
+            text: ButtonWidget::new(config.clone(), &id).with_icon("xrandr"),
+            id: id,
+            update_interval: block_config.interval,
+            current_idx: 0,
+            icons: block_config.icons,
+            resolution: block_config.resolution,
+            step_width: step_width,
+            monitors: Vec::new(),
+            config: config,
+        }
+    }
+}
 impl Block for Xrandr
 {
     fn update(&mut self) -> Option<Duration> {

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -52,6 +52,44 @@ pub struct Xrandr {
     config: Config,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct XrandrConfig {
+    /// Update interval in seconds
+    #[serde(default = "XrandrConfig::default_interval")]
+    pub interval: Duration,
+
+    /// Show icons for brightness and resolution (needs awesome fonts support)
+    #[serde(default = "XrandrConfig::default_icons")]
+    pub icons: bool,
+
+    /// Shows the screens resolution
+    #[serde(default = "XrandrConfig::default_resolution")]
+    pub resolution: bool,
+
+    /// The steps brightness is in/decreased for the selected screen (When greater than 50 it gets limited to 50)
+    #[serde(default = "XrandrConfig::default_step_width")]
+    pub step_width: u32,
+}
+
+impl XrandrConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+
+    fn default_icons() -> bool {
+        true
+    }
+
+    fn default_resolution() -> bool {
+        false
+    }
+
+    fn default_step_width() -> u32 {
+        5 as u32
+    }
+}
+
 macro_rules! unwrap_or_continue {
     ($e: expr) => (
         match $e {

--- a/src/de.rs
+++ b/src/de.rs
@@ -5,7 +5,53 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::str::FromStr;
+use std::time::Duration;
 use toml::{self, value};
+
+pub fn deserialize_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct DurationWrapper;
+
+    impl<'de> de::Visitor<'de> for DurationWrapper {
+        type Value = Duration;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("i64, f64 or map")
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Duration::from_secs(value as u64))
+        }
+
+        fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Duration::new(0, (value * 1_000_000_000f64) as u32))
+        }
+
+        fn visit_map<A>(self, visitor: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(visitor))
+        }
+    }
+
+    deserializer.deserialize_any(DurationWrapper)
+}
+
+pub fn deserialize_opt_duration<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_duration(deserializer).map(Some)
+}
 
 pub struct MapType<T, V>(pub PhantomData<T>, pub PhantomData<V>);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -201,44 +201,12 @@ impl FormatTemplate {
     }
 }
 
-macro_rules! get_str {
-    ($config:expr, $name:expr) => {String::from($config.get($name).and_then(|v| v.as_str()).expect(&format!("Required argument {} not found in block config!", $name)))};
-}
-macro_rules! get_str_default {
-    ($config:expr, $name:expr, $default:expr) => {String::from($config.get($name).and_then(|v| v.as_str()).unwrap_or($default))};
-}
-
-macro_rules! get_u64 {
-    ($config:expr, $name:expr) => {$config.get($name).and_then(|v| v.as_u64()).expect(&format!("Required argument {} not found in block config!", $name))};
-}
-macro_rules! get_u64_default {
-    ($config:expr, $name:expr, $default:expr) => {$config.get($name).and_then(|v| v.as_integer()).unwrap_or($default) as u64};
-}
-
-macro_rules! get_f64 {
-    ($config:expr, $name:expr) => {$config.get($name).and_then(|v| v.as_f64()).expect(&format!("Required argument {} not found in block config!", $name))};
-}
-macro_rules! get_f64_default {
-    ($config:expr, $name:expr, $default:expr) => {$config.get($name).and_then(|v| v.as_float()).unwrap_or($default)};
-}
-
-macro_rules! duration_from_f64 {
-    ($seconds:expr) => {{let val: u64 = ($seconds * 1000f64.powi(3)) as u64;
-                        Duration::new(val/1000u64.pow(3), (val % 1000u64.pow(3)) as u32)}};
-}
 // any uses should be replaced with eprintln! once it is on stable
 macro_rules! eprintln {
     ($fmt:expr, $($arg:tt)*) => {
         use ::std::io::Write;
         writeln!(&mut ::std::io::stderr(), $fmt, $($arg)*).ok();
     };
-}
-
-macro_rules! get_bool {
-    ($config:expr, $name:expr) => {$config.get($name).and_then(|v| v.as_bool()).expect(&format!("Required argument {} not found in block config!", $name))};
-}
-macro_rules! get_bool_default {
-    ($config:expr, $name:expr, $default:expr) => {$config.get($name).and_then(|v| v.as_bool()).unwrap_or($default)};
 }
 
 macro_rules! if_debug {


### PR DESCRIPTION
## Summary

Building on what I mentioned in #41, this PR implements deserialization of block configs into type-safe structs.

## Main changes

* [Added](https://github.com/pitkley/i3status-rust/blob/d9165b1f4ab6861ef22f3511cc012871dc69fc7c/src/block.rs#L25-L29) `trait ConfigBlock: Block` which holds a blocks config in its associated type `Config`
* Added a configuration-struct to every block
* [Deserialize](https://github.com/pitkley/i3status-rust/blob/d9165b1f4ab6861ef22f3511cc012871dc69fc7c/src/blocks/mod.rs#L43-L48) a `toml::Value` into a block's associated config type on creation
* [Added](https://github.com/pitkley/i3status-rust/blob/d9165b1f4ab6861ef22f3511cc012871dc69fc7c/src/de.rs#L11-L54) deserialization helper for durations (used for intervals).

    This deserializes from either an integer, a float or a map:

    ```toml
    interval = 1
    interval = 1.5
    interval = { secs = 1, nanos = 5000000 }
    ```

    Both the integer and float are in seconds, i.e. `interval = 1` equals 1 second, `interval = 1.5` equals 1500 ms. This probably covers the request from #17.

* [Removed](https://github.com/greshake/i3status-rust/compare/master...pitkley:config-struct-blocks?expand=1#diff-d25ef168d08ddcfeaca8453639097a59) no longer needed macros from `src/util.rs`