### PR TITLE
Added total and used info_types, and option to show percentage to disk_space block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -169,6 +169,7 @@ Key | Values | Required | Default
 `info_type` | Currently supported options are available and free | No | `"available"`
 `unit` | Unit that is used to display disk space. Options are MB, MiB, GB and GiB | No | `"GB"`
 `interval` | Update interval, in seconds. | No | `20`
+`show_percentage` | Show percentage of used/available disk space depending on info_type. | No | `false`
 
 ## Focused Window
 

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -16,12 +16,13 @@ extern crate nix;
 
 use self::nix::sys::statvfs::vfs::Statvfs;
 
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
 pub enum Unit {
     MB,
     GB,
     GiB,
     MiB,
+    Percent
 }
 
 impl Unit {
@@ -31,6 +32,7 @@ impl Unit {
             Unit::GB => bytes as f64 / 1000. / 1000. / 1000.,
             Unit::MiB => bytes as f64 / 1024. / 1024.,
             Unit::GiB => bytes as f64 / 1024. / 1024. / 1024.,
+            Unit::Percent => bytes as f64,
         }
     }
 }
@@ -40,9 +42,8 @@ impl Unit {
 pub enum InfoType {
     Available,
     Free,
-    // TODO: implement
-    //Total,
-    //Used,
+    Total,
+    Used,
 }
 
 pub struct DiskSpace {
@@ -55,6 +56,7 @@ pub struct DiskSpace {
     unit: Unit,
     warning: f64,
     alert: f64,
+    show_percentage: bool,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -88,6 +90,9 @@ pub struct DiskSpaceConfig {
     #[serde(default = "DiskSpaceConfig::default_alert")]
     pub alert: f64,
 
+    /// Show percentage
+    #[serde(default = "DiskSpaceConfig::default_show_percentage")]
+    pub show_percentage: bool,
 }
 
 impl DiskSpaceConfig {
@@ -118,20 +123,38 @@ impl DiskSpaceConfig {
     fn default_alert() -> f64 {
         10.
     }
+
+    fn default_show_percentage() -> bool {
+        false
+    }
 }
 
 impl DiskSpace {
     fn compute_state(&self, bytes: u64, warning: f64, alert: f64) -> State {
-        let value = Unit::bytes_in_unit(Unit::GB, bytes);
-        match self.info_type {
-            InfoType::Available | InfoType::Free => if 0. <= value && value < alert {
-                State::Critical
-            } else if alert <= value && value < warning {
-                State::Warning
-            } else {
-                State::Idle
-            },
-            //InfoType::Total | InfoType::Used => unimplemented!(),
+        let value = if self.unit == Unit::Percent { bytes as f64 } else { Unit::bytes_in_unit(Unit::GB, bytes) };
+        match self.unit {
+            Unit::Percent => {
+                match self.info_type {
+                    InfoType::Available | InfoType::Free | InfoType::Total | InfoType::Used => if value > alert {
+                        State::Critical
+                    } else if value <= alert && value > warning {
+                        State::Warning
+                    } else {
+                        State::Idle
+                    }
+                }
+            }
+            _ => {
+                match self.info_type {
+                    InfoType::Available | InfoType::Free | InfoType::Total | InfoType::Used => if 0. <= value && value < alert {
+                        State::Critical
+                    } else if alert <= value && value < warning {
+                        State::Warning
+                    } else {
+                        State::Idle
+                    }
+                }
+            }
         }
     }
 }
@@ -150,6 +173,7 @@ impl ConfigBlock for DiskSpace {
             unit: block_config.unit,
             warning: block_config.warning,
             alert: block_config.alert,
+            show_percentage: block_config.show_percentage,
         })
     }
 }
@@ -158,8 +182,11 @@ impl Block for DiskSpace {
     fn update(&mut self) -> Result<Option<Duration>> {
         let statvfs = Statvfs::for_path(Path::new(self.path.as_str()))
             .block_error("disk_space", "failed to retrieve statvfs")?;
-        let result;
-        let converted;
+        let mut result;
+        let mut converted = 0.0f64;
+        let mut converted_str = String::new();
+        let total = statvfs.f_blocks * statvfs.f_frsize;
+        let used = (statvfs.f_blocks - statvfs.f_bfree) * statvfs.f_frsize;
 
         match self.info_type {
             InfoType::Available => {
@@ -170,15 +197,52 @@ impl Block for DiskSpace {
                 result = statvfs.f_bfree * statvfs.f_bsize;
                 converted = Unit::bytes_in_unit(self.unit, result);
             }
-            //InfoType::Total | InfoType::Used => unimplemented!(),
+            InfoType::Total => {
+                result = used;
+                let converted_used = Unit::bytes_in_unit(self.unit, result);
+                let converted_total = Unit::bytes_in_unit(self.unit, total);
+
+                converted_str = format!(
+                                    "{0:.2}/{1:.2}",
+                                    converted_used,
+                                    converted_total
+                                );
+            }
+            InfoType::Used => {
+                result = used;
+                converted = Unit::bytes_in_unit(self.unit, result);
+            }
         }
 
-        self.disk_space.set_text(format!(
-            "{0} {1:.2} {2:?}",
-            self.alias,
-            converted,
-            self.unit
-        ));
+        let percentage = (result as f32) / (total as f32) * 100f32;
+        if converted_str.is_empty() {
+            converted_str = format!("{0:.2}", converted);
+        }
+
+        if self.unit == Unit::Percent {
+            self.disk_space.set_text(format!("{0} {1:.2}%",
+                self.alias,
+                percentage
+            ));
+            result = percentage as u64;
+        } else {
+            if self.show_percentage {
+                self.disk_space.set_text(format!(
+                    "{0} {1} ({2:.2}%) {3:?}",
+                    self.alias,
+                    converted_str,
+                    percentage,
+                    self.unit
+                ));
+            } else {
+                self.disk_space.set_text(format!(
+                    "{0} {1} {2:?}",
+                    self.alias,
+                    converted_str,
+                    self.unit
+                ));
+            }
+        }
 
         let state = self.compute_state(result, self.warning, self.alert);
         self.disk_space.set_state(state);


### PR DESCRIPTION
Added implementation to the two missing info_types, `used` and `total`. Also there's a possibility to show a percentage which value depends on the info_type used. The default value for this is false.

With `free` it would show: `<free> (<free_percent>%)`
With `total`: `<used>/<total> (<used_precent>%)`