### PR TITLE
Update Cargo.toml to fix pulseaudio library issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ num = "0.1.42"
 chan = "0.1.21"
 inotify = "0.5.1"
 maildir = "0.1.1"
-libpulse-binding = { version = "^2.2", optional = true }
+libpulse-binding = { optional = true, version = "2.2.3", default-features = false }
 # Used only in debug build mode
 # for profiling blocks
 cpuprofiler = { version = "0.0.3", optional = true }


### PR DESCRIPTION
Changes `libpulse-binding` requirements to fix issue #275 as suggested by @atheriel 