### PR TITLE
Fix panick when subtracting "now" Instant

### DIFF
--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -137,18 +137,19 @@ impl RotatingTextWidget {
 
     pub fn next(&mut self) -> Result<(bool, Option<Duration>)> {
         if let Some(next_rotation) = self.next_rotation {
-            if next_rotation > Instant::now() {
-                Ok((false, Some(next_rotation - Instant::now())))
+            let now = Instant::now();
+            if next_rotation > now {
+                Ok((false, Some(next_rotation - now)))
             } else if self.rotating {
                 if self.rotation_pos < self.content.len() {
                     self.rotation_pos += 1;
-                    self.next_rotation = Some(Instant::now() + self.rotation_speed);
+                    self.next_rotation = Some(now + self.rotation_speed);
                     self.update();
                     Ok((true, Some(self.rotation_speed)))
                 } else {
                     self.rotation_pos = 0;
                     self.rotating = false;
-                    self.next_rotation = Some(Instant::now() + self.rotation_interval);
+                    self.next_rotation = Some(now + self.rotation_interval);
                     self.update();
                     Ok((true, Some(self.rotation_interval)))
                 }


### PR DESCRIPTION
Similar to the problem reported in #27, which was fixed in f91a3d4, I saw this
error:

```
thread 'main' panicked at 'other was less than the current instant', libstd/sys/unix/time.rs:292:17
```
(sorry, no backtrace)

Since I am using the music block with text rotation, I am best-guessing that the
error is caused by the Instant subtraction in rotatingtext widget.