### PR TITLE
uptime: add uptime block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -501,6 +501,20 @@ Key | Value
 `{weather}` | Textual description of the weather, e.g. "Raining".
 `{wind}` | Wind speed.
 
+## Uptime
+Creates a block which displays system uptime. The block will always display the 2 biggest units, so minutes and seconds, or hours and minutes or days and hours or weeks and days.
+
+### Examples
+
+```toml
+[[block]]
+block = "uptime"
+```
+
+### Options
+
+None
+
 ## Xrandr
 
 Creates a block which shows screen information (name, brightness, resolution). With a click you can toggle through your active screens and with wheel up and down you can adjust the selected screens brightness.

--- a/src/blocks/lib.rs
+++ b/src/blocks/lib.rs
@@ -1,0 +1,20 @@
+use errors::*;
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+
+pub fn read_file(blockname: &str, path: &str) -> Result<String> {
+    let mut f = OpenOptions::new()
+        .read(true)
+        .open(path)
+        .block_error(blockname, &format!("failed to open file {}", path))?;
+    let mut content = String::new();
+    f.read_to_string(&mut content)
+        .block_error(blockname, &format!("failed to read {}", path))?;
+    // Removes trailing newline
+    content.pop();
+    Ok(content)
+}
+
+pub fn file_exists(path: &str) -> bool {
+    ::std::path::Path::new(path).exists()
+}

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -18,6 +18,7 @@ mod net;
 mod backlight;
 mod weather;
 mod uptime;
+mod lib;
 
 use config::Config;
 use self::time::*;

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -17,6 +17,7 @@ mod xrandr;
 mod net;
 mod backlight;
 mod weather;
+mod uptime;
 
 use config::Config;
 use self::time::*;
@@ -38,6 +39,7 @@ use self::xrandr::*;
 use self::net::*;
 use self::backlight::*;
 use self::weather::*;
+use self::uptime::*;
 
 use super::block::{Block, ConfigBlock};
 use errors::*;
@@ -88,6 +90,7 @@ pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_r
             "xrandr" => Xrandr,
             "net" => Net,
             "backlight" => Backlight,
-            "weather" => Weather
+            "weather" => Weather,
+            "uptime" => Uptime
     )
 }

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -1,18 +1,14 @@
 use std::time::Duration;
 use chan::Sender;
-
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
 use widgets::text::TextWidget;
 use widget::I3BarWidget;
-use input::I3BarEvent;
 use scheduler::Task;
-use std::fs::OpenOptions;
-use std::io::prelude::*;
-
 use uuid::Uuid;
+use blocks::lib::*;
 
 pub struct Uptime {
     text: TextWidget,
@@ -52,22 +48,9 @@ impl ConfigBlock for Uptime {
     }
 }
 
