### PR TITLE
Use SHELL env variable for custom and toggle block

### DIFF
--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -89,7 +89,7 @@ impl Block for Custom {
             .or_else(|| self.command.clone())
             .unwrap_or_else(|| "".to_owned());
 
-        let output = Command::new("sh")
+        let output = Command::new(env::var("SHELL").unwrap_or("sh".to_owned()))
             .args(&["-c", &command_str])
             .output()
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::time::Duration;
 use std::process::Command;
 use chan::Sender;
@@ -62,7 +63,7 @@ impl ConfigBlock for Toggle {
 
 impl Block for Toggle {
     fn update(&mut self) -> Result<Option<Duration>> {
-        let output = Command::new("sh")
+        let output = Command::new(env::var("SHELL").unwrap_or("sh".to_owned()))
             .args(&["-c", &self.command_state])
             .output()
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
@@ -99,7 +100,7 @@ impl Block for Toggle {
                     &self.command_on
                 };
 
-                Command::new("sh")
+                Command::new(env::var("SHELL").unwrap_or("sh".to_owned()))
                     .args(&["-c", cmd])
                     .output()
                     .block_error("toggle", "failed to run toggle command")?;


### PR DESCRIPTION
With the custom block a user can specify a custom command for a block.
By default it is evaluated by `sh`. The `on_click` command is however
evaluated by `$SHELL` if it's set. That behaviour should also be used
for `command` because `sh` is very limited and the user expects the
behaviour to be the same as their default shell.

This commit checks if `$SHELL` is set and uses this for all user
specified commands in the `custom` and `toggle` blocks.