### PR TITLE
Add coretemp block.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,11 @@ version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "i3ipc"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +259,7 @@ dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpuprofiler 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "i3ipc 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -754,6 +760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum i3ipc 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a4e0c68a50475f32bf9a728de1198a8acc573ccdb24212db1192c874e37f302"
 "checksum inotify 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ad0bfe014aafc0f4e177fbe66c5f2b59ba59f66f58b022aa1963bbe71ab4118"
 "checksum inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dceb94c43f70baf4c4cd6afbc1e9037d4161dbe68df8a2cd4351a23319ee4fb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ num = "0.1.42"
 chan = "0.1.21"
 inotify = "0.5.1"
 maildir = "0.1.1"
+glob = "^0.2.0"
 # Used only in debug build mode
 # for profiling blocks
 cpuprofiler = "0.0.3"

--- a/src/blocks/coretemp.rs
+++ b/src/blocks/coretemp.rs
@@ -1,0 +1,159 @@
+use std::fs::File;
+use std::time::Duration;
+use std::path::PathBuf;
+use std::io::prelude::*;
+
+use util::FormatTemplate;
+use chan::Sender;
+use scheduler::Task;
+use uuid::Uuid;
+use glob::glob;
+
+use block::{Block, ConfigBlock};
+use config::Config;
+use de::deserialize_duration;
+use errors::*;
+use widget::{I3BarWidget, State};
+use widgets::text::TextWidget;
+
+type Temperature = i32;
+
+struct Thermometer {
+    paths: Vec<PathBuf>,
+}
+
+impl Thermometer {
+    pub fn new(pattern: &str) -> Result<Self> {
+        let mut paths_vec = Vec::new();
+        let paths = glob(pattern)
+            .block_error("coretemp", "invalid file pattern")?;
+
+        for path in paths {
+            if path.is_ok() {
+                paths_vec.push(path.unwrap())
+            }
+        }
+
+        Ok(Thermometer {
+            paths: paths_vec,
+        })
+    }
+
+    pub fn measure(&self) -> Result<(Temperature, Temperature, Temperature)> {
+        let mut temperatures = Vec::new();
+
+        for path in self.paths.iter() {
+            let mut file = File::open(path).unwrap();
+            let mut temp_raw = String::new();
+
+            file.read_to_string(&mut temp_raw)
+                .block_error("coretemp", "failed to read file")?;
+
+            let temp_raw : i32 = temp_raw.trim().parse()
+                .block_error("coretemp", "failed to parse temperature")?;
+
+            temperatures.push(temp_raw);
+        }
+
+        if temperatures.len() == 0 {
+            return Err(BlockError(
+                "coretemp".to_string(),
+                "No temperatures found".to_string(),
+            ))
+        }
+
+        let min = temperatures.iter().min().unwrap() / 1000;
+        let max = temperatures.iter().max().unwrap() / 1000;
+        let sum: i32 = temperatures.iter().sum();
+        let avg = sum / temperatures.len() as i32 / 1000;
+
+        Ok((min, max, avg))
+    }
+}
+
+pub struct Coretemp {
+    id: String,
+    output: TextWidget,
+    update_interval: Duration,
+    format: FormatTemplate,
+    thermometer: Thermometer,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct CoretempConfig {
+    /// Update interval in seconds.
+    #[serde(default = "CoretempConfig::default_interval", deserialize_with = "deserialize_duration")]
+    pub interval: Duration,
+
+    /// Format override.
+    #[serde(default = "CoretempConfig::default_format")]
+    pub format: String,
+
+    /// Pattern override.
+    #[serde(default = "CoretempConfig::default_pattern")]
+    pub pattern: String,
+}
+
+impl CoretempConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+
+    fn default_format() -> String {
+        "{average}° avg, {max}° max".to_owned()
+    }
+
+    fn default_pattern() -> String {
+        "/sys/devices/platform/coretemp.0/hwmon/*/temp*_input".to_owned()
+    }
+}
+
+impl ConfigBlock for Coretemp {
+    type Config = CoretempConfig;
+
+    fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
+        let id = Uuid::new_v4().simple().to_string();
+        let thermometer = Thermometer::new(&block_config.pattern)?;
+
+        Ok(Coretemp {
+            id: id,
+            output: TextWidget::new(config),
+            update_interval: block_config.interval,
+            format: FormatTemplate::from_string(block_config.format)
+                .block_error("coretemp", "Invalid format specified for temperature")?,
+            thermometer: thermometer,
+        })
+    }
+}
+
+impl Block for Coretemp {
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let (min, max, avg) = self.thermometer.measure()?;
+
+        let values = map!("{average}" => avg,
+                          "{min}" => min,
+                          "{max}" => max);
+
+        let text = self.format.render_static_str(&values)?;
+        self.output.set_text(text);
+
+        self.output.set_state(match max {
+            0...20 => State::Good,
+            21...45 => State::Idle,
+            46...60 => State::Info,
+            61...80 => State::Warning,
+            _ => State::Critical,
+        });
+
+        Ok(Some(self.update_interval))
+    }
+
+    fn view(&self) -> Vec<&I3BarWidget> {
+        vec![&self.output]
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}

