### PR TITLE
Send custom commands to $SHELL

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -138,7 +138,7 @@ Note that `command` and `cycle` are mutually exclusive.
 Key | Values | Required | Default
 ----|--------|----------|--------
 `command` | Shell command to execute & display. | No | None
-`on_click` | Command to execute when the button is clicked. | No | None
+`on_click` | Command to execute when the button is clicked. The command will be passed to whatever is specified in your `$SHELL` variable and - if not set - fallback to `sh`. | No | None
 `cycle` | Commands to execute and change when the button is clicked. | No | None
 `interval` | Update interval, in seconds. | No | `10`
 

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -116,10 +116,8 @@ impl Block for Custom {
         let mut update = false;
 
         if let Some(ref on_click) = self.on_click {
-            match env::var("SHELL") {
-                Ok(name) => Command::new(name), 
-                _ => Command::new("sh")
-            }.args(&["-c", on_click]).output().ok();
+            Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_string()))
+                    .args(&["-c", on_click]).output().ok();
             update = true;
         }
 

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -116,7 +116,7 @@ impl Block for Custom {
         let mut update = false;
 
         if let Some(ref on_click) = self.on_click {
-            Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_string()))
+            Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_owned()))
                     .args(&["-c", on_click]).output().ok();
             update = true;
         }

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -116,7 +116,7 @@ impl Block for Custom {
         let mut update = false;
 
         if let Some(ref on_click) = self.on_click {
-            Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_owned()))
+            Command::new(env::var("SHELL").unwrap_or("sh".to_owned()))
                     .args(&["-c", on_click]).output().ok();
             update = true;
         }

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 use std::process::Command;
 use std::iter::{Cycle, Peekable};
 use std::vec;
+use std::env;
 use chan::Sender;
 
 use block::{Block, ConfigBlock};
@@ -115,7 +116,10 @@ impl Block for Custom {
         let mut update = false;
 
         if let Some(ref on_click) = self.on_click {
-            Command::new("sh").args(&["-c", on_click]).output().ok();
+            match env::var("SHELL") {
+                Ok(name) => Command::new(name), 
+                _ => Command::new("sh")
+            }.args(&["-c", on_click]).output().ok();
             update = true;
         }
 

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -268,7 +268,7 @@ impl Block for Sound {
                         MouseButton::WheelUp => {
                             if volume < 100 {
                                 device.set_volume(
-                                    min(self.step_width, (100 - volume)) as i32,
+                                    min(self.step_width, 100 - volume) as i32,
                                 )?;
                             }
                         }


### PR DESCRIPTION
This implements the feature requested in #158. If `$SHELL` was not set, we'll fall back to `sh`.