### PR TITLE
change pacman block to be a button widget

### DIFF
--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -13,13 +13,13 @@ use config::Config;
 use de::deserialize_duration;
 use errors::*;
 use input::{I3BarEvent, MouseButton};
-use widgets::text::TextWidget;
+use widgets::button::ButtonWidget;
 use widget::{I3BarWidget, State};
 
 use uuid::Uuid;
 
 pub struct Pacman {
-    output: TextWidget,
+    output: ButtonWidget,
     id: String,
     update_interval: Duration,
 }
@@ -45,7 +45,7 @@ impl ConfigBlock for Pacman {
         Ok(Pacman {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
-            output: TextWidget::new(config).with_icon("update"),
+            output: ButtonWidget::new(config, "pacman").with_icon("update"),
         })
     }
 }


### PR DESCRIPTION
I changed the widget type of the pacman block to ButtonWidget so it can actually handle left clicks to manually update.
(The code for manually updating by left click was already there, but didn't work as TextWidget)