### PR TITLE
Moves block profiling (and its dependencies) behind a cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.9.0"
 authors = ["Kai Greshake <development@kai-greshake.de>",
            "Contributors on GitHub (https://github.com/greshake/i3status-rust/graphs/contributors)"]
 
+[features]
+default = []
+# Opt-in block profiling, intended for developers.
+profiling = ["cpuprofiler", "progress"]
+
 [dependencies]
 chrono = "0.4"
 chrono-tz = "0.4"
@@ -22,7 +27,5 @@ num = "0.1.42"
 chan = "0.1.21"
 inotify = "0.5.1"
 maildir = "0.1.1"
-# Used only in debug build mode
-# for profiling blocks
-cpuprofiler = "0.0.3"
-progress = "0.2"
+cpuprofiler = { version = "0.0.3", optional = true }
+progress = { version = "0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Optional:
 
 * Font Awesome is required for `icons="awesome"`. Version 5 of the font is causing some issues (see [#130](https://github.com/greshake/i3status-rust/issues/130)), so for now we recommend version 4. If you have access to the AUR, check out [`ttf-font-awesome-4`](https://aur.archlinux.org/packages/ttf-font-awesome-4/).
 * Powerline Fonts are required for all themes using the powerline arrow char.
-* `gperftools` is used by development builds to profile block performance and find bottlenecks.
+* `gperftools` is required for building with the `"profiling"` feature flag (disabled by default).
 
 ## Getting Started
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,11 @@ mod scheduler;
 mod widget;
 mod widgets;
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "profiling")]
 extern crate cpuprofiler;
-#[cfg(debug_assertions)]
+#[cfg(feature = "profiling")]
 use cpuprofiler::PROFILER;
-#[cfg(debug_assertions)]
+#[cfg(feature = "profiling")]
 extern crate progress;
 
 use std::collections::HashMap;
@@ -138,31 +138,10 @@ fn run(matches: &ArgMatches) -> Result<()> {
     let (tx_update_requests, rx_update_requests): (Sender<Task>, Receiver<Task>) = chan::async();
 
     // In dev build, we might diverge into profiling blocks here
-    #[cfg(debug_assertions)]
-    if_debug!({
-        if matches.value_of("profile").is_some() {
-            for &(ref block_name, ref block_config) in &config.blocks {
-                if block_name == matches.value_of("profile").unwrap() {
-                    let mut block = create_block(
-                        &block_name,
-                        block_config.clone(),
-                        config.clone(),
-                        tx_update_requests.clone(),
-                    )?;
-                    profile(
-                        matches
-                            .value_of("profile-runs")
-                            .unwrap()
-                            .parse::<i32>()
-                            .unwrap(),
-                        &block_name,
-                        block.deref_mut(),
-                    );
-                    return Ok(());
-                }
-            }
-        }
-    });
+    if let Some(name) = matches.value_of("profile") {
+        profile_config(name, matches.value_of("profile-runs").unwrap(), &config, tx_update_requests)?;
+        return Ok(());
+    }
 
     let mut config_alternating_tint = config.clone();
     {
@@ -268,7 +247,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "profiling")]
 fn profile(iterations: i32, name: &str, block: &mut Block) {
     let mut bar = progress::Bar::new();
     println!(
@@ -292,4 +271,33 @@ fn profile(iterations: i32, name: &str, block: &mut Block) {
     }
 
     PROFILER.lock().unwrap().stop().unwrap();
+}
+
+#[cfg(feature = "profiling")]
+fn profile_config(name: &str, runs: &str, config: &Config, update: Sender<Task>) -> Result<()> {
+    let profile_runs = runs.parse::<i32>()
+        .configuration_error("failed to parse --profile-runs as an integer")?;
+    for &(ref block_name, ref block_config) in &config.blocks {
+        if block_name == name {
+            let mut block = create_block(
+                &block_name,
+                block_config.clone(),
+                config.clone(),
+                update.clone(),
+            )?;
+            profile(profile_runs, &block_name, block.deref_mut());
+            break;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "profiling"))]
+fn profile_config(_name: &str, _runs: &str, _config: &Config, _update: Sender<Task>) -> Result<()> {
+    // TODO: Maybe we should just panic! here.
+    Err(InternalError(
+        "profile".to_string(),
+        "The 'profiling' feature was not enabled at compile time.".to_string(),
+        None,
+    ))
 }


### PR DESCRIPTION
I've moved the block profiling support behind a cargo feature flag, because I believe it is little-used by anyone other than the occasional block author. I'll note that the changes I made to the code are quite crude -- perhaps in the future profiling should move to its own file.

There are some nice side effects of this change. At the moment we require the `cpuprofiler` and `progress` crates just for this feature, so as a result we're down at least 5 or so dependencies with this move. For reasons I'm not entirely sure I understand they remain in the `.lock` file, but I don't think they are used. This should also prevent surprises for users, as seen in #265.