### PR TITLE
Add removable option for battery

### DIFF
--- a/src/icons.rs
+++ b/src/icons.rs
@@ -17,6 +17,7 @@ lazy_static! {
         "bat_full" => " FULL ",
         "bat_charging" => " CHG ",
         "bat_discharging" => " DCG ",
+        "bat_disconnected" => " NC ",
         "update" => " UPD ",
         "toggle_off" => " OFF ",
         "toggle_on" => " ON ",
@@ -64,6 +65,7 @@ lazy_static! {
         "bat_full" => " \u{f240} ",
         "bat_charging" => " \u{f1e6} ",
         "bat_discharging" => " \u{f242} ",
+        "bat_disconnected" => " \u{f244} ", // battery_empty
         "update" => " \u{f062} ",
         "toggle_off" => " \u{f204} ",
         "toggle_on" => " \u{f205} ",
@@ -113,6 +115,7 @@ lazy_static! {
         "bat_full" => " \u{e1a4} ",
         "bat_charging" => " \u{e1a3} ",
         "bat_discharging" => " \u{e19c} ",
+        "bat_disconnected" => " \u{e1a6} ", // battery_unknown
         "update" => " \u{e8d7} ",
         "toggle_off" => " \u{e836} ",
         "toggle_on" => " \u{e837} ",


### PR DESCRIPTION
I recently bought a laptop with a dual hot-swappable battery configuration.
To avoid `i3status-rust` throwing an error every time it is swapped, this adds the option to mark a battery as removable.

Currently, I'm just ignoring all errors from `.status()`, in case the battery is removable. Is this fine or do I should I rather check for the specific errors? Additionally, I'm not quite sure whether my code would be seen as idiomatic Rust. Can this be improved?

Thanks!