### PR TITLE
Fixes #190 (underflow causing 2**64-1 update count)

### DIFF
--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -122,14 +122,14 @@ fn get_update_count() -> Result<usize> {
             Command::new("sh")
                 .args(&[
                     "-c",
-                    &format!("fakeroot pacman -Su -p --dbpath \"{}\"", updates_db),
+                    &format!("fakeroot pacman -Qu --dbpath \"{}\"", updates_db),
                 ])
                 .output()
                 .block_error("pacman", "There was a problem running the pacman commands")?
                 .stdout,
         ).block_error("pacman", "there was a problem parsing the output")?
             .lines()
-            .count() - 1,
+            .count(),
     )
 }
 

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -120,6 +120,7 @@ fn get_update_count() -> Result<usize> {
     Ok(
         String::from_utf8(
             Command::new("sh")
+                .env("LC_ALL", "C")
                 .args(&[
                     "-c",
                     &format!("fakeroot pacman -Qu --dbpath \"{}\"", updates_db),
@@ -129,6 +130,7 @@ fn get_update_count() -> Result<usize> {
                 .stdout,
         ).block_error("pacman", "there was a problem parsing the output")?
             .lines()
+            .filter(|line| !line.contains("[ignored]"))
             .count(),
     )
 }


### PR DESCRIPTION
Tested this on either side of the pacman 5.1 update, the `pacman -Qu` command prints the same number of lines in both earlier and later versions.