### PR TITLE
memory block: fix default format strings

### DIFF
--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -2,7 +2,7 @@
 //!
 //! Creates a block displaying memory and swap usage.
 //!
-//! By default, the format of this module is "<Icon>: {MFm}MB/{MTm}MB({Mp}%)" (Swap values
+//! By default, the format of this module is "<Icon>: {MFm}MB/{MTm}MB({MUp}%)" (Swap values
 //! accordingly). That behaviour can be changed within config.json.
 //!
 //! This module keeps track of both Swap and Memory. By default, a click switches between them.
@@ -21,8 +21,8 @@
 //!
 //! Key | Values | Required | Default
 //! ----|--------|----------|--------
-//! format_mem | Format string for Memory view. All format values are described below. | No | {MFm}MB/{MTm}MB({Mp}%)
-//! format_swap | Format string for Swap view. | No | {SFm}MB/{STm}MB({Sp}%)
+//! format_mem | Format string for Memory view. All format values are described below. | No | {MFm}MB/{MTm}MB({MUp}%)
+//! format_swap | Format string for Swap view. | No | {SFm}MB/{STm}MB({SUp}%)
 //! type | Default view displayed on startup. Options are <br/> memory, swap | No | memory
 //! icons | Whether the format string should be prepended with Icons. Options are <br/> true, false | No | true
 //! clickable | Whether the view should switch between memory and swap on click. Options are <br/> true, false | No | true
@@ -282,11 +282,11 @@ pub struct MemoryConfig {
 
 impl MemoryConfig {
     fn default_format_mem() -> String {
-        "{MFm}MB/{MTm}MB({Mp}%)".to_owned()
+        "{MFm}MB/{MTm}MB({MUp}%)".to_owned()
     }
 
     fn default_format_swap() -> String {
-        "{SFm}MB/{STm}MB({Sp}%)".to_owned()
+        "{SFm}MB/{STm}MB({SUp}%)".to_owned()
     }
 
     fn default_display_type() -> Memtype {


### PR DESCRIPTION
`{Mp}` and `{Sp`} don't exist, use `{MUp`} and `{SUp}` instead.

Otherwise, panics with default format strings:

```
thread 'main' panicked at 'Unknown placeholder in format string: {Sp}', libcore/option.rs:914:5
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
   1: std::sys_common::backtrace::print
   2: std::panicking::default_hook::{{closure}}
   3: std::panicking::default_hook
   4: std::panicking::rust_panic_with_hook
   5: std::panicking::begin_panic_fmt
   6: rust_begin_unwind
   7: core::panicking::panic_fmt
   8: core::option::expect_failed
   9: i3status_rs::util::FormatTemplate::render
  10: i3status_rs::util::FormatTemplate::render
  11: i3status_rs::util::FormatTemplate::render
  12: i3status_rs::util::FormatTemplate::render
  13: i3status_rs::util::FormatTemplate::render
  14: <i3status_rs::blocks::memory::Memory as i3status_rs::block::Block>::update
  15: <i3status_rs::blocks::memory::Memory as i3status_rs::block::Block>::click
  16: i3status_rs::main
  17: std::rt::lang_start::{{closure}}
  18: std::panicking::try::do_call
  19: __rust_maybe_catch_panic
  20: std::rt::lang_start_internal
  21: main
  22: __libc_start_main
  23: _start
```