### PR TITLE
Removed duplicated Maildir link

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -20,7 +20,6 @@
 - [Toggle](#toggle)
 - [Weather](#weather)
 - [Xrandr](#xrandr)
-- [Maildir](#maildir)
 
 ## Backlight
 


### PR DESCRIPTION
The internal link 'maildir' has duplicated in the page