### PR TITLE
Backlight don't try to increase brightness beyond 100%, fix clippy warnings

### DIFF
--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -81,7 +81,7 @@ impl BacklitDevice {
         let max_brightness = try!(read_brightness(&first_device.path().join("max_brightness")));
 
         Ok(BacklitDevice {
-            max_brightness: max_brightness,
+            max_brightness,
             device_path: first_device.path(),
         })
     }
@@ -103,8 +103,8 @@ impl BacklitDevice {
         let max_brightness = try!(read_brightness(&device_path.join("max_brightness")));
 
         Ok(BacklitDevice {
-            max_brightness: max_brightness,
-            device_path: device_path,
+            max_brightness,
+            device_path,
         })
     }
 
@@ -193,7 +193,7 @@ impl ConfigBlock for Backlight {
         let backlight = Backlight {
             output: ButtonWidget::new(config, &id),
             id: id.clone(),
-            device: device,
+            device,
             step_width: block_config.step_width,
         };
 

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -251,7 +251,7 @@ impl Block for Backlight {
                 let brightness = try!(self.device.brightness());
                 match event.button {
                     MouseButton::WheelUp => {
-                        if brightness <= 100 {
+                        if brightness < 100 {
                             self.device.set_brightness(brightness + self.step_width)?;
                         }
                     }


### PR DESCRIPTION
Brightness is already capped at 100% so, so we can refactor
if brightness <= 100% { increase(); }
to
if brightness  < 100% { increase(); }