### PR TITLE
Add IBus block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -205,9 +205,9 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `max_width` | Truncates titles to this length. | No | `21`
 
-## ibus
+## IBus
 
-Creates a block which displays the current global engine set in ibus. Updates are instant as D-Bus signalling is used.
+Creates a block which displays the current global engine set in [IBus](https://wiki.archlinux.org/index.php/IBus). Updates are instant as D-Bus signalling is used.
 
 ### Examples
 

--- a/blocks.md
+++ b/blocks.md
@@ -6,6 +6,7 @@
 - [Custom](#custom)
 - [Disk Space](#disk-space)
 - [Focused Window](#focused-window)
+- [ibus](#ibus)
 - [Load](#load)
 - [Maildir](#maildir)
 - [Memory](#memory)
@@ -203,6 +204,17 @@ max_width = 21
 Key | Values | Required | Default
 ----|--------|----------|--------
 `max_width` | Truncates titles to this length. | No | `21`
+
+## ibus
+
+Creates a block which displays the current global engine set in ibus. Updates are instant as D-Bus signalling is used.
+
+### Examples
+
+```toml
+[[block]]
+block = "ibus"
+```
 
 ## Load
 

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -154,8 +154,10 @@ fn parse_msg(ci: &ConnectionItem) -> Option<&str> {
 fn get_ibus_address() -> Result<String> {
     // TODO: Check IBUS_ADDRESS variable, as it seems it can be manually set too.
 
+    // TODO: Don't fail if $XDG_CONFIG_HOME is not set. 
+    // Next try $HOME/.config, then only error if that $HOME is not set.
     let config_dir = env::var("XDG_CONFIG_HOME")
-        .block_error("ibus", "Problem getting $XDG_CONFIG_HOME")?;
+        .block_error("ibus", "$XDG_CONFIG_HOME not set")?;
 
     // TODO: Check /var/lib/dbus/machine-id if /etc/machine-id fails
     let mut f = File::open("/etc/machine-id")

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -185,7 +185,7 @@ fn get_ibus_address() -> Result<String> {
         .block_error("ibus", &format!("Could not open {}", ibus_socket_path))?;
     let mut ibus_address = String::new();
     f.read_to_string(&mut ibus_address)
-        .block_error("ibus", &format!("Error reading contents of {}", ibus_address))?;
+        .block_error("ibus", &format!("Error reading contents of {}", ibus_socket_path))?;
     let re = Regex::new(r"IBUS_ADDRESS=(.*),guid").unwrap(); // valid regex expression will not cause panic
     let cap = re.captures(&ibus_address)
         .block_error("ibus", &format!("Failed to extract address out of {}", ibus_address))?;

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -1,0 +1,170 @@
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+use chan::Sender;
+
+use block::{Block, ConfigBlock};
+use config::Config;
+use errors::*;
+use widgets::text::TextWidget;
+use widget::I3BarWidget;
+use input::I3BarEvent;
+use scheduler::Task;
+
+use uuid::Uuid;
+
+extern crate dbus;
+extern crate regex;
+use self::dbus::{Connection, ConnectionItem, stdintf, arg};
+use self::regex::Regex;
+
+pub struct IBus {
+    id: String,
+    text: TextWidget,
+    engine: Arc<Mutex<String>>,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct IBusConfig {
+    /// Set to display engine name as icon.
+    #[serde(default = "IBusConfig::default_as_icon")]
+    pub as_icon: bool,
+}
+
+impl IBusConfig {
+    fn default_as_icon() -> bool {
+        true
+    }
+}
+
+impl ConfigBlock for IBus {
+    type Config = IBusConfig;
+
+    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
+        let id: String = Uuid::new_v4().simple().to_string();
+        let id_copy = id.clone();
+
+        let ibus_address = get_ibus_address();
+        let c = Connection::open_private(&ibus_address)
+            .block_error("ibus", "failed to establish D-Bus connection")?;
+        let p = c.with_path("org.freedesktop.IBus", "/org/freedesktop/IBus", 5000);
+        use blocks::dbus::stdintf::org_freedesktop_dbus::Properties;
+        let info: arg::Variant<Box<arg::RefArg>> = p.get("org.freedesktop.IBus", "GlobalEngine").unwrap();
+
+        // info should contain something containing an array with the contents as such:
+        // [name, longname, description, language, license, author, icon, layout, layout_variant, layout_option, rank, hotkeys, symbol, setup, version, textdomain, icon_prop_key]
+        // Refer to: https://github.com/ibus/ibus/blob/7cef5bf572596361bc502e8fa917569676a80372/src/ibusenginedesc.c
+        // e.g.
+        // ["IBusEngineDesc", {}, "xkb:us::eng", "English (US)", "English (US)", "en", "GPL", "Peng Huang <shawn.p.huang@gmail.com>", "ibus-keyboard", "us", 99, "", "", "", "", "", "", "", ""]
+        // We will use the 3rd element of the array which corresponds to 'name' (of the current global IBus engine)
+
+        let current = info.0.as_iter().unwrap().nth(2).unwrap().as_str().unwrap_or("??");
+        let mut engine_original = Arc::new(Mutex::new(String::from(current)));
+
+        let engine = engine_original.clone();
+        thread::spawn(move || {
+            let c = Connection::open_private(&ibus_address).unwrap();
+            c.add_match(
+                "interface='org.freedesktop.IBus',member='GlobalEngineChanged'",
+            ).unwrap();
+            loop {
+                for ci in c.iter(100000) {
+                    if let Some(engine_name) = parse_msg(&ci) {
+                            let mut engine = engine_original.lock().unwrap();
+                            *engine = engine_name.to_string();
+                            // tell block to update now
+                            send.send(Task {
+                                id: id.clone(),
+                                update_time: Instant::now(),
+                            });
+                    };
+                }
+            }
+        });
+
+        Ok(IBus {
+            id: id_copy,
+            text: TextWidget::new(config.clone()).with_text("IBus"),
+            engine
+        })
+    }
+}
+
+impl Block for IBus {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let mut string = (*self.engine
+            .lock()
+            .block_error("ibus", "failed to acquire lock")?)
+            .clone();
+        self.text.set_text(string);
+        Ok(None)
+    }
+
+    fn view(&self) -> Vec<&I3BarWidget> {
+        vec![&self.text]
+    }
+
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn parse_msg(ci: &ConnectionItem) -> Option<&str> {
+    let m = if let &ConnectionItem::Signal(ref s) = ci { s } else { return None };
+    if &*m.interface().unwrap() != "org.freedesktop.IBus" { return None };
+    if &*m.member().unwrap() != "GlobalEngineChanged" { return None };
+    let engine = m.get1::<&str>();
+    engine
+}
+
+fn get_ibus_address() -> String {
+    // By default ibus will write the ibus address to the file
+    // $XDG_CONFIG_HOME/ibus/bus/aaa-bbb-ccc, along with some other info.
+    // with aaa = dbus machine id, usually found at /etc/machine-id
+    //      bbb = hostname - seems to be "unix" in most cases [see L99 of reference]
+    //      ccc = display number from $DISPLAY
+    // Refer to: https://github.com/ibus/ibus/blob/7cef5bf572596361bc502e8fa917569676a80372/src/ibusshare.c
+    //
+    // Example file contents:
+    // # This file is created by ibus-daemon, please do not modify it
+    // IBUS_ADDRESS=unix:abstract=/tmp/dbus-8EeieDfT,guid=7542d73dce451c2461a044e24bc131f4
+    // IBUS_DAEMON_PID=11140
+
+    let config_dir = env::var("XDG_CONFIG_HOME").expect("env var not set?");
+
+    // Do we need to check /var/lib/dbus/machine-id too ??
+    let mut f = File::open("/etc/machine-id").expect("file not found");
+    let mut machine_id = String::new();
+    f.read_to_string(&mut machine_id).expect("something went wrong reading the file");
+    let machine_id = machine_id.trim();
+
+    // TODO: Fix kludge that defaults DISPLAY to '0' on error
+    // Had to implement this as when starting sway on first login,
+    // $DISPLAY doesn't seem to be set until after swaybar is finished being processed.
+    // Possibly because XWayland is only started after swaybar?
+    // Even if I add a 10second delay here it will panic with just a simple unwrap.
+    let display = env::var("DISPLAY").unwrap_or("0".to_string());
+    let re = Regex::new(r"^:(\d{1})$").unwrap();
+    let cap = re.captures(&display).unwrap();
+    let display = &cap[1].to_string();
+
+    let hostname = String::from("unix");
+
+    let ibus_socket_path = format!("{}/ibus/bus/{}-{}-{}", config_dir, machine_id, hostname, display);
+
+    let mut f = File::open(ibus_socket_path).expect("file not found");
+    let mut ibus_address = String::new();
+    f.read_to_string(&mut ibus_address).expect("something went wrong reading the file");
+    let re = Regex::new(r"IBUS_ADDRESS=(.*),guid").unwrap();
+    let cap = re.captures(&ibus_address).unwrap();
+    let ibus_address = &cap[1];
+    ibus_address.to_string()
+}

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -74,10 +74,10 @@ impl ConfigBlock for IBus {
 
         let engine = engine_original.clone();
         thread::spawn(move || {
-            let c = Connection::open_private(&ibus_address).unwrap();
+            let c = Connection::open_private(&ibus_address).expect("Failed to establish D-Bus connection in thread");
             c.add_match(
                 "interface='org.freedesktop.IBus',member='GlobalEngineChanged'",
-            ).unwrap();
+            ).expect("Failed to add D-Bus message rule - has IBus interface changed?");
             loop {
                 for ci in c.iter(100000) {
                     if let Some(engine_name) = parse_msg(&ci) {
@@ -173,7 +173,7 @@ fn get_ibus_address() -> Result<String> {
     // Hence on sway you will need to reload the bar once after login to get the block to work.
     let display_var = env::var("DISPLAY")
         .block_error("ibus", "$DISPLAY not set. Try restarting bar if on sway")?;
-    let re = Regex::new(r"^:(\d{1})$").unwrap();
+    let re = Regex::new(r"^:(\d{1})$").unwrap(); // valid regex expression will not cause panic
     let cap = re.captures(&display_var)
         .block_error("ibus", "Failed to extract display number from $DISPLAY")?;
     let display_number = &cap[1].to_string();
@@ -186,7 +186,7 @@ fn get_ibus_address() -> Result<String> {
     let mut ibus_address = String::new();
     f.read_to_string(&mut ibus_address)
         .block_error("ibus", &format!("Error reading contents of {}", ibus_address))?;
-    let re = Regex::new(r"IBUS_ADDRESS=(.*),guid").unwrap();
+    let re = Regex::new(r"IBUS_ADDRESS=(.*),guid").unwrap(); // valid regex expression will not cause panic
     let cap = re.captures(&ibus_address)
         .block_error("ibus", &format!("Failed to extract address out of {}", ibus_address))?;
     let ibus_address = &cap[1];

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -51,7 +51,6 @@ impl ConfigBlock for IBus {
         let c = Connection::open_private(&ibus_address)
             .block_error("ibus", &format!("Failed to establish D-Bus connection to {}", ibus_address))?;
         let p = c.with_path("org.freedesktop.IBus", "/org/freedesktop/IBus", 5000);
-        use blocks::dbus::stdintf::org_freedesktop_dbus::Properties;
         let info: arg::Variant<Box<arg::RefArg>> = p.get("org.freedesktop.IBus", "GlobalEngine")
             .block_error("ibus", "Failed to query IBus")?;
 

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -102,11 +102,11 @@ impl Block for IBus {
 
     // Updates the internal state of the block.
     fn update(&mut self) -> Result<Option<Duration>> {
-        let string = (*self.engine
+        let engine = (*self.engine
             .lock()
             .block_error("ibus", "failed to acquire lock")?)
             .clone();
-        self.text.set_text(string);
+        self.text.set_text(engine);
         Ok(None)
     }
 

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -49,13 +49,13 @@ impl ConfigBlock for IBus {
         let id_copy = id.clone();
 
         let ibus_address = get_ibus_address()
-            .block_error("ibus", "Could not get ibus address")?;
+            .block_error("ibus", "Could not get IBus address")?;
         let c = Connection::open_private(&ibus_address)
             .block_error("ibus", &format!("Failed to establish D-Bus connection to {}", ibus_address))?;
         let p = c.with_path("org.freedesktop.IBus", "/org/freedesktop/IBus", 5000);
         use blocks::dbus::stdintf::org_freedesktop_dbus::Properties;
         let info: arg::Variant<Box<arg::RefArg>> = p.get("org.freedesktop.IBus", "GlobalEngine")
-            .block_error("ibus", "Couldn't get ibus address")?;
+            .block_error("ibus", "Failed to query IBus")?;
 
         // `info` should contain something containing an array with the contents as such:
         // [name, longname, description, language, license, author, icon, layout, layout_variant, layout_option, rank, hotkeys, symbol, setup, version, textdomain, icon_prop_key]

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -4,21 +4,20 @@ use std::io::prelude::*;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
-use chan::Sender;
 
 use block::{Block, ConfigBlock};
 use config::Config;
 use errors::*;
 use input::I3BarEvent;
 use scheduler::Task;
-use uuid::Uuid;
 use widgets::text::TextWidget;
 use widget::I3BarWidget;
 
-extern crate dbus;
-extern crate regex;
-use self::dbus::{Connection, ConnectionItem, arg};
-use self::regex::Regex;
+use chan::Sender;
+use blocks::dbus::{Connection, ConnectionItem, arg};
+use blocks::dbus::stdintf::org_freedesktop_dbus::Properties;
+use regex::Regex;
+use uuid::Uuid;
 
 pub struct IBus {
     id: String,

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -9,16 +9,15 @@ use chan::Sender;
 use block::{Block, ConfigBlock};
 use config::Config;
 use errors::*;
-use widgets::text::TextWidget;
-use widget::I3BarWidget;
 use input::I3BarEvent;
 use scheduler::Task;
-
 use uuid::Uuid;
+use widgets::text::TextWidget;
+use widget::I3BarWidget;
 
 extern crate dbus;
 extern crate regex;
-use self::dbus::{Connection, ConnectionItem, stdintf, arg};
+use self::dbus::{Connection, ConnectionItem, arg};
 use self::regex::Regex;
 
 pub struct IBus {
@@ -30,13 +29,14 @@ pub struct IBus {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct IBusConfig {
-    /// Set to display engine name as icon.
-    #[serde(default = "IBusConfig::default_as_icon")]
+    /// TODO: Implement this.
+    /// Set to display engine name as the two letter country abbreviation, e.g. "jp".
+    #[serde(default = "IBusConfig::default_abbreviate")]
     pub as_icon: bool,
 }
 
 impl IBusConfig {
-    fn default_as_icon() -> bool {
+    fn default_abbreviate() -> bool {
         true
     }
 }
@@ -44,26 +44,27 @@ impl IBusConfig {
 impl ConfigBlock for IBus {
     type Config = IBusConfig;
 
-    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
+    fn new(_block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
         let id: String = Uuid::new_v4().simple().to_string();
         let id_copy = id.clone();
 
-        let ibus_address = get_ibus_address();
+        let ibus_address = get_ibus_address()
+            .block_error("ibus", "Could not get ibus address")?;
         let c = Connection::open_private(&ibus_address)
-            .block_error("ibus", "failed to establish D-Bus connection")?;
+            .block_error("ibus", &format!("Failed to establish D-Bus connection to {}", ibus_address))?;
         let p = c.with_path("org.freedesktop.IBus", "/org/freedesktop/IBus", 5000);
         use blocks::dbus::stdintf::org_freedesktop_dbus::Properties;
-        let info: arg::Variant<Box<arg::RefArg>> = p.get("org.freedesktop.IBus", "GlobalEngine").unwrap();
+        let info: arg::Variant<Box<arg::RefArg>> = p.get("org.freedesktop.IBus", "GlobalEngine")
+            .block_error("ibus", "Couldn't get ibus address")?;
 
-        // info should contain something containing an array with the contents as such:
-        // [name, longname, description, language, license, author, icon, layout, layout_variant, layout_option, rank, hotkeys, symbol, setup, version, textdomain, icon_prop_key]
-        // Refer to: https://github.com/ibus/ibus/blob/7cef5bf572596361bc502e8fa917569676a80372/src/ibusenginedesc.c
-        // e.g.
-        // ["IBusEngineDesc", {}, "xkb:us::eng", "English (US)", "English (US)", "en", "GPL", "Peng Huang <shawn.p.huang@gmail.com>", "ibus-keyboard", "us", 99, "", "", "", "", "", "", "", ""]
-        // We will use the 3rd element of the array which corresponds to 'name' (of the current global IBus engine)
-
+        /// `info` should contain something containing an array with the contents as such:
+        /// [name, longname, description, language, license, author, icon, layout, layout_variant, layout_option, rank, hotkeys, symbol, setup, version, textdomain, icon_prop_key]
+        /// Refer to: https://github.com/ibus/ibus/blob/7cef5bf572596361bc502e8fa917569676a80372/src/ibusenginedesc.c
+        /// e.g.                   name           longname        description     language
+        /// ["IBusEngineDesc", {}, "xkb:us::eng", "English (US)", "English (US)", "en", "GPL", "Peng Huang <shawn.p.huang@gmail.com>", "ibus-keyboard", "us", 99, "", "", "", "", "", "", "", ""]
+        ///                         ↑ We will use this element (name) as it is what GlobalEngineChanged signal returns.
         let current = info.0.as_iter().unwrap().nth(2).unwrap().as_str().unwrap_or("??");
-        let mut engine_original = Arc::new(Mutex::new(String::from(current)));
+        let engine_original = Arc::new(Mutex::new(String::from(current)));
 
         let engine = engine_original.clone();
         thread::spawn(move || {
@@ -76,7 +77,7 @@ impl ConfigBlock for IBus {
                     if let Some(engine_name) = parse_msg(&ci) {
                             let mut engine = engine_original.lock().unwrap();
                             *engine = engine_name.to_string();
-                            // tell block to update now
+                            /// Tell block to update now.
                             send.send(Task {
                                 id: id.clone(),
                                 update_time: Instant::now(),
@@ -99,8 +100,9 @@ impl Block for IBus {
         &self.id
     }
 
+    /// Updates the internal state of the block.
     fn update(&mut self) -> Result<Option<Duration>> {
-        let mut string = (*self.engine
+        let string = (*self.engine
             .lock()
             .block_error("ibus", "failed to acquire lock")?)
             .clone();
@@ -108,10 +110,14 @@ impl Block for IBus {
         Ok(None)
     }
 
+    /// Returns the view of the block, comprised of widgets.
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
 
+    /// This function is called on every block for every click.
+    /// TODO: Filter events by using the event.name property,
+    /// and use to switch between input engines?
     fn click(&mut self, _: &I3BarEvent) -> Result<()> {
         Ok(())
     }
@@ -125,33 +131,40 @@ fn parse_msg(ci: &ConnectionItem) -> Option<&str> {
     engine
 }
 
-fn get_ibus_address() -> String {
-    // By default ibus will write the ibus address to the file
-    // $XDG_CONFIG_HOME/ibus/bus/aaa-bbb-ccc, along with some other info.
-    // with aaa = dbus machine id, usually found at /etc/machine-id
-    //      bbb = hostname - seems to be "unix" in most cases [see L99 of reference]
-    //      ccc = display number from $DISPLAY
-    // Refer to: https://github.com/ibus/ibus/blob/7cef5bf572596361bc502e8fa917569676a80372/src/ibusshare.c
-    //
-    // Example file contents:
-    // # This file is created by ibus-daemon, please do not modify it
-    // IBUS_ADDRESS=unix:abstract=/tmp/dbus-8EeieDfT,guid=7542d73dce451c2461a044e24bc131f4
-    // IBUS_DAEMON_PID=11140
+/// Gets the address being used by the currently running ibus daemon.
+/// 
+/// By default ibus will write the address to `$XDG_CONFIG_HOME/ibus/bus/aaa-bbb-ccc`
+/// where aaa = dbus machine id, usually found at /etc/machine-id
+///       bbb = hostname - seems to be "unix" in most cases [see L99 of reference]
+///       ccc = display number from $DISPLAY
+/// Refer to: https://github.com/ibus/ibus/blob/7cef5bf572596361bc502e8fa917569676a80372/src/ibusshare.c
+///
+/// Example file contents:
+/// ```
+/// # This file is created by ibus-daemon, please do not modify it
+/// IBUS_ADDRESS=unix:abstract=/tmp/dbus-8EeieDfT,guid=7542d73dce451c2461a044e24bc131f4
+/// IBUS_DAEMON_PID=11140
+/// ```
+fn get_ibus_address() -> Result<String> {
+    /// TODO: Check IBUS_ADDRESS variable, as it seems it can be manually set too.
 
-    let config_dir = env::var("XDG_CONFIG_HOME").expect("env var not set?");
+    let config_dir = env::var("XDG_CONFIG_HOME")
+        .block_error("ibus", "Problem getting $XDG_CONFIG_HOME")?;
 
-    // Do we need to check /var/lib/dbus/machine-id too ??
-    let mut f = File::open("/etc/machine-id").expect("file not found");
+    /// TODO: Check /var/lib/dbus/machine-id if /etc/machine-id fails
+    let mut f = File::open("/etc/machine-id")
+        .block_error("ibus", "Could not open /etc/machine-id")?;
     let mut machine_id = String::new();
-    f.read_to_string(&mut machine_id).expect("something went wrong reading the file");
+    f.read_to_string(&mut machine_id)
+        .block_error("ibus", "Something went wrong reading /etc/machine-id")?;
     let machine_id = machine_id.trim();
 
-    // TODO: Fix kludge that defaults DISPLAY to '0' on error
-    // Had to implement this as when starting sway on first login,
-    // $DISPLAY doesn't seem to be set until after swaybar is finished being processed.
-    // Possibly because XWayland is only started after swaybar?
-    // Even if I add a 10second delay here it will panic with just a simple unwrap.
-    let display = env::var("DISPLAY").unwrap_or("0".to_string());
+    /// On sway, $DISPLAY is only set by programs requiring xwayland, such as ibus (GTK2).
+    /// ibus-daemon can be autostarted by sway (via an entry in config file), however since
+    /// the bar is executed first, $DISPLAY will not yet be set at the time this code runs.
+    /// Hence on sway you will need to reload the bar once after login to get the block to work.
+    let display = env::var("DISPLAY")
+        .block_error("ibus", "$DISPLAY not set. Try restarting block if on sway")?;
     let re = Regex::new(r"^:(\d{1})$").unwrap();
     let cap = re.captures(&display).unwrap();
     let display = &cap[1].to_string();
@@ -159,12 +172,14 @@ fn get_ibus_address() -> String {
     let hostname = String::from("unix");
 
     let ibus_socket_path = format!("{}/ibus/bus/{}-{}-{}", config_dir, machine_id, hostname, display);
-
     let mut f = File::open(ibus_socket_path).expect("file not found");
     let mut ibus_address = String::new();
     f.read_to_string(&mut ibus_address).expect("something went wrong reading the file");
     let re = Regex::new(r"IBUS_ADDRESS=(.*),guid").unwrap();
     let cap = re.captures(&ibus_address).unwrap();
     let ibus_address = &cap[1];
-    ibus_address.to_string()
+    
+    Ok(
+        ibus_address.to_string()
+    )
 }

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -164,7 +164,7 @@ fn get_ibus_address() -> Result<String> {
     // the bar is executed first, $DISPLAY will not yet be set at the time this code runs.
     // Hence on sway you will need to reload the bar once after login to get the block to work.
     let display = env::var("DISPLAY")
-        .block_error("ibus", "$DISPLAY not set. Try restarting block if on sway")?;
+        .block_error("ibus", "$DISPLAY not set. Try restarting bar if on sway")?;
     let re = Regex::new(r"^:(\d{1})$").unwrap();
     let cap = re.captures(&display).unwrap();
     let display = &cap[1].to_string();

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -29,8 +29,8 @@ pub struct IBus {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct IBusConfig {
-    /// TODO: Implement this.
-    /// Set to display engine name as the two letter country abbreviation, e.g. "jp".
+    // TODO: Implement this.
+    // Set to display engine name as the two letter country abbreviation, e.g. "jp".
     #[serde(default = "IBusConfig::default_abbreviate")]
     pub as_icon: bool,
 }
@@ -57,12 +57,12 @@ impl ConfigBlock for IBus {
         let info: arg::Variant<Box<arg::RefArg>> = p.get("org.freedesktop.IBus", "GlobalEngine")
             .block_error("ibus", "Couldn't get ibus address")?;
 
-        /// `info` should contain something containing an array with the contents as such:
-        /// [name, longname, description, language, license, author, icon, layout, layout_variant, layout_option, rank, hotkeys, symbol, setup, version, textdomain, icon_prop_key]
-        /// Refer to: https://github.com/ibus/ibus/blob/7cef5bf572596361bc502e8fa917569676a80372/src/ibusenginedesc.c
-        /// e.g.                   name           longname        description     language
-        /// ["IBusEngineDesc", {}, "xkb:us::eng", "English (US)", "English (US)", "en", "GPL", "Peng Huang <shawn.p.huang@gmail.com>", "ibus-keyboard", "us", 99, "", "", "", "", "", "", "", ""]
-        ///                         ↑ We will use this element (name) as it is what GlobalEngineChanged signal returns.
+        // `info` should contain something containing an array with the contents as such:
+        // [name, longname, description, language, license, author, icon, layout, layout_variant, layout_option, rank, hotkeys, symbol, setup, version, textdomain, icon_prop_key]
+        // Refer to: https://github.com/ibus/ibus/blob/7cef5bf572596361bc502e8fa917569676a80372/src/ibusenginedesc.c
+        // e.g.                   name           longname        description     language
+        // ["IBusEngineDesc", {}, "xkb:us::eng", "English (US)", "English (US)", "en", "GPL", "Peng Huang <shawn.p.huang@gmail.com>", "ibus-keyboard", "us", 99, "", "", "", "", "", "", "", ""]
+        //                         ↑ We will use this element (name) as it is what GlobalEngineChanged signal returns.
         let current = info.0.as_iter().unwrap().nth(2).unwrap().as_str().unwrap_or("??");
         let engine_original = Arc::new(Mutex::new(String::from(current)));
 
@@ -77,7 +77,7 @@ impl ConfigBlock for IBus {
                     if let Some(engine_name) = parse_msg(&ci) {
                             let mut engine = engine_original.lock().unwrap();
                             *engine = engine_name.to_string();
-                            /// Tell block to update now.
+                            // Tell block to update now.
                             send.send(Task {
                                 id: id.clone(),
                                 update_time: Instant::now(),
@@ -100,7 +100,7 @@ impl Block for IBus {
         &self.id
     }
 
-    /// Updates the internal state of the block.
+    // Updates the internal state of the block.
     fn update(&mut self) -> Result<Option<Duration>> {
         let string = (*self.engine
             .lock()
@@ -110,14 +110,14 @@ impl Block for IBus {
         Ok(None)
     }
 
-    /// Returns the view of the block, comprised of widgets.
+    // Returns the view of the block, comprised of widgets.
     fn view(&self) -> Vec<&I3BarWidget> {
         vec![&self.text]
     }
 
-    /// This function is called on every block for every click.
-    /// TODO: Filter events by using the event.name property,
-    /// and use to switch between input engines?
+    // This function is called on every block for every click.
+    // TODO: Filter events by using the event.name property,
+    // and use to switch between input engines?
     fn click(&mut self, _: &I3BarEvent) -> Result<()> {
         Ok(())
     }
@@ -131,27 +131,27 @@ fn parse_msg(ci: &ConnectionItem) -> Option<&str> {
     engine
 }
 
-/// Gets the address being used by the currently running ibus daemon.
-/// 
-/// By default ibus will write the address to `$XDG_CONFIG_HOME/ibus/bus/aaa-bbb-ccc`
-/// where aaa = dbus machine id, usually found at /etc/machine-id
-///       bbb = hostname - seems to be "unix" in most cases [see L99 of reference]
-///       ccc = display number from $DISPLAY
-/// Refer to: https://github.com/ibus/ibus/blob/7cef5bf572596361bc502e8fa917569676a80372/src/ibusshare.c
-///
-/// Example file contents:
-/// ```
-/// # This file is created by ibus-daemon, please do not modify it
-/// IBUS_ADDRESS=unix:abstract=/tmp/dbus-8EeieDfT,guid=7542d73dce451c2461a044e24bc131f4
-/// IBUS_DAEMON_PID=11140
-/// ```
+// Gets the address being used by the currently running ibus daemon.
+// 
+// By default ibus will write the address to `$XDG_CONFIG_HOME/ibus/bus/aaa-bbb-ccc`
+// where aaa = dbus machine id, usually found at /etc/machine-id
+//       bbb = hostname - seems to be "unix" in most cases [see L99 of reference]
+//       ccc = display number from $DISPLAY
+// Refer to: https://github.com/ibus/ibus/blob/7cef5bf572596361bc502e8fa917569676a80372/src/ibusshare.c
+//
+// Example file contents:
+// ```
+// # This file is created by ibus-daemon, please do not modify it
+// IBUS_ADDRESS=unix:abstract=/tmp/dbus-8EeieDfT,guid=7542d73dce451c2461a044e24bc131f4
+// IBUS_DAEMON_PID=11140
+// ```
 fn get_ibus_address() -> Result<String> {
-    /// TODO: Check IBUS_ADDRESS variable, as it seems it can be manually set too.
+    // TODO: Check IBUS_ADDRESS variable, as it seems it can be manually set too.
 
     let config_dir = env::var("XDG_CONFIG_HOME")
         .block_error("ibus", "Problem getting $XDG_CONFIG_HOME")?;
 
-    /// TODO: Check /var/lib/dbus/machine-id if /etc/machine-id fails
+    // TODO: Check /var/lib/dbus/machine-id if /etc/machine-id fails
     let mut f = File::open("/etc/machine-id")
         .block_error("ibus", "Could not open /etc/machine-id")?;
     let mut machine_id = String::new();
@@ -159,10 +159,10 @@ fn get_ibus_address() -> Result<String> {
         .block_error("ibus", "Something went wrong reading /etc/machine-id")?;
     let machine_id = machine_id.trim();
 
-    /// On sway, $DISPLAY is only set by programs requiring xwayland, such as ibus (GTK2).
-    /// ibus-daemon can be autostarted by sway (via an entry in config file), however since
-    /// the bar is executed first, $DISPLAY will not yet be set at the time this code runs.
-    /// Hence on sway you will need to reload the bar once after login to get the block to work.
+    // On sway, $DISPLAY is only set by programs requiring xwayland, such as ibus (GTK2).
+    // ibus-daemon can be autostarted by sway (via an entry in config file), however since
+    // the bar is executed first, $DISPLAY will not yet be set at the time this code runs.
+    // Hence on sway you will need to reload the bar once after login to get the block to work.
     let display = env::var("DISPLAY")
         .block_error("ibus", "$DISPLAY not set. Try restarting block if on sway")?;
     let re = Regex::new(r"^:(\d{1})$").unwrap();

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -47,8 +47,7 @@ impl ConfigBlock for IBus {
         let id: String = Uuid::new_v4().simple().to_string();
         let id_copy = id.clone();
 
-        let ibus_address = get_ibus_address()
-            .block_error("ibus", "Could not get IBus address")?;
+        let ibus_address = get_ibus_address()?;
         let c = Connection::open_private(&ibus_address)
             .block_error("ibus", &format!("Failed to establish D-Bus connection to {}", ibus_address))?;
         let p = c.with_path("org.freedesktop.IBus", "/org/freedesktop/IBus", 5000);

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -30,7 +30,7 @@ pub struct IBus {
 #[serde(deny_unknown_fields)]
 pub struct IBusConfig {
     // TODO: Implement this.
-    // Set to display engine name as the two letter country abbreviation, e.g. "jp".
+    /// Set to display engine name as the two letter country abbreviation, e.g. "jp".
     #[serde(default = "IBusConfig::default_abbreviate")]
     pub as_icon: bool,
 }

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -21,6 +21,7 @@ mod uptime;
 pub mod nvidia_gpu;
 pub mod maildir;
 mod networkmanager;
+pub mod ibus;
 
 use config::Config;
 use self::time::*;
@@ -46,6 +47,7 @@ use self::uptime::*;
 use self::nvidia_gpu::*;
 use self::maildir::*;
 use self::networkmanager::*;
+use self::ibus::*;
 
 use super::block::{Block, ConfigBlock};
 use errors::*;
@@ -100,6 +102,7 @@ pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_r
             "uptime" => Uptime,
             "nvidia_gpu" => NvidiaGpu,
             "maildir" => Maildir,
-            "networkmanager" => NetworkManager
+            "networkmanager" => NetworkManager,
+            "ibus" => IBus
     )
 }


### PR DESCRIPTION
`IBus` (Intelligent Input Bus) is an input method user interface which is used to type in languages other than English, such as Japanese.

This block displays the current input method ("global engine") in the status bar so that you can check before starting to type something. It updates instantly by subscribing to D-Bus signal event emitted by IBus.

Have been using this for a couple of weeks with no issues so far, however I kindly request a code review due to being a Rust noob.