### PR TITLE
Add power consumption (watt)

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -88,7 +88,15 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `device` | The device in `/sys/class/power_supply/` to read from. | No | `"BAT0"`
 `interval` | Update interval, in seconds. | No | `10`
-`show` | Show remaining 'time', 'percentage' or 'both' | No | `percentage`
+`show` | Format string | No | `{level}%`
+
+### Format string
+
+Placeholder | Description
+------------|-------------
+`{percentage}` | Battery level (in percent) excluding %
+`{time}` | Remaining time (in hh:mm)
+`{power}` | Power consumption (in watt) from battery or from power supply for charging
 
 ## CPU Utilization
 


### PR DESCRIPTION
I added the battery power consumption, but there are some things which needs discussion:
- Adding new values to the `ShowType`-enum for all variants doesn't feel right (see https://github.com/SWW13/i3status-rust/tree/battery_consumption2). I switched to an `Vec` for now.
- I'd love to have an format string for more customization, but that involves adding some sort of template engine and would require some more refactoring. Any plans for generic format solution yet?

![battery_consumption](https://user-images.githubusercontent.com/1280142/44922058-92f96780-ad44-11e8-968f-69b50d9559dd.png)

```toml
[[block]]
block = "battery"
interval = 10
show = ["time", "percentage", "watt"]
```

### TODO:
- [x] Finalize config
- [x]  Update Documentation
- [ ] Add/Update Tests