### PR TITLE
cpu: if cpu utilization is below 100% aka in the double digits, try...

### DIFF
--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -134,8 +134,11 @@ impl Block for Cpu {
             _ => State::Idle,
         });
 
-        self.utilization.set_text(format!("{:02}%", utilization));
-
+        if utilization < 100  {// 2 digits, pad with extra space to ensure consistent length
+            self.utilization.set_text(format!("  {:02}%", utilization));
+        } else {
+            self.utilization.set_text(format!("{:02}%", utilization));
+        }
         Ok(Some(self.update_interval))
     }
 


### PR DESCRIPTION
..to pad string with spaces to ensure consistent text length to prevent other widgets from being shoved back and forth all the time.

It seems the default font is not monospace so I could't get it to fit perfectly, however this is already a lot less annoying.