### PR TITLE
Add alpha channel to color utils.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -159,26 +159,29 @@ pub fn print_blocks(order: &Vec<String>, block_map: &HashMap<String, &mut Block>
     Ok(())
 }
 
-pub fn get_color_from_html(color: &str) -> ::std::result::Result<(u8, u8, u8), ParseIntError> {
+pub fn color_from_rgba(color: &str) -> ::std::result::Result<(u8, u8, u8, u8), ParseIntError> {
     Ok((
         u8::from_str_radix(&color[1..3], 16)?,
         u8::from_str_radix(&color[3..5], 16)?,
         u8::from_str_radix(&color[5..7], 16)?,
+        u8::from_str_radix(&color.get(7..9).unwrap_or("FF"), 16)?,
     ))
 }
 
-pub fn color_to_html(color: (u8, u8, u8)) -> String {
-    format!("#{:02X}{:02X}{:02X}", color.0, color.1, color.2)
+pub fn color_to_rgba(color: (u8, u8, u8, u8)) -> String {
+    format!("#{:02X}{:02X}{:02X}{:02X}", color.0, color.1, color.2, color.3)
 }
 
 // TODO: Allow for other non-additive tints
 pub fn add_colors(a: &str, b: &str) -> ::std::result::Result<String, ParseIntError> {
-    let (r_a, g_a, b_a) = get_color_from_html(a)?;
-    let (r_b, g_b, b_b) = get_color_from_html(b)?;
-    Ok(color_to_html((
+    let (r_a, g_a, b_a, a_a) = color_from_rgba(a)?;
+    let (r_b, g_b, b_b, a_b) = color_from_rgba(b)?;
+
+    Ok(color_to_rgba((
         r_a.checked_add(r_b).unwrap_or(255),
         g_a.checked_add(g_b).unwrap_or(255),
         b_a.checked_add(b_b).unwrap_or(255),
+        a_a.checked_add(a_b).unwrap_or(255),
     )))
 }
 


### PR DESCRIPTION
This commit introduces an alpha channel to the current color arithmetic. That allows for a completely transparent background.