### PR TITLE
remove all residual use of the `try!` macro

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -231,7 +231,7 @@ impl ConfigBlock for Battery {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
             output: TextWidget::new(config),
-            device: try!(PowerSupplyDevice::from_device(block_config.device)),
+            device: PowerSupplyDevice::from_device(block_config.device)?,
             show: block_config.show,
         })
     }

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -109,7 +109,7 @@ impl ConnectionManager {
     }
 
     pub fn state(&self, c: &Connection) -> Result<NetworkState> {
-        let m = try!(Self::get_property(c, "State"));
+        let m = Self::get_property(c, "State")?;
 
         let state: Variant<u32> = m.get1()
             .block_error("networkmanager", "Failed to read property")?;
@@ -118,7 +118,7 @@ impl ConnectionManager {
     }
 
     pub fn connection_type(&self, c: &Connection) -> Result<ConnectionType> {
-        let m = try!(Self::get_property(c, "PrimaryConnectionType"));
+        let m = Self::get_property(c, "PrimaryConnectionType")?;
 
         let connection_type: Variant<String> = m.get1()
             .block_error("networkmanager", "Failed to read property")?;


### PR DESCRIPTION
Since the rest of the code base is not using it, might as well keep some consistency