### PR TITLE
blocks/temperature: Add format field

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -412,6 +412,7 @@ Creates a block which displays the system temperature, based on lm_sensors' `sen
 block = "temperature"
 collapsed = false
 interval = 10
+format = "{min}° min, {max}° max, {average}° avg"
 ```
 
 ### Options

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -34,7 +34,7 @@ pub struct LoadConfig {
 
 impl LoadConfig {
     fn default_format() -> String {
-        "{avg}° avg, {max}° max".to_owned()
+        "{average}° avg, {max}° max".to_owned()
     }
 
     fn default_interval() -> Duration {
@@ -135,7 +135,7 @@ impl Block for Temperature {
                 .block_error("temperature", "failed to get min temperature")?;
             let avg: i64 = (temperatures.iter().sum::<i64>() as f64 / temperatures.len() as f64).round() as i64;
 
-            let values = map!("{avg}" => avg,
+            let values = map!("{average}" => avg,
                               "{min}" => min,
                               "{max}" => max);
 

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -25,26 +25,6 @@ pub struct Temperature {
 
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct LoadConfig {
-    #[serde(default = "LoadConfig::default_format")]
-    pub format: String,
-    #[serde(default = "LoadConfig::default_interval", deserialize_with = "deserialize_duration")]
-    pub interval: Duration,
-}
-
-impl LoadConfig {
-    fn default_format() -> String {
-        "{average}° avg, {max}° max".to_owned()
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(5)
-    }
-}
-
-
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
 pub struct TemperatureConfig {
     /// Update interval in seconds
     #[serde(default = "TemperatureConfig::default_interval", deserialize_with = "deserialize_duration")]
@@ -55,11 +35,15 @@ pub struct TemperatureConfig {
     pub collapsed: bool,
 
     /// Format override
-    #[serde(default = "LoadConfig::default_format")]
+    #[serde(default = "TemperatureConfig::default_format")]
     pub format: String,
 }
 
 impl TemperatureConfig {
+    fn default_format() -> String {
+        "{average}° avg, {max}° max".to_owned()
+    }
+
     fn default_interval() -> Duration {
         Duration::from_secs(5)
     }

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -81,7 +81,7 @@ impl ConfigBlock for Temperature {
             collapsed: block_config.collapsed,
             id,
             format: FormatTemplate::from_string(block_config.format)
-                .block_error("load", "Invalid format specified for temperature")?,
+                .block_error("temperature", "Invalid format specified for temperature")?,
         })
     }
 }


### PR DESCRIPTION
This adds an optional `format` field to the `temperature` block.

The default format remains the same as before, so it should be fully backwards compatible. The format code was borrowed from the `load` block implementation.

The goal was to allow more compact temperature strings like:

`format = "{min}~{max}°"`

(particularly since I don't care much about the average.)

I'm a beginner rustacean, so please excuse any code faux pas. Feedback is welcome. I am particularly unsure if there is a better way to get the min/max/avg in one pass (instead of 3).