### PR TITLE
blocks: add pacman2 block.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Optional:
 * Font Awesome, for `icons="awesome"`. Version 5 of the font is causing some issues (see [#130](https://github.com/greshake/i3status-rust/issues/130)), so for now we recommend version 4. If you have access to the AUR, check out [`ttf-font-awesome-4`](https://aur.archlinux.org/packages/ttf-font-awesome-4/).
 * `gperftools` For dev builds, needed to profile block performance and bottlenecks.
 * [`powerline-fonts`](https://www.archlinux.org/packages/community/x86_64/powerline-fonts/) For all themes using the powerline arrow char. Recommended. See [`powerline on GitHub`](https://github.com/powerline/powerline/tree/develop/font)
+* [`cower`](https://aur.archlinux.org/packages/cower/) For the pacman2 block.
 
 # How to use it
 1. If you are using Arch Linux, you can install from the AUR: [`i3status-rust-git`](https://aur.archlinux.org/packages/i3status-rust-git/) and proceed to step 3. Otherwise, clone the repository: `git clone https://github.com/XYunknown/i3status-rust.git`

--- a/blocks.md
+++ b/blocks.md
@@ -12,6 +12,7 @@
 - [Net](#net)
 - [Nvidia Gpu](#nvidia-gpu)
 - [Pacman](#pacman)
+- [Pacman2](#pacman2)
 - [Sound](#sound)
 - [Speed Test](#speed-test)
 - [Temperature](#temperature)
@@ -356,7 +357,7 @@ Proprietary nvidia driver required.
 
 Creates a block which displays the Nvidia GPU utilization, temperature, used and total memory, fan speed, gpu clocks. You can set gpu label, that displayed by default.
 
-Clicking the left button on the icon changes the output of the label to the output of the gpu name. Same with memory: used/total. 
+Clicking the left button on the icon changes the output of the label to the output of the gpu name. Same with memory: used/total.
 
 Clicking the left button on the fans turns on the mode of changing the speed of the fans using the wheel. Press again to turn off the mode. For this opportunity you need nvidia-settings!
 
@@ -387,6 +388,28 @@ Key | Values | Required | Default
 ## Pacman
 
 Creates a block which displays the pending updates available on pacman.
+
+### Examples
+
+Update the list of pending updates every ten seconds:
+
+```toml
+[[block]]
+block = "pacman"
+interval = 10
+```
+
+### Options
+
+Key | Values | Required | Default
+----|--------|----------|--------
+`interval` | Update interval, in seconds. | No | `600` (10min)
+
+## Pacman2
+
+Creates a block which displays the pending updates available on pacman, both for official packages and the AUR.
+Unlike the pacman block, it does not require fakeroot.
+This block requires ````cower```` to be installed.
 
 ### Examples
 

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -8,6 +8,7 @@ mod battery;
 mod custom;
 mod disk_space;
 mod pacman;
+mod pacman2;
 mod temperature;
 mod toggle;
 mod sound;
@@ -32,6 +33,7 @@ use self::battery::*;
 use self::custom::*;
 use self::disk_space::*;
 use self::pacman::*;
+use self::pacman2::*;
 use self::sound::*;
 use self::speedtest::*;
 use self::toggle::*;
@@ -82,6 +84,7 @@ pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_r
             "memory" => Memory,
             "cpu" => Cpu,
             "pacman" => Pacman,
+            "pacman2" => Pacman2,
             "battery" => Battery,
             "custom" => Custom,
             "disk_space" => DiskSpace,

--- a/src/blocks/pacman2.rs
+++ b/src/blocks/pacman2.rs
@@ -1,0 +1,119 @@
+use chan::Sender;
+use scheduler::Task;
+use std::process::Command;
+use std::time::Duration;
+
+use block::{Block, ConfigBlock};
+use config::Config;
+use de::deserialize_duration;
+use errors::*;
+use input::{I3BarEvent, MouseButton};
+use widget::{I3BarWidget, State};
+use widgets::button::ButtonWidget;
+
+use uuid::Uuid;
+
+pub struct Pacman2 {
+    output: ButtonWidget,
+    id: String,
+    update_interval: Duration,
+}
+
+struct UpdateCount {
+    official: usize,
+    aur: usize,
+}
+
+impl UpdateCount {
+    fn new(official: usize, aur: usize) -> UpdateCount {
+        UpdateCount { official, aur }
+    }
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct Pacman2Config {
+    /// Update interval in seconds
+    #[serde(default = "Pacman2Config::default_interval", deserialize_with = "deserialize_duration")]
+    pub interval: Duration,
+}
+
+impl Pacman2Config {
+    fn default_interval() -> Duration {
+        Duration::from_secs(60 * 10)
+    }
+}
+
+impl ConfigBlock for Pacman2 {
+    type Config = Pacman2Config;
+
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
+        Ok(Pacman2 {
+            id: Uuid::new_v4().simple().to_string(),
+            update_interval: block_config.interval,
+            output: ButtonWidget::new(config, "pacman2").with_icon("update"),
+        })
+    }
+}
+
+fn get_update_count() -> Result<UpdateCount> {
+    let checkupdates_output = Command::new("checkupdates")
+        .env("LANG", "en_US")
+        .env("LC_ALL", "en_US")
+        .output()
+        .block_error("pacman2", "failed to run checkupdates")?
+        .stdout;
+    let cower = Command::new("cower")
+        .arg("-u")
+        .env("LANG", "en_US")
+        .env("LC_ALL", "en_US")
+        .output()
+        .block_error("pacman2", "failed to run cower -u")
+        .unwrap();
+    // if we are offline, cower will print a bunch of warnings to stderr but exit with 0
+    // if we are online, and no updates are found, cower will print nothing and exit with 0
+    // if we are online and cower found updates, we will have updates in stdout and exit status 1
+    // checkupdates will just silently ignore network failure, no need to handle this
+    let cower_exit_code: i32 = cower.status.code().unwrap();
+    let cower_update_count = match cower_exit_code {
+        0 => 0,
+        _ => {
+            let cower_output = cower.stdout;
+            String::from_utf8_lossy(&cower_output).lines().count()
+        }
+    };
+
+    let checkupdates_count = String::from_utf8_lossy(&checkupdates_output).lines().count();
+
+    let update_count = UpdateCount::new(checkupdates_count, cower_update_count);
+
+    Ok(update_count)
+}
+
+impl Block for Pacman2 {
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let count = get_update_count()?;
+        self.output.set_text(format!("{} {}", count.official, count.aur));
+        self.output.set_state(match count.official + count.aur {
+            0 => State::Idle,
+            _ => State::Info,
+        });
+        Ok(Some(self.update_interval))
+    }
+
+    fn view(&self) -> Vec<&I3BarWidget> {
+        vec![&self.output]
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn click(&mut self, event: &I3BarEvent) -> Result<()> {
+        if event.name.as_ref().map(|s| s == "pacman2").unwrap_or(false) && event.button == MouseButton::Left {
+            self.update()?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This block has a simpler design than the original pacman block and does not require fakeroot.
It uses checkupdate to get official updates and requires cower binary to get aur updates which are displayed side by side.

Closes #179