### PR TITLE
fix nightly breakage

### DIFF
--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -268,7 +268,7 @@ impl Block for Sound {
                         MouseButton::WheelUp => {
                             if volume < 100 {
                                 device.set_volume(
-                                    min(self.step_width, (100 - volume)) as i32,
+                                    min(self.step_width, 100 - volume) as i32,
                                 )?;
                             }
                         }


### PR DESCRIPTION
unneeded parenthesis became a warning, thus making nightly fail to build