### PR TITLE
Battery: implement "show" config option to display percentage, time until (dis)charged or both.

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -50,7 +50,7 @@ Key | Values | Required | Default
 
 ## Battery
 
-Creates a block which displays the current battery state (Full, Charging or Discharging) and percentage charged.
+Creates a block which displays the current battery state (Full, Charging or Discharging), percentage charged and estimate time until (dis)charged.
 
 ### Examples
 
@@ -60,6 +60,7 @@ Update the battery state every ten seconds:
 [[block]]
 block = "battery"
 interval = 10
+show = "percentage"
 ```
 
 ### Options
@@ -68,6 +69,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `device` | The device in `/sys/class/power_supply/` to read from. | No | `"BAT0"`
 `interval` | Update interval, in seconds. | No | `10`
+`show` | Show remaining 'time', 'percentage' or 'both' | No | `both`
 
 ## CPU Utilization
 
@@ -501,7 +503,7 @@ Key | Value
 
 ## Xrandr
 
-Creates a block which shows screen information (name, brightness, resolution). With a click you can toggle through your active screens and with wheel up and down you can adjust the selected screens brighntess.
+Creates a block which shows screen information (name, brightness, resolution). With a click you can toggle through your active screens and with wheel up and down you can adjust the selected screens brightness.
 
 ### Examples
 

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -138,7 +138,7 @@ impl Block for Battery {
         };
 
         let energy_full = if file_exists(&format!("{}energy_full", self.device_path)) {
-             read_file(&format!("{}energy_full", self.device_path))?
+            read_file(&format!("{}energy_full", self.device_path))?
                 .parse::<u64>()
                 .block_error("battery", "failed to parse  energy_full")?
         } else {
@@ -149,42 +149,46 @@ impl Block for Battery {
             read_file(&format!("{}power_now", self.device_path))?
                 .parse::<u64>()
                 .block_error("battery", "failed to parse current voltage")?
-        } else  {
+        } else {
             0
         };
 
         let (hours, minutes) = if power_now > 0 && energy_now > 0 {
             if state == "Discharging" {
                 let h = (energy_now as f64 / power_now as f64) as u64;
-                let m = (((energy_now  as f64 / power_now as f64) - h as f64)*60.0) as u64;
-                (h,m)
+                let m = (((energy_now as f64 / power_now as f64) - h as f64) * 60.0) as u64;
+                (h, m)
             } else if state == "Charging" {
                 let h = ((energy_full as f64 - energy_now as f64) / power_now as f64) as u64;
-                let m = ((((energy_full as f64 - energy_now as f64)  / power_now as f64) - h as f64) * 60.0) as u64;
-                (h,m)
+                let m = ((((energy_full as f64 - energy_now as f64) / power_now as f64) - h as f64) * 60.0) as u64;
+                (h, m)
             } else {
-                (0,0)
+                (0, 0)
             }
         } else {
-            (0,0)
+            (0, 0)
         };
 
         // Don't need to display a percentage when the battery is full
         if current_percentage != 100 && state != "Full" {
             match self.show.as_ref() {
-                "both" => self.output.set_text(format!("{}% {}:{:02}", current_percentage, hours, minutes)),
+                "both" => self.output
+                    .set_text(format!("{}% {}:{:02}", current_percentage, hours, minutes)),
                 "percentage" => self.output.set_text(format!("{}%", current_percentage)),
                 "time" => self.output.set_text(format!("{}:{:02}", hours, minutes)),
-                _ => { return Err(BlockError(
-                    "battery".to_string(),
-                    format!("Invalid 'show' option: '{}', use 'time', 'percentage' or 'both'", self.show).to_string(),
+                _ => {
+                    return Err(BlockError(
+                        "battery".to_string(),
+                        format!(
+                            "Invalid 'show' option: '{}', use 'time', 'percentage' or 'both'",
+                            self.show
+                        ).to_string(),
                     ));
                 }
             }
         } else {
             self.output.set_text(String::from(""));
         }
-
 
         self.output.set_icon(match state.as_str() {
             "Full" => "bat_full",


### PR DESCRIPTION
Example:
 ````       show = "percentage"````

Possible values: "both", "time", "percentage".
Default: "both".
    
Closes #138
