### PR TITLE
WIP: Add block for notmuch email users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
       - libdbus-1-dev
       - libgoogle-perftools-dev
-      - libnotmuch4
+      - libnotmuch3
 os:
   - linux
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
       - libdbus-1-dev
       - libgoogle-perftools-dev
-      - libnotmuch3
+      - libnotmuch3-dev
 os:
   - linux
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
       - libdbus-1-dev
       - libgoogle-perftools-dev
-      - libnotmuch3-dev
+      - libnotmuch-dev
 os:
   - linux
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
     packages:
       - libdbus-1-dev
       - libgoogle-perftools-dev
+      - libnotmuch4
 os:
   - linux
 matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "maildir 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notmuch 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -388,6 +389,14 @@ dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "notmuch"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -771,6 +780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mailparse 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "517ae98201a037bbd2dccdf88763e5818b26fc98a46725ae524424de2f67339f"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f"
+"checksum notmuch 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31759fa1f271621166e7716f11c203de1ddb7360b65e94aa5a0fa4f65cffc16b"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "81b483ea42927c463e191802e7334556b48e7875297564c0e9951bd3a0ae53e3"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ name = "atty"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -33,7 +33,7 @@ dependencies = [
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -44,7 +44,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ name = "dbus"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -257,6 +257,7 @@ dependencies = [
  "i3ipc 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "maildir 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -277,7 +278,7 @@ dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -285,7 +286,7 @@ name = "inotify-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -293,7 +294,7 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -323,7 +324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -373,7 +374,7 @@ name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -385,7 +386,7 @@ dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -495,7 +496,7 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -505,7 +506,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -598,7 +599,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -607,7 +608,7 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -634,7 +635,7 @@ name = "time"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -762,7 +763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
 "checksum libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8720f9274907052cb50313f91201597868da9d625f8dd125f2aca5bddb7e83a1"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ maildir = "0.1.1"
 # for profiling blocks
 cpuprofiler = "0.0.3"
 progress = "0.2"
+notmuch = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ maildir = "0.1.1"
 # for profiling blocks
 cpuprofiler = "0.0.3"
 progress = "0.2"
-notmuch = "*"
+notmuch = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Kai Greshake <development@kai-greshake.de>",
 
 [dependencies]
 chrono = "0.4"
+libc = "^0.2.42"
 lazy_static = "1.0"
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -20,6 +20,7 @@ mod weather;
 mod uptime;
 pub mod nvidia_gpu;
 pub mod maildir;
+pub mod notmuch;
 
 use config::Config;
 use self::time::*;
@@ -44,6 +45,7 @@ use self::weather::*;
 use self::uptime::*;
 use self::nvidia_gpu::*;
 use self::maildir::*;
+use self::notmuch::*;
 
 use super::block::{Block, ConfigBlock};
 use errors::*;
@@ -97,6 +99,7 @@ pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_r
             "weather" => Weather,
             "uptime" => Uptime,
             "nvidia_gpu" => NvidiaGpu,
-            "maildir" => Maildir
+            "maildir" => Maildir,
+            "notmuch" => Notmuch
     )
 }

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -17,6 +17,7 @@ use self::libc::c_char;
 use std::env;
 use std::ffi::CString;
 use std::ptr;
+use std::result;
 use widget::State;
 
 use uuid::Uuid;
