### PR TITLE
Add a simple Backlight (brightness) block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ nix = "0.8.1"
 i3ipc = "0.4.2"
 num = "0.1.39"
 chan = "0.1.19"
+inotify = "0.5.0"
 # Used only in debug build mode
 # for profiling blocks
 cpuprofiler = "0.0.3"

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -1,0 +1,132 @@
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use chan::Sender;
+
+use block::{Block, ConfigBlock};
+use config::Config;
+use de::deserialize_duration;
+use errors::*;
+use widgets::text::TextWidget;
+use widget::I3BarWidget;
+use input::I3BarEvent;
+use scheduler::Task;
+
+use uuid::Uuid;
+
+pub struct Backlight {
+    output: TextWidget,
+    id: String,
+    update_interval: Duration,
+    max_brightness: u64,
+    device_path: PathBuf,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct BacklightConfig {
+    /// The update interval, in seconds.
+    #[serde(default = "BacklightConfig::default_interval", deserialize_with = "deserialize_duration")]
+    pub interval: Duration,
+
+    /// The backlight device in `/sys/class/backlight/` to read brightness from.
+    #[serde(default = "BacklightConfig::default_device")]
+    pub device: Option<String>,
+}
+
+impl BacklightConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+
+    fn default_device() -> Option<String> {
+        None
+    }
+}
+
+fn get_default_device() -> Result<PathBuf> {
+    let devices = try!(Path::new("/sys/class/backlight")
+        .read_dir()
+        .block_error("backlight",
+                     "Failed to read backlight device directory"));
+
+    let first_device = try!(match devices.take(1).next() {
+        None => Err(BlockError("backlight".to_string(),
+                               "No backlit devices found".to_string())),
+        Some(device) => device.map_err(|_| {
+            BlockError("backlight".to_string(),
+                       "Failed to read default device file".to_string())
+        }),
+    });
+
+   Ok(first_device.path())
+}
+
+fn read_brightness(device_file: &Path) -> Result<u64> {
+    let mut file = try!(OpenOptions::new()
+        .read(true)
+        .open(device_file)
+        .block_error("backlight",
+                     "Failed to open brightness file"));
+    let mut content = String::new();
+    try!(file.read_to_string(&mut content)
+         .block_error("backlight",
+                      "Failed to read brightness file"));
+    // Removes trailing newline.
+    content.pop();
+    content.parse::<u64>()
+        .block_error("backlight",
+                     "Failed to read value from brightness file")
+}
+
+impl ConfigBlock for Backlight {
+    type Config = BacklightConfig;
+
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
+        let mut backlight = Backlight {
+            output: TextWidget::new(config),
+            id: Uuid::new_v4().simple().to_string(),
+            update_interval: block_config.interval,
+            max_brightness: 0,
+            device_path: match block_config.device {
+                Some(path) => Path::new("/sys/class/backlight").join(path),
+                None => try!(get_default_device()),
+            },
+        };
+
+        if !backlight.device_path.exists() {
+            return Err(BlockError("backlight".to_string(),
+                                  format!("Backlight device '{}' does not exist",
+                                          backlight.device_path.to_string_lossy())));
+        }
+
+        backlight.max_brightness = try!(read_brightness(
+            &backlight.device_path.join("max_brightness")
+        ));
+
+        Ok(backlight)
+    }
+}
+
+impl Block for Backlight {
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let brightness = try!(read_brightness(&self.device_path.join("brightness")));
+        let display = ((brightness as f64 / self.max_brightness as f64) * 100.0) as u64;
+        self.output.set_text(format!("{}%", display));
+        self.output.set_icon("xrandr");
+        Ok(Some(self.update_interval))
+    }
+
+    fn view(&self) -> Vec<&I3BarWidget> {
+        vec![&self.output]
+    }
+
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -141,7 +141,7 @@ impl ConfigBlock for Backlight {
         let id = Uuid::new_v4().simple().to_string();
         let brightness_file = device.brightness_file();
 
-        let mut backlight = Backlight {
+        let backlight = Backlight {
             output: TextWidget::new(config),
             id: id.clone(),
             device: device,
@@ -170,7 +170,6 @@ impl ConfigBlock for Backlight {
             }
         });
 
-        backlight.output.set_icon("xrandr");
         Ok(backlight)
     }
 }
@@ -180,6 +179,13 @@ impl Block for Backlight {
         let brightness = try!(self.device.brightness());
         let display = ((brightness as f64 / self.device.max_brightness as f64) * 100.0) as u64;
         self.output.set_text(format!("{}%", display));
+        match display {
+            0...19 => self.output.set_icon("backlight_empty"),
+            20...39 => self.output.set_icon("backlight_partial1"),
+            40...59 => self.output.set_icon("backlight_partial2"),
+            60...79 => self.output.set_icon("backlight_partial3"),
+            _ => self.output.set_icon("backlight_full"),
+        }
         Ok(None)
     }
 

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -15,6 +15,7 @@ mod speedtest;
 mod focused_window;
 mod xrandr;
 mod net;
+mod backlight;
 
 use config::Config;
 use self::time::*;
@@ -34,6 +35,7 @@ use self::focused_window::*;
 use self::temperature::*;
 use self::xrandr::*;
 use self::net::*;
+use self::backlight::*;
 
 use super::block::{Block, ConfigBlock};
 use errors::*;
@@ -82,5 +84,7 @@ pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_r
             "temperature" => Temperature,
             "focused_window" => FocusedWindow,
             "xrandr" => Xrandr,
-            "net" => Net)
+            "net" => Net,
+            "backlight" => Backlight
+    )
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -29,7 +29,12 @@ lazy_static! {
         "xrandr" => " SCREEN ",
         "net_up" => " UP ",
         "net_down" => " DOWN ",
-        "ping" => " PING "
+        "ping" => " PING ",
+        "backlight_empty" => " BRIGHT ",
+        "backlight_partial1" => " BRIGHT ",
+        "backlight_partial2" => " BRIGHT ",
+        "backlight_partial3" => " BRIGHT ",
+        "backlight_full" => " BRIGHT "
     };
 
     pub static ref AWESOME: Map<String, String> = map_to_owned! {
@@ -60,7 +65,12 @@ lazy_static! {
         "xrandr" => " \u{f26c} ",
         "net_up" => " \u{2b06} ",
         "net_down" => " \u{2b07} ",
-        "ping" => " \u{21ba} "
+        "ping" => " \u{21ba} ",
+        "backlight_empty" => " \u{1f315} ",
+        "backlight_partial1" => " \u{1f314} ",
+        "backlight_partial2" => " \u{1f313} ",
+        "backlight_partial3" => " \u{1f312} ",
+        "backlight_full" => " \u{1f311} "
     };
 
     pub static ref MATERIAL: Map<String, String> = map_to_owned! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ extern crate clap;
 extern crate uuid;
 extern crate regex;
 extern crate num;
+extern crate inotify;
 
 #[macro_use]
 mod de;


### PR DESCRIPTION
This PR adds a `backlight` block that shows brightness information for a given display device. It does duplicate some aspects of the `xrandr` block, but has two important advantages:

1. It reads the `sysfs` files directly instead of using an external command (like `xrandr`), which means it works on Wayland, and addresses #92; and
2. It uses `inotify` (on a separate thread) to update the block whenever the display brightness is changed, instead of updating at a set interval.

This approach does mean adding the `inotify` crate as a dependency, and it will only work on Linux. I haven't carefully profiled the block for performance issues, but it doesn't look all that suspicious in `htop`.

I've also run `cargo fmt` on the main file, for what it's worth.