### PR TITLE
Fix alternating colors in slick theme

### DIFF
--- a/src/themes.rs
+++ b/src/themes.rs
@@ -2,21 +2,21 @@ use std::str::FromStr;
 
 lazy_static! {
     pub static ref SLICK: Theme = Theme {
-        idle_bg: "#424242de".to_owned(),
+        idle_bg: "#424242".to_owned(),
         idle_fg: "#ffffff".to_owned(),
-        info_bg: "#2196f3de".to_owned(),
+        info_bg: "#2196f3".to_owned(),
         info_fg: "#ffffff".to_owned(),
-        good_bg: "#8bc34ade".to_owned(),
-        good_fg: "#000000de".to_owned(),
-        warning_bg: "#ffc107de".to_owned(),
-        warning_fg: "#000000de".to_owned(),
-        critical_bg: "#f44336de".to_owned(),
+        good_bg: "#8bc34a".to_owned(),
+        good_fg: "#000000".to_owned(),
+        warning_bg: "#ffc107".to_owned(),
+        warning_fg: "#000000".to_owned(),
+        critical_bg: "#f44336".to_owned(),
         critical_fg: "#ffffff".to_owned(),
         separator: "\u{e0b2}".to_owned(),
         separator_bg: "auto".to_owned(),
         separator_fg: "auto".to_owned(),
-        alternating_tint_bg: "#000000".to_owned(),
-        alternating_tint_fg: "#000000".to_owned(),
+        alternating_tint_bg: "#111111".to_owned(),
+        alternating_tint_fg: "#111111".to_owned(),
     };
 
     pub static ref SOLARIZED_DARK: Theme = Theme {


### PR DESCRIPTION
When i recently recompiled i3 to its newest version i noticed the alternating colors of the slick theme not working correctly.

So i looked at the code and noticed that this was implemented very weirdly. The slick theme did not use the alternating tint, which is meant to be used for this, but rather used a (probably) non-intentional behavior of the tinting, in that it removes the fourth color channel (alpha?). This way, the alternating blocks did not have a fourth channel while every other block had one. Now my new version of i3 apparently does not display this fourth channel anymore, which made all the blocks have the same background color.

This change makes the slick theme use the tint. This also inverts the light and dark blocks compared to the previous version, which is not avoidable since we can only tint positively. Also, all the grey backgrounds are a little brighter. I think it looks alright.

Let me know if i got something wrong :)