### PR TITLE
Graphical interfaces

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -349,6 +349,7 @@ Key | Values | Required | Default
 `graph_up` | Display a bar graph for upload speed. | No | `false`
 `graph_down` | Display a bar graph for download speed. | No | `false`
 `interval` | Update interval, in seconds. | No | `1`
+`on_click` | Command to execute when the right button is clicked. To launch a graphical interface, run `xterm -e <command>`. | No | `"xterm -e nmtui"`
 
 ## Nvidia Gpu
 

--- a/blocks.md
+++ b/blocks.md
@@ -87,6 +87,7 @@ Key | Values | Required | Default
 `device` | The device in `/sys/class/power_supply/` to read from. | No | `"BAT0"`
 `interval` | Update interval, in seconds. | No | `10`
 `show` | Show remaining 'time', 'percentage' or 'both' | No | `percentage`
+`on_click` | Command to execute when the right button is clicked. | No | `"gnome-power-statistics"`
 
 ## CPU Utilization
 

--- a/blocks.md
+++ b/blocks.md
@@ -113,6 +113,7 @@ Key | Values | Required | Default
 `critical` | Minimum usage, where state is set to critical. | No | `90`
 `interval` | Update interval, in seconds. | No | `1`
 `frequency` | Shows avg cpu frequency in GHz | No | `false`
+`on_click` | Command to execute when the right button is clicked. | No | `"gnome-system-monitor"`
 
 ## Custom
 

--- a/blocks.md
+++ b/blocks.md
@@ -87,7 +87,7 @@ Key | Values | Required | Default
 `device` | The device in `/sys/class/power_supply/` to read from. | No | `"BAT0"`
 `interval` | Update interval, in seconds. | No | `10`
 `show` | Show remaining 'time', 'percentage' or 'both' | No | `percentage`
-`on_click` | Command to execute when the right button is clicked. | No | `"gnome-power-statistics"`
+`on_click` | Command to execute when the right button is clicked, for instance: `"gnome-power-statistics"`. | No | `""`
 
 ## CPU Utilization
 
@@ -113,7 +113,7 @@ Key | Values | Required | Default
 `critical` | Minimum usage, where state is set to critical. | No | `90`
 `interval` | Update interval, in seconds. | No | `1`
 `frequency` | Shows avg cpu frequency in GHz | No | `false`
-`on_click` | Command to execute when the right button is clicked. | No | `"gnome-system-monitor"`
+`on_click` | Command to execute when the right button is clicked, for instance: "`gnome-system-monitor"`. | No | `""`
 
 ## Custom
 

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -65,7 +65,7 @@ impl BatteryConfig {
     }
 
     fn default_on_click() -> Option<String> {
-        Some("gnome-power-statistics".to_string())
+        Some("".to_string())
     }
 }
 

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -81,7 +81,7 @@ impl CpuConfig {
     }
 
     fn default_on_click() -> Option<String> {
-        Some("gnome-system-monitor".to_string())
+        Some("".to_string())
     }
 }
 


### PR DESCRIPTION
By right-clicking on blocks, the appropriate GUI interface opens.

I updated these blocks converting `TextWidget` by `ButtonWidget`:
* **Battery**: launch `gnome-power-statistics` by default
* **CPU**: launch `gnome-system-monitor` by default
* **Net**: launch `nmtui` by default. Actually, it works only by clicking on text but not on a graphic.

The `on_click` argument is an `Option<String>` so it is still possible to open nothing like this:
```toml
[[block]]
name = "my_block"
on_click = ""
```