### PR TITLE
Add padding to percent values of memory block.

### DIFF
--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -351,7 +351,7 @@ impl Memory {
         );
         self.values.insert(
             "{MFpi}".to_string(),
-            format!("{}", mem_free.percent(mem_total) as i32),
+            format!("{:02}", mem_free.percent(mem_total) as i32),
         );
         self.values
             .insert("{MUg}".to_string(), format!("{:.1}", mem_total_used.gib()));
@@ -363,7 +363,7 @@ impl Memory {
         );
         self.values.insert(
             "{MUpi}".to_string(),
-            format!("{}", mem_total_used.percent(mem_total) as i32),
+            format!("{:02}", mem_total_used.percent(mem_total) as i32),
         );
         self.values
             .insert("{Mug}".to_string(), format!("{:.1}", mem_used.gib()));
@@ -375,7 +375,7 @@ impl Memory {
         );
         self.values.insert(
             "{Mupi}".to_string(),
-            format!("{}", mem_used.percent(mem_total) as i32),
+            format!("{:02}", mem_used.percent(mem_total) as i32),
         );
         self.values
             .insert("{MAg}".to_string(), format!("{:.1}", mem_avail.gib()));
@@ -387,7 +387,7 @@ impl Memory {
         );
         self.values.insert(
             "{MApi}".to_string(),
-            format!("{}", mem_avail.percent(mem_total) as i32),
+            format!("{:02}", mem_avail.percent(mem_total) as i32),
         );
         self.values
             .insert("{STg}".to_string(), format!("{:.1}", swap_total.gib()));
@@ -403,7 +403,7 @@ impl Memory {
         );
         self.values.insert(
             "{SFpi}".to_string(),
-            format!("{}", swap_free.percent(swap_total) as i32),
+            format!("{:02}", swap_free.percent(swap_total) as i32),
         );
         self.values
             .insert("{SUg}".to_string(), format!("{:.1}", swap_used.gib()));
@@ -415,7 +415,7 @@ impl Memory {
         );
         self.values.insert(
             "{SUpi}".to_string(),
-            format!("{}", swap_used.percent(swap_total) as i32),
+            format!("{:02}", swap_used.percent(swap_total) as i32),
         );
         self.values
             .insert("{Bg}".to_string(), format!("{:.1}", buffers.gib()));
@@ -427,7 +427,7 @@ impl Memory {
         );
         self.values.insert(
             "{Bpi}".to_string(),
-            format!("{}", buffers.percent(mem_total) as i32),
+            format!("{:02}", buffers.percent(mem_total) as i32),
         );
         self.values
             .insert("{Cg}".to_string(), format!("{:.1}", cached.gib()));
@@ -439,7 +439,7 @@ impl Memory {
         );
         self.values.insert(
             "{Cpi}".to_string(),
-            format!("{}", cached.percent(mem_total) as i32),
+            format!("{:02}", cached.percent(mem_total) as i32),
         );
 
         match self.memtype {


### PR DESCRIPTION
This commit adds zero-padding to the percent values of the `memory` block. On my system for example, memory usage is always around `10%`. This leads to the memory block changing from one digit to two digits and vice-versa quite frequently.

I'd like to have less movement in my status bar, while keeping the values recent. The idea was to pad single-digit values with `0` in front as done in the `cpu` block. We could also pad using space.