### PR TITLE
Fixes a logic bug in the uptime block format and gives it an icon

### DIFF
--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -41,7 +41,7 @@ impl ConfigBlock for Uptime {
         Ok(Uptime {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
-            text: TextWidget::new(config.clone()),
+            text: TextWidget::new(config.clone()).with_icon("uptime"),
             tx_update_request: tx_update_request,
             config: config,
         })
@@ -90,18 +90,20 @@ impl Block for Uptime {
         let rem_minutes = (rem_hours % 60) as u32;
         let seconds = rem_minutes as u32;
 
-        let mut text = String::from("0");
-        // display two digits at most
-        if hours == 0 && days == 0 && weeks == 0 {
-            text = format!("⏱ {}m {}s", minutes, seconds);
-        } else if hours > 0 && days == 0 {
-            text = format!("⏱ {}h {}m", hours, minutes,);
-        } else if hours > 0 && days > 0 && weeks == 0 {
-            text = format!("⏱ {}d {}h", days, hours);
-        } else if days > 0 && weeks > 0 {
-            text = format!("⏱ {}w {}d", weeks, days);
-        }
-        //debug:  let text = format!("uptime: {}w, {}d, {}h, {}m, {}s", weeks, days, hours, minutes, seconds);
+        // Display the two largest units.
+        let text = if hours == 0 && days == 0 && weeks == 0 {
+            format!("{}m {}s", minutes, seconds)
+        } else if hours > 0 && days == 0 && weeks == 0 {
+            format!("{}h {}m", hours, minutes)
+        } else if days > 0 && weeks == 0 {
+            format!("{}d {}h", days, hours)
+        } else if days == 0 && weeks > 0 {
+            format!("{}w {}h", weeks, hours)
+        } else if weeks > 0 {
+            format!("{}w {}d", weeks, days)
+        } else {
+            unreachable!()
+        };
         self.text.set_text(text);
         Ok(Some(self.update_interval))
     }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -42,7 +42,8 @@ lazy_static! {
         "weather_thunder" => " STORM ",
         "weather_clouds" => " CLOUDY ",
         "weather_rain" => " RAIN ",
-        "weather_default" => " WEATHER "
+        "weather_default" => " WEATHER ",
+        "uptime" => " UP "
     };
 
     pub static ref AWESOME: Map<String, String> = map_to_owned! {
@@ -87,7 +88,9 @@ lazy_static! {
         "weather_clouds" => " \u{f0c2} ",
         "weather_rain" => " \u{f043} ",
         // Cloud symbol as default
-        "weather_default" => " \u{f0c2} "
+        "weather_default" => " \u{f0c2} ",
+        // Same as time symbol.
+        "uptime" => " \u{f017} "
     };
 
     pub static ref MATERIAL: Map<String, String> = map_to_owned! {
@@ -115,7 +118,9 @@ lazy_static! {
         // This icon has no spaces around it because it is manually set as text. (sound.rs)
         "volume_muted" => "\u{e04f}",
         "thermometer" => " \u{f2c8} ", // TODO
-        "xrandr" => " \u{e31e} "
+        "xrandr" => " \u{e31e} ",
+        // Same as time symbol.
+        "uptime" => " \u{e192} "
     };
 }
 


### PR DESCRIPTION
This is meant to address #157, although I'll confirm that it does before closing that issue. Hopefully this will fix issues related to fonts/positioning (since it no longer uses a hardcoded unicode symbol) as well as blank output at certain uptimes.