### PR TITLE
Make temperature block only switch on left clicks

### DIFF
--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -10,7 +10,7 @@ use de::deserialize_duration;
 use errors::*;
 use widgets::button::ButtonWidget;
 use widget::{I3BarWidget, State};
-use input::I3BarEvent;
+use input::{I3BarEvent, MouseButton};
 
 use uuid::Uuid;
 
@@ -146,7 +146,7 @@ impl Block for Temperature {
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
         if let Some(ref name) = e.name {
-            if name.as_str() == self.id {
+            if name.as_str() == self.id && e.button == MouseButton::Left {
                 self.collapsed = !self.collapsed;
                 if self.collapsed {
                     self.text.set_text(String::new());


### PR DESCRIPTION
This is a personal annoyance, so feel free to close if the 'works with any click' functionality is desired. I could also see it being a left or right click thing, I could make that change... I just don't want it going off on scrolling.