### PR TITLE
Add mail block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +146,63 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "error-chain"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +257,7 @@ dependencies = [
  "i3ipc 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maildir 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -285,6 +348,24 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "maildir"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "mailparse 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mailparse"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quoted_printable 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -402,6 +483,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
@@ -643,6 +729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
 "checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
+"checksum base64 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a51012ca17f843e723dedc71fdd7feac9d8b53be85492aa9232b2da59ce6bb3b"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
 "checksum bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1d50c876fb7545f5f289cd8b2aee3f359d073ae819eed5d6373638e2c61e59"
@@ -655,6 +742,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum dbus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5b2c58aab20dd6637871e6e03cb6122f00b496a91eb65b688639c940012d8710"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
+"checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+"checksum encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+"checksum encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+"checksum encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+"checksum encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+"checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+"checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -672,6 +766,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8720f9274907052cb50313f91201597868da9d625f8dd125f2aca5bddb7e83a1"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
+"checksum maildir 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83d9b449b6ff23db5eda044963296380c74941ac9480fc629840d7405e436c73"
+"checksum mailparse 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "517ae98201a037bbd2dccdf88763e5818b26fc98a46725ae524424de2f67339f"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
@@ -685,6 +781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b820305721858696053a7fd0215cfeeee16ecaaf96b7a209945428e02f1c44"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum quoted_printable 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ec1a063e17beecae242623379d30100975588fb3d2a4bf1df8550d872268a89f"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ i3ipc = "0.8.2"
 num = "0.1.42"
 chan = "0.1.21"
 inotify = "0.5.1"
+maildir = "0.1.1"
 # Used only in debug build mode
 # for profiling blocks
 cpuprofiler = "0.0.3"

--- a/blocks.md
+++ b/blocks.md
@@ -19,6 +19,7 @@
 - [Toggle](#toggle)
 - [Weather](#weather)
 - [Xrandr](#xrandr)
+- [Mail](#mail)
 
 ## Backlight
 
@@ -599,4 +600,28 @@ Key | Values | Required | Default
 `icons` | Show icons for brightness and resolution (needs awesome fonts support) | No | `true`
 `resolution` | Shows the screens resolution | No | `false`
 `step_width` | The steps brightness is in/decreased for the selected screen (When greater than 50 it gets limited to 50) | No | `5`
+`interval` | Update interval, in seconds. | No | `5`
+
+## Mail
+
+Creates a block which shows unread mails. Currently only supports maildir.
+
+### Examples
+
+```toml
+[[block]]
+block = "mail"
+interval = 60
+inboxes = ["/home/user/mail/local", "/home/user/mail/gmail/Inbox"]
+threshold_warning = 1
+threshold_warning = 10
+```
+
+### Options
+
+Key | Values | Required | Default
+----|--------|----------|--------
+`inboxes` | List of maildir inboxes to look for mails in | Yes | None
+`threshold_warning` | Number of unread mails where state is set to warning | No | `1`
+`threshold_critical` | Number of unread mails where state is set to critical | No | `10`
 `interval` | Update interval, in seconds. | No | `5`

--- a/blocks.md
+++ b/blocks.md
@@ -19,7 +19,7 @@
 - [Toggle](#toggle)
 - [Weather](#weather)
 - [Xrandr](#xrandr)
-- [Mail](#mail)
+- [Maildir](#maildir)
 
 ## Backlight
 
@@ -602,15 +602,15 @@ Key | Values | Required | Default
 `step_width` | The steps brightness is in/decreased for the selected screen (When greater than 50 it gets limited to 50) | No | `5`
 `interval` | Update interval, in seconds. | No | `5`
 
-## Mail
+## Maildir
 
-Creates a block which shows unread mails. Currently only supports maildir.
+Creates a block which shows unread mails. Only supports maildir format.
 
 ### Examples
 
 ```toml
 [[block]]
-block = "mail"
+block = "maildir"
 interval = 60
 inboxes = ["/home/user/mail/local", "/home/user/mail/gmail/Inbox"]
 threshold_warning = 1

--- a/blocks.md
+++ b/blocks.md
@@ -614,7 +614,7 @@ block = "mail"
 interval = 60
 inboxes = ["/home/user/mail/local", "/home/user/mail/gmail/Inbox"]
 threshold_warning = 1
-threshold_warning = 10
+threshold_critical = 10
 ```
 
 ### Options

--- a/src/blocks/mail.rs
+++ b/src/blocks/mail.rs
@@ -17,12 +17,6 @@ pub struct Mail {
     text: TextWidget,
     id: String,
     update_interval: Duration,
-
-    //useful, but optional
-    #[allow(dead_code)]
-    config: Config,
-    #[allow(dead_code)]
-    tx_update_request: Sender<Task>,
     inboxes: Vec<String>,
     threshold_warning: usize,
     threshold_critical: usize,
@@ -56,15 +50,13 @@ impl MailConfig {
 impl ConfigBlock for Mail {
     type Config = MailConfig;
 
-    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Result<Self> {
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
         Ok(Mail {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
             text: TextWidget::new(config.clone())
                 .with_icon("mail")
                 .with_text(""),
-            tx_update_request: tx_update_request,
-            config: config,
             inboxes: block_config.inboxes,
             threshold_warning: block_config.threshold_warning,
             threshold_critical: block_config.threshold_critical,

--- a/src/blocks/mail.rs
+++ b/src/blocks/mail.rs
@@ -1,0 +1,105 @@
+use std::time::Duration;
+use chan::Sender;
+
+use block::{Block, ConfigBlock};
+use config::Config;
+use de::deserialize_duration;
+use errors::*;
+use widgets::text::TextWidget;
+use widget::{I3BarWidget, State};
+use input::I3BarEvent;
+use scheduler::Task;
+use maildir::*;
+
+use uuid::Uuid;
+
+pub struct Mail {
+    text: TextWidget,
+    id: String,
+    update_interval: Duration,
+
+    //useful, but optional
+    #[allow(dead_code)]
+    config: Config,
+    #[allow(dead_code)]
+    tx_update_request: Sender<Task>,
+    inboxes: Vec<String>,
+    threshold_warning: usize,
+    threshold_critical: usize,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct MailConfig {
+    /// Update interval in seconds
+    #[serde(default = "MailConfig::default_interval", deserialize_with = "deserialize_duration")]
+    pub interval: Duration,
+    pub inboxes: Vec<String>,
+    #[serde(default = "MailConfig::default_threshold_warning")]
+    pub threshold_warning: usize,
+    #[serde(default = "MailConfig::default_threshold_critical")]
+    pub threshold_critical: usize,
+}
+
+impl MailConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+    fn default_threshold_warning() -> usize {
+        1 as usize
+    }
+    fn default_threshold_critical() -> usize {
+        10 as usize
+    }
+}
+
+impl ConfigBlock for Mail {
+    type Config = MailConfig;
+
+    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Result<Self> {
+        Ok(Mail {
+            id: Uuid::new_v4().simple().to_string(),
+            update_interval: block_config.interval,
+            text: TextWidget::new(config.clone())
+                .with_icon("mail")
+                .with_text(""),
+            tx_update_request: tx_update_request,
+            config: config,
+            inboxes: block_config.inboxes,
+            threshold_warning: block_config.threshold_warning,
+            threshold_critical: block_config.threshold_critical,
+        })
+    }
+}
+
+impl Block for Mail {
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let mut newmails = 0;
+        for inbox in &self.inboxes {
+            let isl: &str = &inbox[..];
+            let maildir = Maildir::from(isl);
+            newmails += maildir.count_new();
+        }
+        let mut state = { State::Idle };
+        if newmails >= self.threshold_critical {
+            state = { State::Critical };
+        } else if newmails >= self.threshold_warning {
+            state = { State::Warning };
+        }
+        self.text.set_state(state);
+        self.text.set_text(format!("{}", newmails));
+        Ok(Some(self.update_interval))
+    }
+
+    fn view(&self) -> Vec<&I3BarWidget> {
+        vec![&self.text]
+    }
+
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -20,7 +20,7 @@ mod weather;
 mod uptime;
 mod lib;
 pub mod nvidia_gpu;
-pub mod mail;
+pub mod maildir;
 
 use config::Config;
 use self::time::*;
@@ -44,7 +44,7 @@ use self::backlight::Backlight;
 use self::weather::*;
 use self::uptime::*;
 use self::nvidia_gpu::*;
-use self::mail::*;
+use self::maildir::*;
 
 use super::block::{Block, ConfigBlock};
 use errors::*;
@@ -98,6 +98,6 @@ pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_r
             "weather" => Weather,
             "uptime" => Uptime,
             "nvidia_gpu" => NvidiaGpu,
-            "mail" => Mail
+            "maildir" => Maildir
     )
 }

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -20,6 +20,7 @@ mod weather;
 mod uptime;
 mod lib;
 pub mod nvidia_gpu;
+pub mod mail;
 
 use config::Config;
 use self::time::*;
@@ -43,6 +44,7 @@ use self::backlight::Backlight;
 use self::weather::*;
 use self::uptime::*;
 use self::nvidia_gpu::*;
+use self::mail::*;
 
 use super::block::{Block, ConfigBlock};
 use errors::*;
@@ -95,6 +97,7 @@ pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_r
             "backlight" => Backlight,
             "weather" => Weather,
             "uptime" => Uptime,
-            "nvidia_gpu" => NvidiaGpu
+            "nvidia_gpu" => NvidiaGpu,
+            "mail" => Mail
     )
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -44,7 +44,8 @@ lazy_static! {
         "weather_rain" => " RAIN ",
         "weather_default" => " WEATHER ",
         "uptime" => " UP ",
-        "gpu" => " GPU "
+        "gpu" => " GPU ",
+        "mail" => " "
     };
 
     pub static ref AWESOME: Map<String, String> = map_to_owned! {
@@ -92,7 +93,8 @@ lazy_static! {
         "weather_default" => " \u{f0c2} ",
         // Same as time symbol.
         "uptime" => " \u{f017} ",
-        "gpu" => " \u{f26c} "
+        "gpu" => " \u{f26c} ",
+        "mail" => " \u{f0e0} "
     };
 
     pub static ref MATERIAL: Map<String, String> = map_to_owned! {
@@ -123,7 +125,8 @@ lazy_static! {
         "xrandr" => " \u{e31e} ",
         // Same as time symbol.
         "uptime" => " \u{e192} ",
-        "gpu" => " \u{e333} "
+        "gpu" => " \u{e333} ",
+        "mail" => " \u{e0be} "
     };
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ extern crate uuid;
 extern crate regex;
 extern crate num;
 extern crate inotify;
+extern crate maildir;
 
 #[macro_use]
 mod de;


### PR DESCRIPTION
Adds a block which displays the number of unread mails in configured inboxes. Currently only supports maildir format. It has pretty minimal functionality but might be useful to some users.