-fn read_file(path: &str) -> Result<String> {
-    let mut f = OpenOptions::new()
-        .read(true)
-        .open(path)
-        .block_error("uptime", &format!("failed to open file {}", path))?;
-    let mut content = String::new();
-    f.read_to_string(&mut content)
-        .block_error("uptime", &format!("failed to read {}", path))?;
-    // Removes trailing newline
-    content.pop();
-    Ok(content)
-}
-
 impl Block for Uptime {
     fn update(&mut self) -> Result<Option<Duration>> {
-        let uptime_raw = match read_file("/proc/uptime") {
+        let uptime_raw = match read_file("uptime", "/proc/uptime") {
             Ok(file) => file,
             Err(e) => {
                 return Err(BlockError(

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -1,0 +1,133 @@
+use std::time::Duration;
+use chan::Sender;
+
+use block::{Block, ConfigBlock};
+use config::Config;
+use de::deserialize_duration;
+use errors::*;
+use widgets::text::TextWidget;
+use widget::I3BarWidget;
+use input::I3BarEvent;
+use scheduler::Task;
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+
+use uuid::Uuid;
+
+pub struct Uptime {
+    text: TextWidget,
+    id: String,
+    update_interval: Duration,
+
+    //useful, but optional
+    #[allow(dead_code)] config: Config,
+    #[allow(dead_code)] tx_update_request: Sender<Task>,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct UptimeConfig {
+    /// Update interval in seconds
+    #[serde(default = "UptimeConfig::default_interval", deserialize_with = "deserialize_duration")]
+    pub interval: Duration,
+}
+
+impl UptimeConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(60)
+    }
+}
+
+impl ConfigBlock for Uptime {
+    type Config = UptimeConfig;
+
+    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Result<Self> {
+        Ok(Uptime {
+            id: Uuid::new_v4().simple().to_string(),
+            update_interval: block_config.interval,
+            text: TextWidget::new(config.clone()),
+            tx_update_request: tx_update_request,
+            config: config,
+        })
+    }
+}
+
+fn read_file(path: &str) -> Result<String> {
+    let mut f = OpenOptions::new()
+        .read(true)
+        .open(path)
+        .block_error("uptime", &format!("failed to open file {}", path))?;
+    let mut content = String::new();
+    f.read_to_string(&mut content)
+        .block_error("uptime", &format!("failed to read {}", path))?;
+    // Removes trailing newline
+    content.pop();
+    Ok(content)
+}
+
+impl Block for Uptime {
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let uptime_raw = match read_file("/proc/uptime") {
+            Ok(file) => file,
+            Err(e) => {
+                return Err(BlockError(
+                    "Uptime".to_owned(),
+                    format!("Uptime failed to read /proc/uptime: '{}'", e),
+                ));
+            }
+        };
+        let uptime = match uptime_raw.split_whitespace().nth(0) {
+            Some(uptime) => uptime,
+            None => {
+                return Err(BlockError(
+                    "Uptime".to_owned(),
+                    "Uptime failed to read uptime string.".to_owned(),
+                ));
+            }
+        };
+
+        let total_seconds = match uptime.parse::<f64>() {
+            Ok(uptime) => uptime as u32,
+            Err(e) => {
+                return Err(BlockError(
+                    "Uptime".to_owned(),
+                    format!("Uptime failed to convert uptime float to integer: '{}')", e),
+                ));
+            }
+        };
+
+        // split up seconds into more human readable portions
+        let weeks = (total_seconds / 604_800) as u32;
+        let rem_weeks = (total_seconds % 604_800) as u32;
+        let days = (rem_weeks / 86_400) as u32;
+        let rem_days = (rem_weeks % 86_400) as u32;
+        let hours = (rem_days / 3600) as u32;
+        let rem_hours = (rem_days % 3600) as u32;
+        let minutes = (rem_hours / 60) as u32;
+        let rem_minutes = (rem_hours % 60) as u32;
+        let seconds = rem_minutes as u32;
+
+        let mut text = String::from("0");
+        // display two digits at most
+        if hours == 0 && days == 0 && weeks == 0 {
+            text = format!("⏱ {}m {}s", minutes, seconds);
+        } else if hours > 0 && days == 0 {
+            text = format!("⏱ {}h {}m", hours, minutes,);
+        } else if hours > 0 && days > 0 && weeks == 0 {
+            text = format!("⏱ {}d {}h", days, hours);
+        } else if days > 0 && weeks > 0 {
+            text = format!("⏱ {}w {}d", weeks, days);
+        }
+        //debug:  let text = format!("uptime: {}w, {}d, {}h, {}m, {}s", weeks, days, hours, minutes, seconds);
+        self.text.set_text(text);
+        Ok(Some(self.update_interval))
+    }
+
+    fn view(&self) -> Vec<&I3BarWidget> {
+        vec![&self.text]
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}


### PR DESCRIPTION
The block will display system uptime. To save space it will only display the 2 biggest units, so weeks and days or days and hours, or hours and minutes or minutes and seconds.