### PR TITLE
Allow modifying the backlight using the mouse wheel, via sysfs

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -25,6 +25,8 @@ Creates a block to display screen brightness. This is a simplified version of th
 
 When there is no `device` specified, this block will display information from the first device found in the `/sys/class/backlight` directory. If you only have one display, this approach should find it correctly.
 
+It is possible to set the brightness using this block as well -- [see below](#setting-brightness-with-the-mouse-wheel) for details.
+
 ### Examples
 
 Show brightness for a specific device:
@@ -47,6 +49,20 @@ block = "backlight"
 Key | Values | Required | Default
 ----|--------|----------|--------
 `device` | The `/sys/class/backlight` device to read brightness information from. | No | Default device
+`step_width` | The brightness increment to use when scrolling, in percent. | No | `5`
+
+### Setting Brightness with the Mouse Wheel
+
+The block allows for setting brightness with the mouse wheel. However, depending on how you installed i3status-rust, it may not have the appropriate permissions to modify these files, and will fail silently. To remedy this you can write a `udev` rule for your system (if you are comfortable doing so).
+
+First, check that your user is a member of the "video" group using the `groups` command. Then add a rule in the `/etc/udev/rules.d/` directory containing the following, for example in `backlight.rules`:
+
+```
+ACTION=="add", SUBSYSTEM=="backlight", KERNEL=="acpi_video0", RUN+="/bin/chgrp video /sys/class/backlight/%k/brightness"
+ACTION=="add", SUBSYSTEM=="backlight", KERNEL=="acpi_video0", RUN+="/bin/chmod g+w /sys/class/backlight/%k/brightness"
+```
+
+You will need to ensure that the value of the `KERNEL` parameter here is the same as the `device` used to configure the block. (You will also need to restart for this rule to take effect.)
 
 ## Battery
 

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -1,20 +1,29 @@
+//! A block for displaying the brightness of a backlit device.
+//!
+//! This module contains the [`Backlight`](./struct.Backlight.html) block, which
+//! can display the brightness level of physical backlit devices. Brightness
+//! levels are read from and written to the `sysfs` filesystem, so this block
+//! does not depend on `xrandr` (and thus it works on Wayland). To set
+//! brightness levels using `xrandr`, see the
+//! [`Xrandr`](../xrandr/struct.Xrandr.html) block.
+
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, Instant};
+
 use chan::Sender;
 use inotify::{EventMask, Inotify, WatchMask};
+use uuid::Uuid;
 
 use block::{Block, ConfigBlock};
 use config::Config;
 use errors::*;
-use widgets::button::ButtonWidget;
-use widget::I3BarWidget;
 use input::{I3BarEvent, MouseButton};
 use scheduler::Task;
-
-use uuid::Uuid;
+use widget::I3BarWidget;
+use widgets::button::ButtonWidget;
 
 /// Read a brightness value from the given path.
 fn read_brightness(device_file: &Path) -> Result<u64> {
@@ -37,6 +46,7 @@ fn read_brightness(device_file: &Path) -> Result<u64> {
     )
 }
 
+/// Represents a physical backlit device whose brightness level can be queried.
 pub struct BacklitDevice {
     max_brightness: u64,
     device_path: PathBuf,
@@ -76,8 +86,8 @@ impl BacklitDevice {
         })
     }
 
-    /// Use the backlit device `device`. Raises an error if a directory for that
-    /// device is not found.
+    /// Use the backlit device `device`. Returns an error if a directory for
+    /// that device is not found.
     pub fn from_device(device: String) -> Result<Self> {
         let device_path = Path::new("/sys/class/backlight").join(device);
         if !device_path.exists() {
@@ -133,6 +143,7 @@ impl BacklitDevice {
     }
 }
 
+/// A block for displaying the brightness of a backlit device.
 pub struct Backlight {
     id: String,
     output: ButtonWidget,
@@ -140,6 +151,7 @@ pub struct Backlight {
     step_width: u64,
 }
 
+/// Configuration for the [`Backlight`](./struct.Backlight.html) block.
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct BacklightConfig {

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -15,7 +15,7 @@ mod speedtest;
 mod focused_window;
 mod xrandr;
 mod net;
-mod backlight;
+pub mod backlight;
 mod weather;
 
 use config::Config;
@@ -36,7 +36,7 @@ use self::focused_window::*;
 use self::temperature::*;
 use self::xrandr::*;
 use self::net::*;
-use self::backlight::*;
+use self::backlight::Backlight;
 use self::weather::*;
 
 use super::block::{Block, ConfigBlock};

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ mod de;
 #[macro_use]
 mod util;
 mod block;
-mod blocks;
+pub mod blocks;
 mod config;
 mod errors;
 mod input;


### PR DESCRIPTION
This PR adds support for setting the backlight. Since it uses `sysfs`, the binary must have appropriate permissions. This should close #92.

In light of discussion in e.g. #145, scrolling will silently fail instead of crashing the block.

~~I am waiting on #135 to merge before documenting the new `step_width` parameter.~~

This PR also documents the new `step_width` parameter, the process of writing a `udev` rule to fix permissions issues, and, in general, improves internal documentation of the Backlight block.