### PR TITLE
Adding Config options for 'alert' and 'warning' thresholds.

### DIFF
--- a/example_config.toml
+++ b/example_config.toml
@@ -8,6 +8,8 @@ alias = "/"
 info_type = "available"
 unit = "GB"
 interval = 20
+warning = 20.0
+alert = 10.0
 
 [[block]]
 block = "memory"


### PR DESCRIPTION
Defaults to previous values.
Should read "warning" and "alert" from config, alert being "Critical".