### PR TITLE
blocks/toggle: Add icon overrides, make text optional

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -514,9 +514,12 @@ interval = 5
 
 Key | Values | Required | Default
 ----|--------|----------|--------
+`text` | Label to include next to the toggle icon. | No | ""
 `command_on` | Shell Command to enable the toggle | Yes | None
 `command_off` | Shell Command to disable the toggle | Yes | None
 `command_state` | Shell Command to determine toggle state. Empty output => off. Any output => on.| Yes | None
+`icon_on` | Icon override for the toggle button while on. | No | "toggle_on"
+`icon_off` | Icon override for the toggle button while off. | No | "toggle_off"
 `interval` | Update interval, in seconds. | No | None
 
 ## Weather

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -18,6 +18,8 @@ pub struct Toggle {
     command_on: String,
     command_off: String,
     command_state: String,
+    icon_on: String,
+    icon_off: String,
     update_interval: Option<Duration>,
     toggled: bool,
     id: String,
@@ -39,8 +41,31 @@ pub struct ToggleConfig {
     /// Shell Command to determine toggle state. <br/>Empty output => off. Any output => on.
     pub command_state: String,
 
+    /// Icon ID when toggled on (default is "toggle_on")
+    #[serde(default = "ToggleConfig::default_icon_on")]
+    pub icon_on: String,
+
+    /// Icon ID when toggled off (default is "toggle_off")
+    #[serde(default = "ToggleConfig::default_icon_off")]
+    pub icon_off: String,
+
     /// Text to display in i3bar for this block
+    #[serde(default = "ToggleConfig::default_text")]
     pub text: String,
+}
+
+impl ToggleConfig {
+    fn default_icon_on() -> String {
+        "toggle_on".to_owned()
+    }
+
+    fn default_icon_off() -> String {
+        "toggle_off".to_owned()
+    }
+
+    fn default_text() -> String {
+        "".to_owned()
+    }
 }
 
 impl ConfigBlock for Toggle {
@@ -53,6 +78,8 @@ impl ConfigBlock for Toggle {
             command_on: block_config.command_on,
             command_off: block_config.command_off,
             command_state: block_config.command_state,
+            icon_on: block_config.icon_on,
+            icon_off: block_config.icon_off,
             id,
             toggled: false,
             update_interval: block_config.interval,
@@ -71,11 +98,11 @@ impl Block for Toggle {
         self.text.set_icon(match output.trim_left() {
             "" => {
                 self.toggled = false;
-                "toggle_off"
+                self.icon_off.as_str()
             }
             _ => {
                 self.toggled = true;
-                "toggle_on"
+                self.icon_on.as_str()
             }
         });
 
@@ -91,11 +118,11 @@ impl Block for Toggle {
             if name.as_str() == self.id {
                 let cmd = if self.toggled {
                     self.toggled = false;
-                    self.text.set_icon("toggle_off");
+                    self.text.set_icon(self.icon_off.as_str());
                     &self.command_off
                 } else {
                     self.toggled = true;
-                    self.text.set_icon("toggle_on");
+                    self.text.set_icon(self.icon_on.as_str());
                     &self.command_on
                 };
 

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -50,8 +50,7 @@ pub struct ToggleConfig {
     pub icon_off: String,
 
     /// Text to display in i3bar for this block
-    #[serde(default = "ToggleConfig::default_text")]
-    pub text: String,
+    pub text: Option<String>,
 }
 
 impl ToggleConfig {
@@ -62,10 +61,6 @@ impl ToggleConfig {
     fn default_icon_off() -> String {
         "toggle_off".to_owned()
     }
-
-    fn default_text() -> String {
-        "".to_owned()
-    }
 }
 
 impl ConfigBlock for Toggle {
@@ -74,7 +69,7 @@ impl ConfigBlock for Toggle {
     fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
         let id = Uuid::new_v4().simple().to_string();
         Ok(Toggle {
-            text: ButtonWidget::new(config, &id).with_text(&block_config.text),
+            text: ButtonWidget::new(config, &id).with_content(block_config.text),
             command_on: block_config.command_on,
             command_off: block_config.command_off,
             command_state: block_config.command_state,

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -39,6 +39,12 @@ impl ButtonWidget {
         self
     }
 
+    pub fn with_content(mut self, content: Option<String>) -> Self {
+        self.content = content;
+        self.update();
+        self
+    }
+
     pub fn with_text(mut self, content: &str) -> Self {
         self.content = Some(String::from(content));
         self.update();


### PR DESCRIPTION
Allow the user to customize the toggle button icon so that the icon can
represent what the various toggle blocks are doing instead of having to
rely on labels.

By default, the behaviour remains the same and backwards-compatible with older configs.

I currently have multiple toggles in my status bar and they're taking up a lot of space for both the toggle icon and the label, so this allows for many compact toggles without labels.

Here's an example of one I'm using for toggling redshift:

```toml
[[block]]
block = "toggle"
command_state = "systemctl --user -q is-active redshift && echo on"
command_on = "systemctl --user start redshift"
command_off = "systemctl --user stop redshift"
icon_on = "backlight_empty"
icon_off = "backlight_full"
interval = 60
```