### PR TITLE
Fix parsing of input JSON from new sway

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -44,12 +44,12 @@ pub fn process_events(sender: Sender<I3BarEvent>) {
         let mut input = String::new();
         io::stdin().read_line(&mut input).unwrap();
 
-        if !input.starts_with('[') {
-            if input.starts_with(',') {
-                input = input.split_off(1);
-            }
-            let e: I3BarEvent = serde_json::from_str(&input).unwrap();
+        // Take only the valid JSON object betweem curly braces (cut off leading bracket, commas and whitespace)
+        let slice = input.trim_left_matches(|c| c != '{');
+        let slice = slice.trim_right_matches(|c| c != '}');
 
+        if !slice.is_empty() {
+            let e: I3BarEvent = serde_json::from_str(slice).unwrap();
             sender.send(e);
         }
     });


### PR DESCRIPTION
Previously, if the separating comma was at the end of an input buffer, `serde_json::from_str(...)` would return `Err` and the program would panic. The same would happen if the input read hit `EOF`. The former issue was surfaced by running in the latest swaybar (compiled from git), and the latter while debugging the former.

With my changes, only what's between the first open and last close curly brace is sent to Serde, so both problems are fixed. We also don't need to special-case the initial `[` anymore.