--- a/src/blocks/coretemp.rs
+++ b/src/blocks/coretemp.rs
@@ -118,7 +118,7 @@ impl ConfigBlock for Coretemp {
 
         Ok(Coretemp {
             id: id,
-            output: TextWidget::new(config),
+            output: TextWidget::new(config).with_icon("thermometer"),
             update_interval: block_config.interval,
             format: FormatTemplate::from_string(block_config.format)
                 .block_error("coretemp", "Invalid format specified for temperature")?,

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -1,52 +1,51 @@
-mod backlight;
-mod battery;
-mod coretemp;
+mod time;
+mod template;
+mod load;
+mod memory;
 mod cpu;
+mod music;
+pub mod battery;
 mod custom;
 mod disk_space;
-mod focused_window;
-mod load;
-mod maildir;
-mod memory;
-mod music;
-mod net;
-mod nvidia_gpu;
 mod pacman;
+mod temperature;
+mod toggle;
 mod sound;
 mod speedtest;
-mod temperature;
-mod template;
-mod time;
-mod toggle;
-mod uptime;
-mod weather;
+mod focused_window;
 mod xrandr;
+mod net;
+pub mod backlight;
+mod weather;
+mod uptime;
+pub mod nvidia_gpu;
+pub mod maildir;
+mod coretemp;
 
 use config::Config;
-
-use self::backlight::*;
-use self::battery::*;
-use self::coretemp::*;
+use self::time::*;
+use self::template::*;
+use self::music::*;
 use self::cpu::*;
+use self::load::*;
+use self::memory::*;
+use self::battery::*;
 use self::custom::*;
 use self::disk_space::*;
-use self::focused_window::*;
-use self::load::*;
-use self::maildir::*;
-use self::memory::*;
-use self::music::*;
-use self::net::*;
-use self::nvidia_gpu::*;
 use self::pacman::*;
 use self::sound::*;
 use self::speedtest::*;
-use self::temperature::*;
-use self::template::*;
-use self::time::*;
 use self::toggle::*;
-use self::uptime::*;
-use self::weather::*;
+use self::focused_window::*;
+use self::temperature::*;
 use self::xrandr::*;
+use self::net::*;
+use self::backlight::Backlight;
+use self::weather::*;
+use self::uptime::*;
+use self::nvidia_gpu::*;
+use self::maildir::*;
+use self::coretemp::*;
 
 use super::block::{Block, ConfigBlock};
 use errors::*;
@@ -79,28 +78,28 @@ macro_rules! blocks {
 
 pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_request: Sender<Task>) -> Result<Box<Block>> {
     blocks!(name, block_config, config, tx_update_request;
-            "backlight" => Backlight,
-            "battery" => Battery,
-            "coretemp" => Coretemp,
+            "time" => Time,
+            "template" => Template,
+            "music" => Music,
+            "load" => Load,
+            "memory" => Memory,
             "cpu" => Cpu,
+            "pacman" => Pacman,
+            "battery" => Battery,
             "custom" => Custom,
             "disk_space" => DiskSpace,
-            "focused_window" => FocusedWindow,
-            "load" => Load,
-            "maildir" => Maildir,
-            "memory" => Memory,
-            "music" => Music,
-            "net" => Net,
-            "nvidia_gpu" => NvidiaGpu,
-            "pacman" => Pacman,
+            "toggle" => Toggle,
             "sound" => Sound,
             "speedtest" => SpeedTest,
             "temperature" => Temperature,
-            "template" => Template,
-            "time" => Time,
-            "toggle" => Toggle,
-            "uptime" => Uptime,
+            "focused_window" => FocusedWindow,
+            "xrandr" => Xrandr,
+            "net" => Net,
+            "backlight" => Backlight,
             "weather" => Weather,
-            "xrandr" => Xrandr
+            "uptime" => Uptime,
+            "nvidia_gpu" => NvidiaGpu,
+            "maildir" => Maildir,
+            "coretemp" => Coretemp
     )
 }

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -1,49 +1,52 @@
-mod time;
-mod template;
-mod load;
-mod memory;
+mod backlight;
+mod battery;
+mod coretemp;
 mod cpu;
-mod music;
-pub mod battery;
 mod custom;
 mod disk_space;
+mod focused_window;
+mod load;
+mod maildir;
+mod memory;
+mod music;
+mod net;
+mod nvidia_gpu;
 mod pacman;
-mod temperature;
-mod toggle;
 mod sound;
 mod speedtest;
-mod focused_window;
-mod xrandr;
-mod net;
-pub mod backlight;
-mod weather;
+mod temperature;
+mod template;
+mod time;
+mod toggle;
 mod uptime;
-pub mod nvidia_gpu;
-pub mod maildir;
+mod weather;
+mod xrandr;
 
 use config::Config;
-use self::time::*;
-use self::template::*;
-use self::music::*;
-use self::cpu::*;
-use self::load::*;
-use self::memory::*;
+
+use self::backlight::*;
 use self::battery::*;
+use self::coretemp::*;
+use self::cpu::*;
 use self::custom::*;
 use self::disk_space::*;
+use self::focused_window::*;
+use self::load::*;
+use self::maildir::*;
+use self::memory::*;
+use self::music::*;
+use self::net::*;
+use self::nvidia_gpu::*;
 use self::pacman::*;
 use self::sound::*;
 use self::speedtest::*;
-use self::toggle::*;
-use self::focused_window::*;
 use self::temperature::*;
-use self::xrandr::*;
-use self::net::*;
-use self::backlight::Backlight;
-use self::weather::*;
+use self::template::*;
+use self::time::*;
+use self::toggle::*;
 use self::uptime::*;
-use self::nvidia_gpu::*;
-use self::maildir::*;
+use self::weather::*;
+use self::xrandr::*;
 
 use super::block::{Block, ConfigBlock};
 use errors::*;
@@ -76,27 +79,28 @@ macro_rules! blocks {
 
 pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_request: Sender<Task>) -> Result<Box<Block>> {
     blocks!(name, block_config, config, tx_update_request;
-            "time" => Time,
-            "template" => Template,
-            "music" => Music,
-            "load" => Load,
-            "memory" => Memory,
-            "cpu" => Cpu,
-            "pacman" => Pacman,
+            "backlight" => Backlight,
             "battery" => Battery,
+            "coretemp" => Coretemp,
+            "cpu" => Cpu,
             "custom" => Custom,
             "disk_space" => DiskSpace,
-            "toggle" => Toggle,
+            "focused_window" => FocusedWindow,
+            "load" => Load,
+            "maildir" => Maildir,
+            "memory" => Memory,
+            "music" => Music,
+            "net" => Net,
+            "nvidia_gpu" => NvidiaGpu,
+            "pacman" => Pacman,
             "sound" => Sound,
             "speedtest" => SpeedTest,
             "temperature" => Temperature,
-            "focused_window" => FocusedWindow,
-            "xrandr" => Xrandr,
-            "net" => Net,
-            "backlight" => Backlight,
-            "weather" => Weather,
+            "template" => Template,
+            "time" => Time,
+            "toggle" => Toggle,
             "uptime" => Uptime,
-            "nvidia_gpu" => NvidiaGpu,
-            "maildir" => Maildir
+            "weather" => Weather,
+            "xrandr" => Xrandr
     )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate regex;
 extern crate num;
 extern crate inotify;
 extern crate maildir;
+extern crate glob;
 
 #[macro_use]
 mod de;


### PR DESCRIPTION
This pull request adds a new block to measure the current CPU temperature efficiently.

It does not depend on `sensors` nor does it run any external program to retrieve its measurements. By default, the block relies on the sysfs filesystem being present. You can specify any glob pattern to look for files.
The file list will only be retrieved once at startup, since I don't think hot-swapping of CPUs has to be supported.