### PR TITLE
Allow use of pango markup in separator

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -136,7 +136,7 @@ pub fn print_blocks(order: &Vec<String>, block_map: &HashMap<String, &mut Block>
                     "separator_block_width": 0,
                     "background": if sep_bg.is_some() { Value::String(sep_bg.unwrap()) } else { Value::Null },
                     "color": sep_fg,
-                    "markup": pango
+                    "markup": "pango"
                 });
         print!("{}{},", if state.has_predecessor { "," } else { "" },
                separator.to_string());

--- a/src/util.rs
+++ b/src/util.rs
@@ -135,7 +135,8 @@ pub fn print_blocks(order: &Vec<String>, block_map: &HashMap<String, &mut Block>
                     "separator": false,
                     "separator_block_width": 0,
                     "background": if sep_bg.is_some() { Value::String(sep_bg.unwrap()) } else { Value::Null },
-                    "color": sep_fg
+                    "color": sep_fg,
+                    "markup": pango
                 });
         print!("{}{},", if state.has_predecessor { "," } else { "" },
                separator.to_string());


### PR DESCRIPTION
By using [pango markup](https://i3wm.org/docs/i3bar-protocol.html) we can set the font type, size, etc individually just for the separator block, which can be useful in debugging/fixing font issues or just in terms of customisation.

eg in config.toml:
```
[theme.overrides]
separator = "<span font='FontJustForSeparator 12'></span>"
```