### PR TITLE
Add networkmanager block.

### DIFF
--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -20,6 +20,7 @@ mod weather;
 mod uptime;
 pub mod nvidia_gpu;
 pub mod maildir;
+mod networkmanager;
 
 use config::Config;
 use self::time::*;
@@ -44,6 +45,7 @@ use self::weather::*;
 use self::uptime::*;
 use self::nvidia_gpu::*;
 use self::maildir::*;
+use self::networkmanager::*;
 
 use super::block::{Block, ConfigBlock};
 use errors::*;
@@ -97,6 +99,7 @@ pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_r
             "weather" => Weather,
             "uptime" => Uptime,
             "nvidia_gpu" => NvidiaGpu,
-            "maildir" => Maildir
+            "maildir" => Maildir,
+            "networkmanager" => NetworkManager
     )
 }

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -29,7 +29,6 @@ impl From<u32> for NetworkState {
     fn from(id: u32) -> Self {
         match id {
             // https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NMState
-            // TODO: derive this automatically.
             10 => NetworkState::Asleep,
             20 => NetworkState::Disconnected,
             30 => NetworkState::Disconnecting,
@@ -45,14 +44,14 @@ impl From<u32> for NetworkState {
 impl fmt::Display for NetworkState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            NetworkState::Unknown => write!(f, "net_down"),
-            NetworkState::Asleep => write!(f, "net_down"),
-            NetworkState::Disconnected => write!(f, "net_down"),
-            NetworkState::Disconnecting => write!(f, "net_down"),
-            NetworkState::Connecting => write!(f, "net_down"),
-            NetworkState::ConnectedLocal => write!(f, "net_up"),
-            NetworkState::ConnectedSite => write!(f, "net_up"),
-            NetworkState::ConnectedGlobal => write!(f, "net_up"),
+            NetworkState::Unknown => write!(f, "DOWN"),
+            NetworkState::Asleep => write!(f, "DOWN"),
+            NetworkState::Disconnected => write!(f, "DOWN"),
+            NetworkState::Disconnecting => write!(f, "DOWN"),
+            NetworkState::Connecting => write!(f, "DOWN"),
+            NetworkState::ConnectedLocal => write!(f, "UP"),
+            NetworkState::ConnectedSite => write!(f, "UP"),
+            NetworkState::ConnectedGlobal => write!(f, "UP"),
         }
     }
 }
@@ -68,7 +67,7 @@ impl From<String> for ConnectionType {
         match name.as_ref() {
             // https://developer.gnome.org/NetworkManager/unstable/settings-connection.html
             "802-3-ethernet" => ConnectionType::Ethernet,
-            "802-11-ethernet" => ConnectionType::Wireless,
+            "802-11-wireless" => ConnectionType::Wireless,
             _  => ConnectionType::Other,
         }
     }
@@ -201,7 +200,7 @@ impl Block for NetworkManager {
         let state = self.manager.state(&self.dbus_conn)?;
         let connection_type = self.manager.connection_type(&self.dbus_conn)?;
 
-        self.output.set_icon(&state.to_string());
+        self.output.set_icon(&connection_type.to_string());
         self.output.set_state(match state {
             NetworkState::ConnectedGlobal => State::Good,
             NetworkState::ConnectedSite => State::Info,
@@ -214,7 +213,7 @@ impl Block for NetworkManager {
         });
 
         if self.show_type {
-            self.output.set_text(connection_type.to_string());
+            self.output.set_text(state.to_string());
         }
 
         Ok(None)

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -1,0 +1,226 @@
+use std::fmt;
+use std::time::{Duration, Instant};
+use std::thread;
+
+use chan::Sender;
+use uuid::Uuid;
+
+use config::Config;
+use errors::*;
+use scheduler::Task;
+use block::{Block, ConfigBlock};
+use widget::{I3BarWidget, State};
+use widgets::text::TextWidget;
+use blocks::dbus::{BusType, Connection, Message, MessageItem};
+use blocks::dbus::arg::Variant;
+
+enum NetworkState {
+    Unknown = 0,
+    Asleep = 10,
+    Disconnected = 20,
+    Disconnecting = 30,
+    Connecting = 40,
+    ConnectedLocal = 50,
+    ConnectedSite = 60,
+    ConnectedGlobal = 70,
+}
+
+impl From<u32> for NetworkState {
+    fn from(id: u32) -> Self {
+        match id {
+            // https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NMState
+            // TODO: derive this automatically.
+            10 => NetworkState::Asleep,
+            20 => NetworkState::Disconnected,
+            30 => NetworkState::Disconnecting,
+            40 => NetworkState::Connecting,
+            50 => NetworkState::ConnectedLocal,
+            60 => NetworkState::ConnectedSite,
+            70 => NetworkState::ConnectedGlobal,
+            _  => NetworkState::Unknown,
+        }
+    }
+}
+
+impl fmt::Display for NetworkState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NetworkState::Unknown => write!(f, "net_down"),
+            NetworkState::Asleep => write!(f, "net_down"),
+            NetworkState::Disconnected => write!(f, "net_down"),
+            NetworkState::Disconnecting => write!(f, "net_down"),
+            NetworkState::Connecting => write!(f, "net_down"),
+            NetworkState::ConnectedLocal => write!(f, "net_up"),
+            NetworkState::ConnectedSite => write!(f, "net_up"),
+            NetworkState::ConnectedGlobal => write!(f, "net_up"),
+        }
+    }
+}
+
+enum ConnectionType {
+    Ethernet,
+    Wireless,
+    Other,
+}
+
+impl From<String> for ConnectionType {
+    fn from(name: String) -> Self {
+        match name.as_ref() {
+            // https://developer.gnome.org/NetworkManager/unstable/settings-connection.html
+            "802-3-ethernet" => ConnectionType::Ethernet,
+            "802-11-ethernet" => ConnectionType::Wireless,
+            _  => ConnectionType::Other,
+        }
+    }
+}
+
+impl fmt::Display for ConnectionType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ConnectionType::Ethernet => write!(f, "net_wired"),
+            ConnectionType::Wireless => write!(f, "net_wireless"),
+            ConnectionType::Other => write!(f, "net_other"),
+        }
+    }
+}
+
+struct ConnectionManager {
+}
+
+impl ConnectionManager {
+    pub fn new() -> Self {
+        ConnectionManager {}
+    }
+
+    fn get_property(c: &Connection, property: &str) -> Result<Message> {
+        let m = Message::new_method_call(
+            "org.freedesktop.NetworkManager",
+            "/org/freedesktop/NetworkManager",
+            "org.freedesktop.DBus.Properties",
+            "Get")
+            .block_error("networkmanager", "Failed to create message")?
+            .append2(
+                MessageItem::Str("org.freedesktop.NetworkManager".to_string()),
+                MessageItem::Str(property.to_string())
+            );
+
+        let r = c.send_with_reply_and_block(m, 1000);
+
+        r.block_error("networkmanager", "Failed to retrieve property")
+    }
+
+    pub fn state(&self, c: &Connection) -> Result<NetworkState> {
+        let m = try!(Self::get_property(c, "State"));
+
+        let state: Variant<u32> = m.get1()
+            .block_error("networkmanager", "Failed to read property")?;
+
+        Ok(NetworkState::from(state.0))
+    }
+
+    pub fn connection_type(&self, c: &Connection) -> Result<ConnectionType> {
+        let m = try!(Self::get_property(c, "PrimaryConnectionType"));
+
+        let connection_type: Variant<String> = m.get1()
+            .block_error("networkmanager", "Failed to read property")?;
+
+        Ok(ConnectionType::from(connection_type.0))
+    }
+}
+
+pub struct NetworkManager {
+    id: String,
+    output: TextWidget,
+    dbus_conn: Connection,
+    manager: ConnectionManager,
+    show_type: bool,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkManagerConfig {
+    /// Whether to show the connection type or not.
+    #[serde(default = "NetworkManagerConfig::default_show_type")]
+    pub show_type: bool,
+}
+
+impl NetworkManagerConfig {
+    fn default_show_type() -> bool {
+        true
+    }
+}
+
+impl ConfigBlock for NetworkManager {
+    type Config = NetworkManagerConfig;
+
+    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
+        let id: String = Uuid::new_v4().simple().to_string();
+        let id_copy = id.clone();
+        let dbus_conn = Connection::get_private(BusType::System)
+            .block_error("networkmanager", "failed to establish D-Bus connection")?;
+        let manager = ConnectionManager::new();
+
+        thread::spawn(move || {
+            let c = Connection::get_private(BusType::System).unwrap();
+            let rule = format!(
+                "type='signal',\
+                 path='/org/freedesktop/NetworkManager',\
+                 interface='org.freedesktop.NetworkManager',\
+                 member='StateChanged'");
+
+            c.add_match(&rule).unwrap();
+
+            loop {
+                let timeout = 100000;
+
+                for _event in c.iter(timeout) {
+                    send.send(Task {
+                        id: id.clone(),
+                        update_time: Instant::now(),
+                    });
+                }
+            }
+        });
+
+        Ok(NetworkManager {
+            id: id_copy,
+            output: TextWidget::new(config),
+            dbus_conn: dbus_conn,
+            manager: manager,
+            show_type: block_config.show_type,
+        })
+    }
+}
+
+impl Block for NetworkManager {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let state = self.manager.state(&self.dbus_conn)?;
+        let connection_type = self.manager.connection_type(&self.dbus_conn)?;
+
+        self.output.set_icon(&state.to_string());
+        self.output.set_state(match state {
+            NetworkState::ConnectedGlobal => State::Good,
+            NetworkState::ConnectedSite => State::Info,
+            NetworkState::ConnectedLocal => State::Idle,
+            NetworkState::Connecting => State::Warning,
+            NetworkState::Disconnecting => State::Warning,
+            NetworkState::Asleep => State::Warning,
+            NetworkState::Disconnected => State::Critical,
+            NetworkState::Unknown => State::Critical,
+        });
+
+        if self.show_type {
+            self.output.set_text(connection_type.to_string());
+        }
+
+        Ok(None)
+    }
+
+    fn view(&self) -> Vec<&I3BarWidget> {
+        vec![&self.output]
+    }
+}


### PR DESCRIPTION
This pull request adds a block to receive dbus signals from NetworkManager as suggested in #4.

It's a very basic implementation right now. The block can determine the network status and the device you're connected with your network (primary device).

Suggestions are welcome.