### PR TITLE
[on hold]  temperature: add option "show =" which accepts "max", "average" and "both" keys.

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -394,6 +394,7 @@ Creates a block which displays the system temperature, based on lm_sensors' `sen
 block = "temperature"
 collapsed = false
 interval = 10
+show = "max"
 ```
 
 ### Options
@@ -402,6 +403,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 interval | Update interval, in seconds. | No | 5
 collapsed | Collapsed by default? | No | true
+show | Show `max` temperature, `average` of all sensors or `both` | No | `both`
 
 ## Time
 


### PR DESCRIPTION
I found it annoying that the block would display two temps so I added an option to switch between both, only max and only average.