### PR TITLE
blocks/music.rs: Support on_collapsed_click configuration

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -371,6 +371,14 @@ block = "music"
 buttons = ["play", "next"]
 ```
 
+Start Spotify if the block is clicked whilst it's collapsed:
+
+```toml
+[[block]]
+block = "music"
+on_collapsed_click = "spotify"
+```
+
 
 ### Options
 
@@ -382,6 +390,7 @@ Key | Values | Required | Default
 `marquee_interval` | Marquee interval in seconds. This is the delay between each rotation. | No | `10`
 `marquee_speed` | Marquee speed in seconds. This is the scrolling time used per character. | No | `0.5`
 `buttons` | Array of control buttons to be displayed. Options are prev (previous title), play (play/pause) and next (next title) | No | `[]`
+`on_collapsed_click` | Shell command to run when the music block is clicked while collapsed. | No | None
 
 ## Net
 

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -92,6 +92,10 @@ impl RotatingTextWidget {
         self.update()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.content.is_empty()
+    }
+
     fn get_rotated_content(&self) -> String {
         if self.content.len() > self.width {
             let missing = (self.rotation_pos + self.width).saturating_sub(self.content.len());


### PR DESCRIPTION
This implementation was what I reached when playing around with the codebase to work out how I could do this; I'm more than happy to throw this away if we reach a different conclusion on what we want the interface to look like.

Fixes #328