### PR TITLE
fix speedtest net-down/up icons

### DIFF
--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -117,10 +117,10 @@ impl ConfigBlock for SpeedTest {
                     .with_icon("ping")
                     .with_text("0ms"),
                 ButtonWidget::new(config.clone(), &id)
-                    .with_icon("net-down")
+                    .with_icon("net_down")
                     .with_text(&format!("0{}", ty)),
                 ButtonWidget::new(config.clone(), &id)
-                    .with_icon("net-up")
+                    .with_icon("net_up")
                     .with_text(&format!("0{}", ty)),
             ],
             id,


### PR DESCRIPTION
Or we could just give them different names so that they are different icons? Not sure which way we want to go, but the code should've had them being the same