### PR TITLE
PulseAudio Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "i3ipc 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libpulse-binding 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "maildir 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -319,6 +320,23 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libpulse-binding"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libpulse-sys 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libpulse-sys"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -776,6 +794,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8720f9274907052cb50313f91201597868da9d625f8dd125f2aca5bddb7e83a1"
+"checksum libpulse-binding 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94cf8d18cd66838e8a2d049ea3b3ae6942e88ad007c2d593def703a1e7470e52"
+"checksum libpulse-sys 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a5e1843312173214a21c7f7dabd0e2de467033355ed57366f64aadb2a288f47b"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum maildir 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83d9b449b6ff23db5eda044963296380c74941ac9480fc629840d7405e436c73"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ num = "0.1.42"
 chan = "0.1.21"
 inotify = "0.5.1"
 maildir = "0.1.1"
+libpulse-binding = "^2.2"
 # Used only in debug build mode
 # for profiling blocks
 cpuprofiler = "0.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.9.0"
 authors = ["Kai Greshake <development@kai-greshake.de>",
            "Contributors on GitHub (https://github.com/greshake/i3status-rust/graphs/contributors)"]
 
+[features]
+default = ["pulseaudio"]
+
+pulseaudio = ["libpulse-binding"]
+
+
 [dependencies]
 chrono = "0.4"
 chrono-tz = "0.4"
@@ -22,7 +28,7 @@ num = "0.1.42"
 chan = "0.1.21"
 inotify = "0.5.1"
 maildir = "0.1.1"
-libpulse-binding = "^2.2"
+libpulse-binding = { version = "^2.2", optional = true }
 # Used only in debug build mode
 # for profiling blocks
 cpuprofiler = "0.0.3"