@@ -86,21 +87,11 @@ pub enum notmuch_database_mode_t {
 
 #[link(name = "notmuch")]
 extern "C" {
-    pub fn notmuch_query_count_messages(
-        query: *mut notmuch_query_t,
-        count: *mut u16,
-    ) -> notmuch_status_t;
+    pub fn notmuch_query_count_messages(query: *mut notmuch_query_t, count: *mut u16) -> notmuch_status_t;
 
-    pub fn notmuch_query_create(
-        database: *mut notmuch_database_t,
-        query_string: *const c_char,
-    ) -> *mut notmuch_query_t;
+    pub fn notmuch_query_create(database: *mut notmuch_database_t, query_string: *const c_char) -> *mut notmuch_query_t;
 
-    pub fn notmuch_database_open(
-        path: *const c_char,
-        mode: notmuch_database_mode_t,
-        database: *mut *mut notmuch_database_t,
-    ) -> notmuch_status_t;
+    pub fn notmuch_database_open(path: *const c_char, mode: notmuch_database_mode_t, database: *mut *mut notmuch_database_t) -> notmuch_status_t;
 
     pub fn notmuch_database_destroy(database: *mut notmuch_database_t) -> notmuch_status_t;
 
@@ -110,8 +101,8 @@ pub struct Notmuch {
     text: TextWidget,
     id: String,
     update_interval: Duration,
-    query: *mut notmuch_query_t,
-    db: *mut notmuch_database_t,
+    query: CString,
+    db: CString,
     threshold_info: u16,
     threshold_good: u16,
     threshold_warning: u16,
@@ -130,9 +121,7 @@ pub struct Notmuch {
 #[serde(deny_unknown_fields)]
 pub struct NotmuchConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "NotmuchConfig::default_interval", deserialize_with = "deserialize_duration"
-    )]
+    #[serde(default = "NotmuchConfig::default_interval", deserialize_with = "deserialize_duration")]
     pub interval: Duration,
     #[serde(default = "NotmuchConfig::default_maildir")]
     pub maildir: String,
@@ -149,7 +138,7 @@ pub struct NotmuchConfig {
     #[serde(default = "NotmuchConfig::default_name")]
     pub name: Option<String>,
     #[serde(default = "NotmuchConfig::default_no_icon")]
-    pub no_icon: bool
+    pub no_icon: bool,
 }
 
 impl NotmuchConfig {
@@ -186,84 +175,95 @@ impl NotmuchConfig {
         <u16>::max_value()
     }
 
-    fn default_name () -> Option<String> { None }
-    fn default_no_icon () -> bool { false }
+    fn default_name() -> Option<String> {
+        None
+    }
+    fn default_no_icon() -> bool {
+        false
+    }
+}
+
+fn run_query(db_path: &CString, query: &CString) -> result::Result<u16, notmuch_status_t> {
+    let mut db = ptr::null_mut();
+    let mut result = 0u16;
+    unsafe {
+        match notmuch_database_open(db_path.as_ptr(), notmuch_database_mode_t::NOTMUCH_DATABASE_MODE_READ_WRITE, &mut db) {
+            notmuch_status_t::SUCCESS => {
+                let query_ptr = notmuch_query_create(db, query.as_ptr());
+                let p_result: *mut u16 = &mut result;
+                notmuch_query_count_messages(query_ptr, &mut *p_result);
+                notmuch_database_destroy(db);
+                Ok(result)
+            }
+            status => Err(status),
+        }
+    }
 }
 
 impl ConfigBlock for Notmuch {
     type Config = NotmuchConfig;
 
-    fn new(
-        block_config: Self::Config,
-        config: Config,
-        tx_update_request: Sender<Task>,
-    ) -> Result<Self> {
+    fn new(block_config: Self::Config, config: Config, tx_update_request: Sender<Task>) -> Result<Self> {
         let db_c_str = CString::new(block_config.maildir).unwrap();
         let query_c_str = CString::new(block_config.query).unwrap();
-        let mut db = ptr::null_mut();
 
-        unsafe {
-            match notmuch_database_open(
-                db_c_str.as_ptr(),
-                notmuch_database_mode_t::NOTMUCH_DATABASE_MODE_READ_ONLY,
-                &mut db,
-            ) {
-                notmuch_status_t::SUCCESS => {
-                    let query_ptr = notmuch_query_create(db, query_c_str.as_ptr());
-                    let mut widget = TextWidget::new(config.clone());
-                    if !block_config.no_icon {
-                        widget.set_icon("mail");
-                    }
-                    Ok(Notmuch {
-                        id: Uuid::new_v4().simple().to_string(),
-                        update_interval: block_config.interval,
-                        db: db,
-                        query: query_ptr,
-                        threshold_info: block_config.threshold_info,
-                        threshold_good: block_config.threshold_good,
-                        threshold_warning: block_config.threshold_warning,
-                        threshold_critical: block_config.threshold_critical,
-                        name: block_config.name,
-                        no_icon: block_config.no_icon,
-
-                        text: widget,
-                        tx_update_request: tx_update_request,
-                        config: config,
-                    })
-                }
-                _ => Err(Error::ConfigurationError(
-                    "Failed to open db".to_string(),
-                    ("sausages".to_string(), "becausages".to_string()),
-                )),
-            }
+        let mut widget = TextWidget::new(config.clone());
+        if !block_config.no_icon {
+            widget.set_icon("mail");
         }
+        Ok(Notmuch {
+            id: Uuid::new_v4().simple().to_string(),
+            update_interval: block_config.interval,
+            db: db_c_str,
+            query: query_c_str,
+            threshold_info: block_config.threshold_info,
+            threshold_good: block_config.threshold_good,
+            threshold_warning: block_config.threshold_warning,
+            threshold_critical: block_config.threshold_critical,
+            name: block_config.name,
+            no_icon: block_config.no_icon,
+
+            text: widget,
+            tx_update_request: tx_update_request,
+            config: config,
+        })
+    }
+}
+
+impl Notmuch {
+    fn update_text(&mut self, count: u16) {
+        let text = match self.name {
+            Some(ref s) => format!("{}:{}", s, count),
+            _ => format!("{}", count),
+        };
+        self.text.set_text(text);
+    }
+
+    fn update_state(&mut self, count: u16) {
+        let mut state = { State::Idle };
+        if count >= self.threshold_critical {
+            state = { State::Critical };
+        } else if count >= self.threshold_warning {
+            state = { State::Warning };
+        } else if count >= self.threshold_good {
+            state = { State::Good };
+        } else if count >= self.threshold_info {
+            state = { State::Info };
+        }
+        self.text.set_state(state);
     }
 }
 
 impl Block for Notmuch {
     fn update(&mut self) -> Result<Option<Duration>> {
-        let mut result = 0u16;
-        unsafe {
-            let p_result: *mut u16 = &mut result;
-            notmuch_query_count_messages(self.query, &mut *p_result);
+        match run_query(&self.db, &self.query) {
+            Err(_) => Err(BlockError("foo".to_owned(), "bar".to_owned())),
+            Ok(count) => {
+                self.update_text(count);
+                self.update_state(count);
+                Ok(Some(self.update_interval))
+            }
         }
-        let text = match self.name {
-            Some(ref s) => format!("{}:{}", s, result),
-            _ => format!("{}", result)
-        };
-        self.text.set_text(text);
-        let mut state = { State::Idle };
-        if result >= self.threshold_critical {
-            state = { State::Critical };
-        } else if result >= self.threshold_warning {
-            state = { State::Warning };
-        } else if result >= self.threshold_good {
-            state = { State::Good };
-        } else if result >= self.threshold_info {
-            state = { State::Info };
-        }
-        self.text.set_state(state);
-        Ok(Some(self.update_interval))
     }
 
     fn view(&self) -> Vec<&I3BarWidget> {

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -1,0 +1,280 @@
+#![allow(non_camel_case_types)]
+
+use chan::Sender;
+use std::time::Duration;
+
+use block::{Block, ConfigBlock};
+use config::Config;
+use de::deserialize_duration;
+use errors::*;
+use input::I3BarEvent;
+use scheduler::Task;
+use widget::I3BarWidget;
+use widgets::text::TextWidget;
+
+extern crate libc;
+use self::libc::c_char;
+use std::env;
+use std::ffi::CString;
+use std::ptr;
+use widget::State;
+
+use uuid::Uuid;
+
+#[repr(C)]
+pub struct notmuch_query_t;
+pub struct notmuch_database_t;
+
+// Status codes used for the return values of most functions.
+///
+/// A zero value (SUCCESS) indicates that the function completed without error. Any other value
+/// indicates an error.
+#[repr(C)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum notmuch_status_t {
+    /// No error occurred.
+    SUCCESS = 0,
+    /// Out of memory.
+    OUT_OF_MEMORY,
+    /// An attempt was made to write to a database opened in read-only
+    /// mode.
+    READ_ONLY_DATABASE,
+    /// A Xapian exception occurred.
+    ///
+    /// @todo We don't really want to expose this lame XAPIAN_EXCEPTION
+    /// value. Instead we should map to things like DATABASE_LOCKED or
+    /// whatever.
+    XAPIAN_EXCEPTION,
+    /// An error occurred trying to read or write to a file (this could
+    /// be file not found, permission denied, etc.)
+    FILE_ERROR,
+    /// A file was presented that doesn't appear to be an email
+    /// message.
+    FILE_NOT_EMAIL,
+    /// A file contains a message ID that is identical to a message
+    /// already in the database.
+    DUPLICATE_MESSAGE_ID,
+    /// The user erroneously passed a NULL pointer to a notmuch
+    /// function.
+    NULL_POINTER,
+    /// A tag value is too long (exceeds TAG_MAX).
+    TAG_TOO_LONG,
+    /// The `notmuch_message_thaw` function has been called more times
+    /// than `notmuch_message_freeze`.
+    UNBALANCED_FREEZE_THAW,
+    /// `notmuch_database_end_atomic` has been called more times than
+    /// `notmuch_database_begin_atomic`.
+    UNBALANCED_ATOMIC,
+    /// The operation is not supported.
+    UNSUPPORTED_OPERATION,
+    /// The operation requires a database upgrade.
+    UPGRADE_REQUIRED,
+    /// There is a problem with the proposed path, e.g. a relative path
+    /// passed to a function expecting an absolute path.
+    PATH_ERROR,
+    /// One of the arguments violates the preconditions for the
+    /// function, in a way not covered by a more specific argument.
+    NOTMUCH_STATUS_ILLEGAL_ARGUMENT,
+}
+
+#[repr(C)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum notmuch_database_mode_t {
+    NOTMUCH_DATABASE_MODE_READ_ONLY = 0,
+    NOTMUCH_DATABASE_MODE_READ_WRITE,
+}
+
+#[link(name = "notmuch")]
+extern "C" {
+    pub fn notmuch_query_count_messages(
+        query: *mut notmuch_query_t,
+        count: *mut u16,
+    ) -> notmuch_status_t;
+
+    pub fn notmuch_query_create(
+        database: *mut notmuch_database_t,
+        query_string: *const c_char,
+    ) -> *mut notmuch_query_t;
+
+    pub fn notmuch_database_open(
+        path: *const c_char,
+        mode: notmuch_database_mode_t,
+        database: *mut *mut notmuch_database_t,
+    ) -> notmuch_status_t;
+
+    pub fn notmuch_database_destroy(database: *mut notmuch_database_t) -> notmuch_status_t;
+
+}
+
+pub struct Notmuch {
+    text: TextWidget,
+    id: String,
+    update_interval: Duration,
+    query: *mut notmuch_query_t,
+    db: *mut notmuch_database_t,
+    threshold_info: u16,
+    threshold_good: u16,
+    threshold_warning: u16,
+    threshold_critical: u16,
+    name: Option<String>,
+    no_icon: bool,
+
+    //useful, but optional
+    #[allow(dead_code)]
+    config: Config,
+    #[allow(dead_code)]
+    tx_update_request: Sender<Task>,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct NotmuchConfig {
+    /// Update interval in seconds
+    #[serde(
+        default = "NotmuchConfig::default_interval", deserialize_with = "deserialize_duration"
+    )]
+    pub interval: Duration,
+    #[serde(default = "NotmuchConfig::default_maildir")]
+    pub maildir: String,
+    #[serde(default = "NotmuchConfig::default_query")]
+    pub query: String,
+    #[serde(default = "NotmuchConfig::default_threshold_warning")]
+    pub threshold_warning: u16,
+    #[serde(default = "NotmuchConfig::default_threshold_critical")]
+    pub threshold_critical: u16,
+    #[serde(default = "NotmuchConfig::default_threshold_info")]
+    pub threshold_info: u16,
+    #[serde(default = "NotmuchConfig::default_threshold_good")]
+    pub threshold_good: u16,
+    #[serde(default = "NotmuchConfig::default_name")]
+    pub name: Option<String>,
+    #[serde(default = "NotmuchConfig::default_no_icon")]
+    pub no_icon: bool
+}
+
+impl NotmuchConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(10)
+    }
+
+    fn default_maildir() -> String {
+        let home_dir = match env::home_dir() {
+            Some(path) => path.into_os_string().into_string().unwrap(),
+            None => "".to_owned(),
+        };
+
+        format!("{}/.mail", home_dir)
+    }
+
+    fn default_query() -> String {
+        "".to_owned()
+    }
+
+    fn default_threshold_info() -> u16 {
+        <u16>::max_value()
+    }
+
+    fn default_threshold_good() -> u16 {
+        <u16>::max_value()
+    }
+
+    fn default_threshold_warning() -> u16 {
+        <u16>::max_value()
+    }
+
+    fn default_threshold_critical() -> u16 {
+        <u16>::max_value()
+    }
+
+    fn default_name () -> Option<String> { None }
+    fn default_no_icon () -> bool { false }
+}
+
+impl ConfigBlock for Notmuch {
+    type Config = NotmuchConfig;
+
+    fn new(
+        block_config: Self::Config,
+        config: Config,
+        tx_update_request: Sender<Task>,
+    ) -> Result<Self> {
+        let db_c_str = CString::new(block_config.maildir).unwrap();
+        let query_c_str = CString::new(block_config.query).unwrap();
+        let mut db = ptr::null_mut();
+
+        unsafe {
+            match notmuch_database_open(
+                db_c_str.as_ptr(),
+                notmuch_database_mode_t::NOTMUCH_DATABASE_MODE_READ_ONLY,
+                &mut db,
+            ) {
+                notmuch_status_t::SUCCESS => {
+                    let query_ptr = notmuch_query_create(db, query_c_str.as_ptr());
+                    let mut widget = TextWidget::new(config.clone());
+                    if !block_config.no_icon {
+                        widget.set_icon("mail");
+                    }
+                    Ok(Notmuch {
+                        id: Uuid::new_v4().simple().to_string(),
+                        update_interval: block_config.interval,
+                        db: db,
+                        query: query_ptr,
+                        threshold_info: block_config.threshold_info,
+                        threshold_good: block_config.threshold_good,
+                        threshold_warning: block_config.threshold_warning,
+                        threshold_critical: block_config.threshold_critical,
+                        name: block_config.name,
+                        no_icon: block_config.no_icon,
+
+                        text: widget,
+                        tx_update_request: tx_update_request,
+                        config: config,
+                    })
+                }
+                _ => Err(Error::ConfigurationError(
+                    "Failed to open db".to_string(),
+                    ("sausages".to_string(), "becausages".to_string()),
+                )),
+            }
+        }
+    }
+}
+
+impl Block for Notmuch {
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let mut result = 0u16;
+        unsafe {
+            let p_result: *mut u16 = &mut result;
+            notmuch_query_count_messages(self.query, &mut *p_result);
+        }
+        let text = match self.name {
+            Some(ref s) => format!("{}:{}", s, result),
+            _ => format!("{}", result)
+        };
+        self.text.set_text(text);
+        let mut state = { State::Idle };
+        if result >= self.threshold_critical {
+            state = { State::Critical };
+        } else if result >= self.threshold_warning {
+            state = { State::Warning };
+        } else if result >= self.threshold_good {
+            state = { State::Good };
+        } else if result >= self.threshold_info {
+            state = { State::Info };
+        }
+        self.text.set_state(state);
+        Ok(Some(self.update_interval))
+    }
+
+    fn view(&self) -> Vec<&I3BarWidget> {
+        vec![&self.text]
+    }
+
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -7,10 +7,10 @@ use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
-use input::I3BarEvent;
 use scheduler::Task;
 use widget::I3BarWidget;
 use widgets::text::TextWidget;
+use input::{I3BarEvent, MouseButton};
 
 extern crate libc;
 use self::libc::c_char;
@@ -22,9 +22,9 @@ use widget::State;
 
 use uuid::Uuid;
 
-#[repr(C)]
-pub struct notmuch_query_t;
-pub struct notmuch_database_t;
+pub enum notmuch_query_t{}
+
+pub enum notmuch_database_t{}
 
 // Status codes used for the return values of most functions.
 ///
@@ -108,7 +108,6 @@ pub struct Notmuch {
     threshold_warning: u16,
     threshold_critical: u16,
     name: Option<String>,
-    no_icon: bool,
 
     //useful, but optional
     #[allow(dead_code)]
@@ -221,7 +220,6 @@ impl ConfigBlock for Notmuch {
             threshold_warning: block_config.threshold_warning,
             threshold_critical: block_config.threshold_critical,
             name: block_config.name,
-            no_icon: block_config.no_icon,
 
             text: widget,
             tx_update_request: tx_update_request,
@@ -270,7 +268,11 @@ impl Block for Notmuch {
         vec![&self.text]
     }
 
-    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+    fn click(&mut self, event: &I3BarEvent) -> Result<()> {
+        if event.name.as_ref().map(|s| s == "notmuch").unwrap_or(false) && event.button == MouseButton::Left {
+            self.update()?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
This PR adds a new notmuch block that queries a notmuch database and displays the count of messages. It directly uses the notmuch C lib rather than shelling out.

The simplest configuration will return the total count of messages in the notmuch database stored at $HOME/.mail

```
[[block]]
block = "notmuch"
```

Optionally, we can apply labels, thresholds, or suppress the mail icon.

```
[[block]]
block = "notmuch"
query = "tag:inbox"
threshold_good = 1
name = "I"

[[block]]
block = "notmuch"
query = "tag:alert and not tag:trash"
threshold_warning = 1
threshold_critical = 10
name = "A"
no_icon = true

[[block]]
block = "notmuch"
query = "tag:todo"
threshold_info = 1
name = "T"
no_icon = true
```
![mail](https://user-images.githubusercontent.com/50893/42561880-37fc64ec-84f2-11e8-804d-de8fa62c0ed8.png)