### PR TITLE
change formatting line width from 100 to 200.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-max_width = 200
+max_width = 100
 write_mode = "Overwrite"


### PR DESCRIPTION
Not sure why 200 was chosen, but it looks *really* bad imo, and since my editor auto-runs rustfmt it would constantly reflow code of a file I am editing.