--- a/blocks.md
+++ b/blocks.md
@@ -451,11 +451,11 @@ Creates a block which displays the volume level (according to PulseAudio or ALSA
 
 Requires a PulseAudio installation or `alsa-utils` for ALSA.
 
-PulseAudio support is feature and can be turn on (`--features "pulseaudio"`) / off (`--no-default-features`) during build with `cargo`.  
-If PulseAudio support is enabled the sound block will first try to connect to PulseAudio and then fallback to ALSA on error.
+PulseAudio support is a feature and can be turned on (`--features "pulseaudio"`) / off (`--no-default-features`) during build with `cargo`.  
+If PulseAudio support is enabled the `"auto"` driver will first try to connect to PulseAudio and then fallback to ALSA on error.
 
 
-Note that if you are using PulseAudio commands (such as `pactl`) to control your volume, ALSA (and therefore this block) may not report updates after the volume exceeds 100%. See [#266](https://github.com/greshake/i3status-rust/issues/266#issuecomment-425724196) for some discussion.
+Note that if you are using PulseAudio commands (such as `pactl`) to control your volume, you should select the `"pulseaudio"` (or `"auto"`) driver to see volume changes that exceed 100%.
 
 ### Examples
 
@@ -471,6 +471,7 @@ step_width = 3
 
 Key | Values | Required | Default
 ----|--------|----------|--------
+`driver` | `"auto"`, `"pulseaudio"`, `"alsa"` | No | `"auto"` (Pulseaudio with ALSA fallback)
 `name` | PulseAudio / ALSA device name | No | Default Device (`@DEFAULT_SINK@` / `Master`)
 `step_width` | The percent volume level is increased/decreased for the selected audio device when scrolling. Capped automatically at 50. | No | `5`
 `on_click` | Shell command to run when the sound block is clicked. | No | None

--- a/blocks.md
+++ b/blocks.md
@@ -447,9 +447,13 @@ Key | Values | Required | Default
 
 ## Sound
 
-Creates a block which displays the volume level (according to ALSA). Right click to toggle mute, scroll to adjust volume.
+Creates a block which displays the volume level (according to PulseAudio or ALSA). Right click to toggle mute, scroll to adjust volume.
 
-Requires `alsa-utils`.
+Requires a PulseAudio installation or `alsa-utils` for ALSA.
+
+PulseAudio support is feature and can be turn on (`--features "pulseaudio"`) / off (`--no-default-features`) during build with `cargo`.  
+If PulseAudio support is enabled the sound block will first try to connect to PulseAudio and then fallback to ALSA on error.
+
 
 Note that if you are using PulseAudio commands (such as `pactl`) to control your volume, ALSA (and therefore this block) may not report updates after the volume exceeds 100%. See [#266](https://github.com/greshake/i3status-rust/issues/266#issuecomment-425724196) for some discussion.
 
@@ -467,6 +471,7 @@ step_width = 3
 
 Key | Values | Required | Default
 ----|--------|----------|--------
+`name` | PulseAudio / ALSA device name | No | Default Device (`@DEFAULT_SINK@` / `Master`)
 `step_width` | The percent volume level is increased/decreased for the selected audio device when scrolling. Capped automatically at 50. | No | `5`
 `on_click` | Shell command to run when the sound block is clicked. | No | None
 

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -297,6 +297,11 @@ impl PulseAudioClient {
             };
 
             loop {
+                // make sure mainloop dispatched everything
+                for _ in 0..10 {
+                    connection.iterate(false).unwrap();
+                }
+
                 match recv_req.recv() {
                     None => { },
                     Some(req) => {
@@ -321,6 +326,7 @@ impl PulseAudioClient {
                             // PulseAudioClientRequest::QuitClient => { break; }
                         };
 
+                        // send request and receive response
                         connection.iterate(true).unwrap();
                         connection.iterate(true).unwrap();
                     }

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -39,23 +39,6 @@ trait SoundDevice {
     fn monitor(&mut self, id: String, tx_update_request: Sender<Task>) { }
 }
 
-enum GenericSoundDevice {
-    AlsaSoundDevice(AlsaSoundDevice),
-    PulseAudioSoundDevice(PulseAudioSoundDevice)
-}
-
-impl From<AlsaSoundDevice> for GenericSoundDevice {
-    fn from(device: AlsaSoundDevice) -> Self {
-        GenericSoundDevice::AlsaSoundDevice(device)
-    }
-}
-impl From<PulseAudioSoundDevice> for GenericSoundDevice {
-    fn from(device: PulseAudioSoundDevice) -> Self {
-        GenericSoundDevice::PulseAudioSoundDevice(device)
-    }
-}
-
-
 struct AlsaSoundDevice {
     name: String,
     volume: u32,

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -209,7 +209,6 @@ enum PulseAudioClientRequest {
 
 #[cfg(feature = "pulseaudio")]
 lazy_static! {
-    // TODO: catch errors somehow
     static ref PULSEAUDIO_CLIENT: Result<PulseAudioClient> = PulseAudioClient::new();
     static ref PULSEAUDIO_EVENT_LISTENER: Mutex<HashMap<String, Sender<Task>>> = Mutex::new(HashMap::new());
     static ref PULSEAUDIO_DEFAULT_SINK: Mutex<String> = Mutex::new("@DEFAULT_SINK@".into());
@@ -606,7 +605,6 @@ impl ConfigBlock for Sound {
             step_width = 50;
         }
 
-        // TODO: fix pulseaudio with alsa fallback
         #[cfg(feature = "pulseaudio")]
         let pulseaudio_device = match block_config.name.clone() {
             None => PulseAudioSoundDevice::new(),
@@ -618,6 +616,7 @@ impl ConfigBlock for Sound {
             "PulseAudio feature disabled".into(),
         ));
         
+        // prefere PulseAudio if available, fallback to ALSA
         let device: Box<SoundDevice> = match pulseaudio_device {
             Ok(dev) => Box::new(dev),
             Err(_) => Box::new(AlsaSoundDevice::new(block_config.name.unwrap_or_else(|| "Master".into()))?)

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -180,7 +180,6 @@ struct PulseAudioClient {
 
 #[cfg(feature = "pulseaudio")]
 struct PulseAudioSoundDevice {
-    // client: PulseAudioClient,
     name: Option<String>,
     volume: Option<ChannelVolumes>,
     volume_avg: u32,
@@ -200,11 +199,8 @@ enum PulseAudioClientRequest {
     GetDefaultDevice,
     GetSinkInfoByIndex(u32),
     GetSinkInfoByName(String),
-    // SetSinkVolumeByIndex(u32, ChannelVolumes),
     SetSinkVolumeByName(String, ChannelVolumes),
-    // SetSinkMuteByIndex(u32, bool),
     SetSinkMuteByName(String, bool),
-    // QuitClient,
 }
 
 #[cfg(feature = "pulseaudio")]
@@ -337,7 +333,6 @@ impl PulseAudioClient {
                             PulseAudioClientRequest::SetSinkMuteByName(name, mute) => {
                                 introspector.set_sink_mute_by_name(&name, mute, None);
                             },
-                            // PulseAudioClientRequest::QuitClient => { break; }
                         };
 
                         // send request and receive response

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -191,10 +191,10 @@ impl PulseAudioSoundDevice {
         proplist.sets(properties::APPLICATION_NAME, "i3status-rs")
             .block_error("sound", "could not set pulseaudio APPLICATION_NAME poperty")?;
 
-        let mut mainloop = Rc::new(RefCell::new(Mainloop::new()
+        let mainloop = Rc::new(RefCell::new(Mainloop::new()
             .block_error("sound", "failed to create pulseaudio mainloop")?));
 
-        let mut context = Rc::new(RefCell::new(Context::new_with_proplist(
+        let context = Rc::new(RefCell::new(Context::new_with_proplist(
             mainloop.borrow().deref(),
             "i3status-rs_context",
             &proplist

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -319,7 +319,6 @@ pub struct Sound {
     id: String,
     device: Box<SoundDevice>,
     step_width: u32,
-    current_idx: usize,
     config: Config,
     on_click: Option<String>,
 }
@@ -421,7 +420,6 @@ impl ConfigBlock for Sound {
             id: id.clone(),
             device,
             step_width: step_width,
-            current_idx: 0,
             config: config,
             on_click: block_config.on_click,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ extern crate inotify;
 extern crate maildir;
 extern crate chrono;
 extern crate chrono_tz;
+extern crate libpulse_binding as pulse;
 
 #[macro_use]
 mod de;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ extern crate inotify;
 extern crate maildir;
 extern crate chrono;
 extern crate chrono_tz;
+#[cfg(feature = "pulseaudio")]
 extern crate libpulse_binding as pulse;
 
 #[macro_use]


### PR DESCRIPTION
I started working on PulseAudio support (#20).

Currently the connection to the PulseAudio server works. Retrieving the current state will require callbacks as the PulseAudio library doesn't offer synchronous calls. Besides getting the callbacks to work the whole sound block should be refactored to work with different audio systems.

Current State:
- [x] retrieve volume / mute state
- [x] listen to state changes
- [x] increase / decrease volume
- [x] mute / unmute
- [x] pulse audio / alsa fallback
- [x] clean up
- [x] documentation