### PR TITLE
Fix rotating text widget width

### DIFF
--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -126,7 +126,7 @@ impl RotatingTextWidget {
                                 self.get_rotated_content()),
             "separator": false,
             "separator_block_width": 0,
-            "min_width": if self.content == "" {"".to_string()} else {"0".repeat(self.width)},
+            "min_width": if self.content == "" {"".to_string()} else {"0".repeat(self.width+5)},
             "align": "left",
             "background": key_bg,
             "color": key_fg

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -126,7 +126,7 @@ impl RotatingTextWidget {
                                 self.get_rotated_content()),
             "separator": false,
             "separator_block_width": 0,
-            "min_width": if self.content == "" {0} else {240},
+            "min_width": if self.content == "" {"".to_string()} else {"0".repeat(self.width)},
             "align": "left",
             "background": key_bg,
             "color": key_fg


### PR DESCRIPTION
Currently the minimum size of the block is hardcoded to 240 pixels for reasons unknown.
This leads to issues such as #223 with the music block.

Proposed changes:
- set `min_width` based on the user provided `width` value
- `min_width` should be set by characters (by passing a string) instead of by pixels

EDIT:
**1) Fixed the max_width setting for the widget**
Before (latest i3status-git, max_width set to 10 yet block size is large)
![ezgif-3-bd71b56c94](https://user-images.githubusercontent.com/20397027/45302294-e0988000-b54d-11e8-8357-9566d922f34b.gif)

After (this PR):
![ezgif-3-367da31595](https://user-images.githubusercontent.com/20397027/45302360-1473a580-b54e-11e8-8526-60fd17363264.gif)

**2) Fixed the 'jitter' during scrolling:**
Before (latest i3status-git):
![ezgif-3-78bdb17443](https://user-images.githubusercontent.com/20397027/45301497-10df1f00-b54c-11e8-8ff3-b1e7ba30f3e1.gif)

After (this PR):
![ezgif-3-1cc0242860 1](https://user-images.githubusercontent.com/20397027/45301689-687d8a80-b54c-11e8-82e5-2a7a64182e82.gif)