### PR TITLE
sound: Add config show_volume_when_muted

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -498,6 +498,7 @@ Key | Values | Required | Default
 `name` | PulseAudio / ALSA device name | No | Default Device (`@DEFAULT_SINK@` / `Master`)
 `step_width` | The percent volume level is increased/decreased for the selected audio device when scrolling. Capped automatically at 50. | No | `5`
 `on_click` | Shell command to run when the sound block is clicked. | No | None
+`show_volume_when_muted` | Show the volume even if it is currently muted. | No | `false
 
 ## Speed Test
 


### PR DESCRIPTION
The sound block doesn't show the volume when it's muted. This commit
adds a config option to enable just that.

It is useful to see how high the volume is turned up before unmuting.
This also allows you to adjust the volume while muted and then unmute at
the right volume.