### PR TITLE
Allow for Missing Network

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -1,9 +1,9 @@
+use chan::Sender;
 use config::Config;
 use errors::*;
-use scheduler::Task;
-use chan::Sender;
-use std::time::Duration;
 use input::I3BarEvent;
+use scheduler::Task;
+use std::time::Duration;
 use widget::I3BarWidget;
 
 pub trait Block {

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -27,21 +27,12 @@ use widgets::button::ButtonWidget;
 
 /// Read a brightness value from the given path.
 fn read_brightness(device_file: &Path) -> Result<u64> {
-    let mut file = OpenOptions::new()
-            .read(true)
-            .open(device_file)
-            .block_error("backlight", "Failed to open brightness file")?;
+    let mut file = OpenOptions::new().read(true).open(device_file).block_error("backlight", "Failed to open brightness file")?;
     let mut content = String::new();
-    file.read_to_string(&mut content).block_error(
-        "backlight",
-        "Failed to read brightness file",
-    )?;
+    file.read_to_string(&mut content).block_error("backlight", "Failed to read brightness file")?;
     // Removes trailing newline.
     content.pop();
-    content.parse::<u64>().block_error(
-        "backlight",
-        "Failed to read value from brightness file",
-    )
+    content.parse::<u64>().block_error("backlight", "Failed to read value from brightness file")
 }
 
 /// Represents a physical backlit device whose brightness level can be queried.
@@ -55,23 +46,12 @@ impl BacklitDevice {
     /// `/sys/class/backlight` directory.
     pub fn default() -> Result<Self> {
         let devices = Path::new("/sys/class/backlight")
-                           .read_dir() // Iterate over entries in the directory.
-                           .block_error("backlight",
-                                        "Failed to read backlight device directory")?;
+            .read_dir() // Iterate over entries in the directory.
+            .block_error("backlight", "Failed to read backlight device directory")?;
 
         let first_device = match devices.take(1).next() {
-            None => Err(BlockError(
-                "backlight".to_string(),
-                "No backlit devices found".to_string(),
-            )),
-            Some(device) => {
-                device.map_err(|_| {
-                    BlockError(
-                        "backlight".to_string(),
-                        "Failed to read default device file".to_string(),
-                    )
-                })
-            }
+            None => Err(BlockError("backlight".to_string(), "No backlit devices found".to_string())),
+            Some(device) => device.map_err(|_| BlockError("backlight".to_string(), "Failed to read default device file".to_string())),
         }?;
 
         let max_brightness = read_brightness(&first_device.path().join("max_brightness"))?;
@@ -87,21 +67,12 @@ impl BacklitDevice {
     pub fn from_device(device: String) -> Result<Self> {
         let device_path = Path::new("/sys/class/backlight").join(device);
         if !device_path.exists() {
-            return Err(BlockError(
-                "backlight".to_string(),
-                format!(
-                    "Backlight device '{}' does not exist",
-                    device_path.to_string_lossy()
-                ),
-            ));
+            return Err(BlockError("backlight".to_string(), format!("Backlight device '{}' does not exist", device_path.to_string_lossy())));
         }
 
         let max_brightness = read_brightness(&device_path.join("max_brightness"))?;
 
-        Ok(BacklitDevice {
-            max_brightness,
-            device_path,
-        })
+        Ok(BacklitDevice { max_brightness, device_path })
     }
 
     /// Query the brightness value for this backlit device, as a percent.
@@ -116,9 +87,7 @@ impl BacklitDevice {
 
     /// Set the brightness value for this backlit device, as a percent.
     pub fn set_brightness(&self, value: u64) -> Result<()> {
-        let file = OpenOptions::new().write(true).open(self.device_path.join(
-            "brightness",
-        ));
+        let file = OpenOptions::new().write(true).open(self.device_path.join("brightness"));
         if file.is_err() {
             // TODO: Find a way to issue a non-fatal error, since this is likely
             // due to a permissions issue and not the fault of the user. It
@@ -132,9 +101,7 @@ impl BacklitDevice {
         };
         let raw = (((safe_value as f64) / 100.0) * (self.max_brightness as f64)).round() as u64;
         // It's safe to unwrap() here because we checked for errors above.
-        file.unwrap()
-            .write_fmt(format_args!("{}", raw))
-            .block_error("backlight", "Failed to write into brightness file")
+        file.unwrap().write_fmt(format_args!("{}", raw)).block_error("backlight", "Failed to write into brightness file")
     }
 
     /// The brightness file itself.
@@ -197,15 +164,11 @@ impl ConfigBlock for Backlight {
         // device, and schedule an update if needed.
         thread::spawn(move || {
             let mut notify = Inotify::init().expect("Failed to start inotify");
-            notify
-                .add_watch(brightness_file, WatchMask::MODIFY)
-                .expect("Failed to watch brightness file");
+            notify.add_watch(brightness_file, WatchMask::MODIFY).expect("Failed to watch brightness file");
 
             let mut buffer = [0; 1024];
             loop {
-                let mut events = notify.read_events_blocking(&mut buffer).expect(
-                    "Error while reading inotify events",
-                );
+                let mut events = notify.read_events_blocking(&mut buffer).expect("Error while reading inotify events");
 
                 if events.any(|event| event.mask.contains(EventMask::MODIFY)) {
                     tx_update_request.send(Task {

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -1,18 +1,18 @@
-use std::time::{Duration, Instant};
-use std::process::Command;
-use std::iter::{Cycle, Peekable};
-use std::vec;
-use std::env;
 use chan::Sender;
+use std::env;
+use std::iter::{Cycle, Peekable};
+use std::process::Command;
+use std::time::{Duration, Instant};
+use std::vec;
 
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
-use widgets::button::ButtonWidget;
-use widget::I3BarWidget;
 use input::I3BarEvent;
 use scheduler::Task;
+use widget::I3BarWidget;
+use widgets::button::ButtonWidget;
 
 use uuid::Uuid;
 
@@ -83,7 +83,8 @@ impl ConfigBlock for Custom {
 
 impl Block for Custom {
     fn update(&mut self) -> Result<Option<Duration>> {
-        let command_str = self.cycle
+        let command_str = self
+            .cycle
             .as_mut()
             .map(|c| c.peek().cloned().unwrap_or_else(|| "".to_owned()))
             .or_else(|| self.command.clone())
@@ -116,8 +117,7 @@ impl Block for Custom {
         let mut update = false;
 
         if let Some(ref on_click) = self.on_click {
-            Command::new(env::var("SHELL").unwrap_or_else(|_|"sh".to_owned()))
-                    .args(&["-c", on_click]).output().ok();
+            Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_owned())).args(&["-c", on_click]).output().ok();
             update = true;
         }
 

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -1,18 +1,18 @@
 use std::time::Duration;
 
 use block::{Block, ConfigBlock};
+use chan::Sender;
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
-use widgets::text::TextWidget;
-use widget::{I3BarWidget, State};
-use util::FormatTemplate;
-use chan::Sender;
 use scheduler::Task;
+use util::FormatTemplate;
+use widget::{I3BarWidget, State};
+use widgets::text::TextWidget;
 
-use std::io::BufReader;
-use std::io::prelude::*;
 use std::fs::{File, OpenOptions};
+use std::io::prelude::*;
+use std::io::BufReader;
 
 use uuid::Uuid;
 
@@ -47,12 +47,9 @@ impl ConfigBlock for Load {
     type Config = LoadConfig;
 
     fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
-        let text = TextWidget::new(config)
-            .with_icon("cogs")
-            .with_state(State::Info);
+        let text = TextWidget::new(config).with_icon("cogs").with_state(State::Info);
 
-        let f = File::open("/proc/cpuinfo")
-            .block_error("load", "Your system doesn't support /proc/cpuinfo")?;
+        let f = File::open("/proc/cpuinfo").block_error("load", "Your system doesn't support /proc/cpuinfo")?;
         let f = BufReader::new(f);
 
         let mut logical_cores = 0;
@@ -61,9 +58,7 @@ impl ConfigBlock for Load {
             // TODO: Does this value always represent the correct number of logical cores?
             if line.starts_with("siblings") {
                 let split: Vec<&str> = (&line).split(' ').collect();
-                logical_cores = split[1]
-                    .parse::<u32>()
-                    .block_error("load", "Invalid Cpu info format!")?;
+                logical_cores = split[1].parse::<u32>().block_error("load", "Invalid Cpu info format!")?;
                 break;
             }
         }
@@ -72,8 +67,7 @@ impl ConfigBlock for Load {
             id: Uuid::new_v4().simple().to_string(),
             logical_cores,
             update_interval: block_config.interval,
-            format: FormatTemplate::from_string(&block_config.format)
-                .block_error("load", "Invalid format specified for load")?,
+            format: FormatTemplate::from_string(&block_config.format).block_error("load", "Invalid format specified for load")?,
             text,
         })
     }
@@ -84,13 +78,9 @@ impl Block for Load {
         let mut f = OpenOptions::new()
             .read(true)
             .open("/proc/loadavg")
-            .block_error(
-                "load",
-                "Your system does not support reading the load average from /proc/loadavg",
-            )?;
+            .block_error("load", "Your system does not support reading the load average from /proc/loadavg")?;
         let mut loadavg = String::new();
-        f.read_to_string(&mut loadavg)
-            .block_error("load", "Failed to read the load average of your system!")?;
+        f.read_to_string(&mut loadavg).block_error("load", "Failed to read the load average of your system!")?;
 
         let split: Vec<&str> = (&loadavg).split(' ').collect();
 
@@ -98,16 +88,12 @@ impl Block for Load {
                           "{5m}" => split[1],
                           "{15m}" => split[2]);
 
-        let used_perc = values["{1m}"]
-            .parse::<f32>()
-            .block_error("load", "failed to parse float percentage")? / self.logical_cores as f32;
-        self.text.set_state(
-            match_range!(used_perc, default: (State::Idle) {
+        let used_perc = values["{1m}"].parse::<f32>().block_error("load", "failed to parse float percentage")? / self.logical_cores as f32;
+        self.text.set_state(match_range!(used_perc, default: (State::Idle) {
                 0.0 ; 0.3 => State::Idle,
                 0.3 ; 0.6 => State::Info,
                 0.6 ; 0.9 => State::Warning
-        }),
-        );
+        }));
 
         self.text.set_text(self.format.render_static_str(&values)?);
 

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -1,15 +1,15 @@
-use std::time::Duration;
 use chan::Sender;
+use std::time::Duration;
 
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
-use widgets::text::TextWidget;
-use widget::{I3BarWidget, State};
 use input::I3BarEvent;
-use scheduler::Task;
 use maildir::Maildir as ExtMaildir;
+use scheduler::Task;
+use widget::{I3BarWidget, State};
+use widgets::text::TextWidget;
 
 use uuid::Uuid;
 
@@ -54,9 +54,7 @@ impl ConfigBlock for Maildir {
         Ok(Maildir {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
-            text: TextWidget::new(config.clone())
-                .with_icon("mail")
-                .with_text(""),
+            text: TextWidget::new(config.clone()).with_icon("mail").with_text(""),
             inboxes: block_config.inboxes,
             threshold_warning: block_config.threshold_warning,
             threshold_critical: block_config.threshold_critical,

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -72,27 +72,27 @@
 //! {SUpi} | Swap used (%) as integer
 
 //!
-use std::time::{Duration, Instant};
-use std::collections::HashMap;
-use util::*;
+use block::{Block, ConfigBlock};
 use chan::Sender;
+use input::{I3BarEvent, MouseButton};
+use std::collections::HashMap;
+use std::fmt;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use block::{Block, ConfigBlock};
-use input::{I3BarEvent, MouseButton};
 use std::str::FromStr;
+use std::time::{Duration, Instant};
+use util::*;
 use uuid::Uuid;
-use std::fmt;
 
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
-use widgets::button::ButtonWidget;
-use widget::{I3BarWidget, State};
 use scheduler::Task;
+use widget::{I3BarWidget, State};
+use widgets::button::ButtonWidget;
 
-use std::io::Write;
 use std::fs::OpenOptions;
+use std::io::Write;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
@@ -331,116 +331,46 @@ impl Memory {
         let swap_used = Unit::KiB(mem_state.swap_total() - mem_state.swap_free());
         let mem_total_used = Unit::KiB(mem_total.n() - mem_free.n());
         let buffers = Unit::KiB(mem_state.buffers());
-        let cached = Unit::KiB(
-            mem_state.cached() + mem_state.s_reclaimable() - mem_state.shmem(),
-        );
+        let cached = Unit::KiB(mem_state.cached() + mem_state.s_reclaimable() - mem_state.shmem());
         let mem_used = Unit::KiB(mem_total_used.n() - (buffers.n() + cached.n()));
         let mem_avail = Unit::KiB(mem_total.n() - mem_used.n());
 
-        self.values
-            .insert("{MTg}".to_string(), format!("{:.1}", mem_total.gib()));
-        self.values
-            .insert("{MTm}".to_string(), format!("{}", mem_total.mib()));
-        self.values
-            .insert("{MFg}".to_string(), format!("{:.1}", mem_free.gib()));
-        self.values
-            .insert("{MFm}".to_string(), format!("{}", mem_free.mib()));
-        self.values.insert(
-            "{MFp}".to_string(),
-            format!("{:.2}", mem_free.percent(mem_total)),
-        );
-        self.values.insert(
-            "{MFpi}".to_string(),
-            format!("{:02}", mem_free.percent(mem_total) as i32),
-        );
-        self.values
-            .insert("{MUg}".to_string(), format!("{:.1}", mem_total_used.gib()));
-        self.values
-            .insert("{MUm}".to_string(), format!("{}", mem_total_used.mib()));
-        self.values.insert(
-            "{MUp}".to_string(),
-            format!("{:.2}", mem_total_used.percent(mem_total)),
-        );
-        self.values.insert(
-            "{MUpi}".to_string(),
-            format!("{:02}", mem_total_used.percent(mem_total) as i32),
-        );
-        self.values
-            .insert("{Mug}".to_string(), format!("{:.1}", mem_used.gib()));
-        self.values
-            .insert("{Mum}".to_string(), format!("{}", mem_used.mib()));
-        self.values.insert(
-            "{Mup}".to_string(),
-            format!("{:.2}", mem_used.percent(mem_total)),
-        );
-        self.values.insert(
-            "{Mupi}".to_string(),
-            format!("{:02}", mem_used.percent(mem_total) as i32),
-        );
-        self.values
-            .insert("{MAg}".to_string(), format!("{:.1}", mem_avail.gib()));
-        self.values
-            .insert("{MAm}".to_string(), format!("{}", mem_avail.mib()));
-        self.values.insert(
-            "{MAp}".to_string(),
-            format!("{:.2}", mem_avail.percent(mem_total)),
-        );
-        self.values.insert(
-            "{MApi}".to_string(),
-            format!("{:02}", mem_avail.percent(mem_total) as i32),
-        );
-        self.values
-            .insert("{STg}".to_string(), format!("{:.1}", swap_total.gib()));
-        self.values
-            .insert("{STm}".to_string(), format!("{}", swap_total.mib()));
-        self.values
-            .insert("{SFg}".to_string(), format!("{:.1}", swap_free.gib()));
-        self.values
-            .insert("{SFm}".to_string(), format!("{}", swap_free.mib()));
-        self.values.insert(
-            "{SFp}".to_string(),
-            format!("{:.2}", swap_free.percent(swap_total)),
-        );
-        self.values.insert(
-            "{SFpi}".to_string(),
-            format!("{:02}", swap_free.percent(swap_total) as i32),
-        );
-        self.values
-            .insert("{SUg}".to_string(), format!("{:.1}", swap_used.gib()));
-        self.values
-            .insert("{SUm}".to_string(), format!("{}", swap_used.mib()));
-        self.values.insert(
-            "{SUp}".to_string(),
-            format!("{:.2}", swap_used.percent(swap_total)),
-        );
-        self.values.insert(
-            "{SUpi}".to_string(),
-            format!("{:02}", swap_used.percent(swap_total) as i32),
-        );
-        self.values
-            .insert("{Bg}".to_string(), format!("{:.1}", buffers.gib()));
-        self.values
-            .insert("{Bm}".to_string(), format!("{}", buffers.mib()));
-        self.values.insert(
-            "{Bp}".to_string(),
-            format!("{:.2}", buffers.percent(mem_total)),
-        );
-        self.values.insert(
-            "{Bpi}".to_string(),
-            format!("{:02}", buffers.percent(mem_total) as i32),
-        );
-        self.values
-            .insert("{Cg}".to_string(), format!("{:.1}", cached.gib()));
-        self.values
-            .insert("{Cm}".to_string(), format!("{}", cached.mib()));
-        self.values.insert(
-            "{Cp}".to_string(),
-            format!("{:.2}", cached.percent(mem_total)),
-        );
-        self.values.insert(
-            "{Cpi}".to_string(),
-            format!("{:02}", cached.percent(mem_total) as i32),
-        );
+        self.values.insert("{MTg}".to_string(), format!("{:.1}", mem_total.gib()));
+        self.values.insert("{MTm}".to_string(), format!("{}", mem_total.mib()));
+        self.values.insert("{MFg}".to_string(), format!("{:.1}", mem_free.gib()));
+        self.values.insert("{MFm}".to_string(), format!("{}", mem_free.mib()));
+        self.values.insert("{MFp}".to_string(), format!("{:.2}", mem_free.percent(mem_total)));
+        self.values.insert("{MFpi}".to_string(), format!("{:02}", mem_free.percent(mem_total) as i32));
+        self.values.insert("{MUg}".to_string(), format!("{:.1}", mem_total_used.gib()));
+        self.values.insert("{MUm}".to_string(), format!("{}", mem_total_used.mib()));
+        self.values.insert("{MUp}".to_string(), format!("{:.2}", mem_total_used.percent(mem_total)));
+        self.values.insert("{MUpi}".to_string(), format!("{:02}", mem_total_used.percent(mem_total) as i32));
+        self.values.insert("{Mug}".to_string(), format!("{:.1}", mem_used.gib()));
+        self.values.insert("{Mum}".to_string(), format!("{}", mem_used.mib()));
+        self.values.insert("{Mup}".to_string(), format!("{:.2}", mem_used.percent(mem_total)));
+        self.values.insert("{Mupi}".to_string(), format!("{:02}", mem_used.percent(mem_total) as i32));
+        self.values.insert("{MAg}".to_string(), format!("{:.1}", mem_avail.gib()));
+        self.values.insert("{MAm}".to_string(), format!("{}", mem_avail.mib()));
+        self.values.insert("{MAp}".to_string(), format!("{:.2}", mem_avail.percent(mem_total)));
+        self.values.insert("{MApi}".to_string(), format!("{:02}", mem_avail.percent(mem_total) as i32));
+        self.values.insert("{STg}".to_string(), format!("{:.1}", swap_total.gib()));
+        self.values.insert("{STm}".to_string(), format!("{}", swap_total.mib()));
+        self.values.insert("{SFg}".to_string(), format!("{:.1}", swap_free.gib()));
+        self.values.insert("{SFm}".to_string(), format!("{}", swap_free.mib()));
+        self.values.insert("{SFp}".to_string(), format!("{:.2}", swap_free.percent(swap_total)));
+        self.values.insert("{SFpi}".to_string(), format!("{:02}", swap_free.percent(swap_total) as i32));
+        self.values.insert("{SUg}".to_string(), format!("{:.1}", swap_used.gib()));
+        self.values.insert("{SUm}".to_string(), format!("{}", swap_used.mib()));
+        self.values.insert("{SUp}".to_string(), format!("{:.2}", swap_used.percent(swap_total)));
+        self.values.insert("{SUpi}".to_string(), format!("{:02}", swap_used.percent(swap_total) as i32));
+        self.values.insert("{Bg}".to_string(), format!("{:.1}", buffers.gib()));
+        self.values.insert("{Bm}".to_string(), format!("{}", buffers.mib()));
+        self.values.insert("{Bp}".to_string(), format!("{:.2}", buffers.percent(mem_total)));
+        self.values.insert("{Bpi}".to_string(), format!("{:02}", buffers.percent(mem_total) as i32));
+        self.values.insert("{Cg}".to_string(), format!("{:.1}", cached.gib()));
+        self.values.insert("{Cm}".to_string(), format!("{}", cached.mib()));
+        self.values.insert("{Cp}".to_string(), format!("{:.2}", cached.percent(mem_total)));
+        self.values.insert("{Cpi}".to_string(), format!("{:02}", cached.percent(mem_total) as i32));
 
         match self.memtype {
             Memtype::Memory => self.output.0.set_state(match mem_used.percent(mem_total) {
@@ -448,23 +378,16 @@ impl Memory {
                 x if f64::from(x) > self.warning.0 => State::Warning,
                 _ => State::Idle,
             }),
-            Memtype::Swap => self.output.1.set_state(
-                match swap_used.percent(swap_total) {
-                    x if f64::from(x)  > self.critical.1 => State::Critical,
-                    x if f64::from(x) > self.warning.1 => State::Warning,
-                    _ => State::Idle,
-                },
-            ),
+            Memtype::Swap => self.output.1.set_state(match swap_used.percent(swap_total) {
+                x if f64::from(x) > self.critical.1 => State::Critical,
+                x if f64::from(x) > self.warning.1 => State::Warning,
+                _ => State::Idle,
+            }),
         };
 
         if_debug!({
-            let mut f = OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open("/tmp/i3log")
-                .block_error("memory", "can't open /tmp/i3log")?;
-            writeln!(f, "Inserted values: {:?}", self.values)
-                .block_error("memory", "failed to write to /tmp/i3log")?;
+            let mut f = OpenOptions::new().create(true).append(true).open("/tmp/i3log").block_error("memory", "can't open /tmp/i3log")?;
+            writeln!(f, "Inserted values: {:?}", self.values).block_error("memory", "failed to write to /tmp/i3log")?;
         });
 
         Ok(match self.memtype {
@@ -492,18 +415,12 @@ impl ConfigBlock for Memory {
             id: Uuid::new_v4().simple().to_string(),
             memtype: block_config.display_type,
             output: if icons {
-                (
-                    widget.clone().with_icon("memory_mem"),
-                    widget.with_icon("memory_swap"),
-                )
+                (widget.clone().with_icon("memory_mem"), widget.with_icon("memory_swap"))
             } else {
                 (widget.clone(), widget)
             },
             clickable: block_config.clickable,
-            format: (
-                FormatTemplate::from_string(&block_config.format_mem)?,
-                FormatTemplate::from_string(&block_config.format_swap)?,
-            ),
+            format: (FormatTemplate::from_string(&block_config.format_mem)?, FormatTemplate::from_string(&block_config.format_swap)?),
             update_interval: block_config.interval,
             tx_update_request: tx,
             values: HashMap::<String, String>::new(),
@@ -513,28 +430,21 @@ impl ConfigBlock for Memory {
     }
 }
 
-
 impl Block for Memory {
     fn id(&self) -> &str {
         &self.id
     }
 
     fn update(&mut self) -> Result<Option<Duration>> {
-        let f = File::open("/proc/meminfo")
-            .block_error("memory", "/proc/meminfo does not exist")?;
+        let f = File::open("/proc/meminfo").block_error("memory", "/proc/meminfo does not exist")?;
         let f = BufReader::new(f);
 
         let mut mem_state = Memstate::new();
 
         for line in f.lines() {
             if_debug!({
-                let mut f = OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open("/tmp/i3log")
-                    .block_error("memory", "can't open /tmp/i3log")?;
-                writeln!(f, "Updated: {:?}", mem_state)
-                    .block_error("memory", "failed to write to /tmp/i3log")?;
+                let mut f = OpenOptions::new().create(true).append(true).open("/tmp/i3log").block_error("memory", "can't open /tmp/i3log")?;
+                writeln!(f, "Updated: {:?}", mem_state).block_error("memory", "failed to write to /tmp/i3log")?;
             });
 
             // stop reading if all values are already present
@@ -550,67 +460,35 @@ impl Block for Memory {
 
             match line[0] {
                 "MemTotal:" => {
-                    mem_state.mem_total = (
-                        u64::from_str(line[1])
-                            .block_error("memory", "failed to parse mem_total")?,
-                        true,
-                    );
+                    mem_state.mem_total = (u64::from_str(line[1]).block_error("memory", "failed to parse mem_total")?, true);
                     continue;
                 }
                 "MemFree:" => {
-                    mem_state.mem_free = (
-                        u64::from_str(line[1])
-                            .block_error("memory", "failed to parse mem_free")?,
-                        true,
-                    );
+                    mem_state.mem_free = (u64::from_str(line[1]).block_error("memory", "failed to parse mem_free")?, true);
                     continue;
                 }
                 "Buffers:" => {
-                    mem_state.buffers = (
-                        u64::from_str(line[1])
-                            .block_error("memory", "failed to parse buffers")?,
-                        true,
-                    );
+                    mem_state.buffers = (u64::from_str(line[1]).block_error("memory", "failed to parse buffers")?, true);
                     continue;
                 }
                 "Cached:" => {
-                    mem_state.cached = (
-                        u64::from_str(line[1])
-                            .block_error("memory", "failed to parse cached")?,
-                        true,
-                    );
+                    mem_state.cached = (u64::from_str(line[1]).block_error("memory", "failed to parse cached")?, true);
                     continue;
                 }
                 "SReclaimable:" => {
-                    mem_state.s_reclaimable = (
-                        u64::from_str(line[1])
-                            .block_error("memory", "failed to parse s_reclaimable")?,
-                        true,
-                    );
+                    mem_state.s_reclaimable = (u64::from_str(line[1]).block_error("memory", "failed to parse s_reclaimable")?, true);
                     continue;
                 }
                 "Shmem:" => {
-                    mem_state.shmem = (
-                        u64::from_str(line[1])
-                            .block_error("memory", "failed to parse shmem")?,
-                        true,
-                    );
+                    mem_state.shmem = (u64::from_str(line[1]).block_error("memory", "failed to parse shmem")?, true);
                     continue;
                 }
                 "SwapTotal:" => {
-                    mem_state.swap_total = (
-                        u64::from_str(line[1])
-                            .block_error("memory", "failed to parse swap_total")?,
-                        true,
-                    );
+                    mem_state.swap_total = (u64::from_str(line[1]).block_error("memory", "failed to parse swap_total")?, true);
                     continue;
                 }
                 "SwapFree:" => {
-                    mem_state.swap_free = (
-                        u64::from_str(line[1])
-                            .block_error("memory", "failed to parse swap_free")?,
-                        true,
-                    );
+                    mem_state.swap_free = (u64::from_str(line[1]).block_error("memory", "failed to parse swap_free")?, true);
                     continue;
                 }
                 _ => {
@@ -628,26 +506,16 @@ impl Block for Memory {
         }
 
         if_debug!({
-            let mut f = OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open("/tmp/i3log")
-                .block_error("memory", "failed to open /tmp/i3log")?;
-            writeln!(f, "Updated: {:?}", self)
-                .block_error("memory", "failed to write to /tmp/i3log")?;
+            let mut f = OpenOptions::new().create(true).append(true).open("/tmp/i3log").block_error("memory", "failed to open /tmp/i3log")?;
+            writeln!(f, "Updated: {:?}", self).block_error("memory", "failed to write to /tmp/i3log")?;
         });
         Ok(Some(self.update_interval))
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
         if_debug!({
-            let mut f = OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open("/tmp/i3log")
-                .block_error("memory", "failed to open /tmp/i3log")?;
-            writeln!(f, "Click received: {:?}", event)
-                .block_error("memory", "failed to write to /tmp/i3log")?;
+            let mut f = OpenOptions::new().create(true).append(true).open("/tmp/i3log").block_error("memory", "failed to open /tmp/i3log")?;
+            writeln!(f, "Click received: {:?}", event).block_error("memory", "failed to write to /tmp/i3log")?;
         });
 
         if let Some(ref s) = event.name {
@@ -665,11 +533,9 @@ impl Block for Memory {
     }
 
     fn view(&self) -> Vec<&I3BarWidget> {
-        vec![
-            match self.memtype {
-                Memtype::Memory => &self.output.0,
-                Memtype::Swap => &self.output.1,
-            },
-        ]
+        vec![match self.memtype {
+            Memtype::Memory => &self.output.0,
+            Memtype::Swap => &self.output.1,
+        }]
     }
 }

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -1,68 +1,67 @@
-mod time;
-mod template;
-mod load;
-mod memory;
-mod cpu;
-mod music;
+pub mod backlight;
 pub mod battery;
+mod cpu;
 mod custom;
 mod disk_space;
+mod focused_window;
+mod load;
+pub mod maildir;
+mod memory;
+mod music;
+mod net;
+mod networkmanager;
+pub mod nvidia_gpu;
 mod pacman;
-mod temperature;
-mod toggle;
 mod sound;
 mod speedtest;
-mod focused_window;
-mod xrandr;
-mod net;
-pub mod backlight;
-mod weather;
+mod temperature;
+mod template;
+mod time;
+mod toggle;
 mod uptime;
-pub mod nvidia_gpu;
-pub mod maildir;
-mod networkmanager;
+mod weather;
+mod xrandr;
 
-use config::Config;
-use self::time::*;
-use self::template::*;
-use self::music::*;
-use self::cpu::*;
-use self::load::*;
-use self::memory::*;
+use self::backlight::Backlight;
 use self::battery::*;
+use self::cpu::*;
 use self::custom::*;
 use self::disk_space::*;
+use self::focused_window::*;
+use self::load::*;
+use self::maildir::*;
+use self::memory::*;
+use self::music::*;
+use self::net::*;
+use self::networkmanager::*;
+use self::nvidia_gpu::*;
 use self::pacman::*;
 use self::sound::*;
 use self::speedtest::*;
-use self::toggle::*;
-use self::focused_window::*;
 use self::temperature::*;
-use self::xrandr::*;
-use self::net::*;
-use self::backlight::Backlight;
-use self::weather::*;
+use self::template::*;
+use self::time::*;
+use self::toggle::*;
 use self::uptime::*;
-use self::nvidia_gpu::*;
-use self::maildir::*;
-use self::networkmanager::*;
+use self::weather::*;
+use self::xrandr::*;
+use config::Config;
 
 use super::block::{Block, ConfigBlock};
-use errors::*;
 use super::scheduler::Task;
+use errors::*;
 
 extern crate dbus;
 
-use serde::de::Deserialize;
 use chan::Sender;
+use serde::de::Deserialize;
 use toml::value::Value;
 
 macro_rules! block {
     ($block_type:ident, $block_config:expr, $config:expr, $tx_update_request:expr) => {{
-        let block_config: <$block_type as ConfigBlock>::Config = <$block_type as ConfigBlock>::Config::deserialize($block_config)
-            .configuration_error("failed to deserialize block config")?;
+        let block_config: <$block_type as ConfigBlock>::Config = <$block_type as ConfigBlock>::Config::deserialize($block_config).configuration_error("failed to deserialize block config")?;
         Ok(Box::new($block_type::new(block_config, $config, $tx_update_request)?) as Box<Block>)
-    }}
+    }};
 }
 
 macro_rules! blocks {

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -1,21 +1,21 @@
-use std::time::{Duration, Instant};
 use chan::Sender;
-use std::thread;
 use std::boxed::Box;
+use std::thread;
+use std::time::{Duration, Instant};
 
-use config::Config;
-use errors::*;
-use scheduler::Task;
-use input::I3BarEvent;
 use block::{Block, ConfigBlock};
+use config::Config;
 use de::deserialize_duration;
-use widgets::rotatingtext::RotatingTextWidget;
-use widgets::button::ButtonWidget;
+use errors::*;
+use input::I3BarEvent;
+use scheduler::Task;
 use widget::{I3BarWidget, State};
+use widgets::button::ButtonWidget;
+use widgets::rotatingtext::RotatingTextWidget;
 
-use blocks::dbus::{arg, stdintf, BusType, Connection, ConnectionItem, Message};
-use blocks::dbus::arg::{Array, RefArg};
 use self::stdintf::org_freedesktop_dbus::Properties;
+use blocks::dbus::arg::{Array, RefArg};
+use blocks::dbus::{arg, stdintf, BusType, Connection, ConnectionItem, Message};
 use uuid::Uuid;
 
 pub struct Music {
@@ -28,7 +28,7 @@ pub struct Music {
     player_avail: bool,
     marquee: bool,
     player: Option<String>,
-    auto_discover: bool
+    auto_discover: bool,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -90,9 +90,8 @@ impl ConfigBlock for Music {
 
         thread::spawn(move || {
             let c = Connection::get_private(BusType::Session).unwrap();
-            c.add_match(
-                "interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',path='/org/mpris/MediaPlayer2'",
-            ).unwrap();
+            c.add_match("interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',path='/org/mpris/MediaPlayer2'")
+                .unwrap();
             loop {
                 for ci in c.iter(100_000) {
                     if let ConnectionItem::Signal(_) = ci {
@@ -110,31 +109,10 @@ impl ConfigBlock for Music {
         let mut next: Option<ButtonWidget> = None;
         for button in block_config.buttons {
             match &*button {
-                "play" => {
-                    play = Some(
-                        ButtonWidget::new(config.clone(), "play")
-                            .with_icon("music_play")
-                            .with_state(State::Info),
-                    )
-                }
-                "next" => {
-                    next = Some(
-                        ButtonWidget::new(config.clone(), "next")
-                            .with_icon("music_next")
-                            .with_state(State::Info),
-                    )
-                }
-                "prev" => {
-                    prev = Some(
-                        ButtonWidget::new(config.clone(), "prev")
-                            .with_icon("music_prev")
-                            .with_state(State::Info),
-                    )
-                }
-                x => Err(BlockError(
-                    "music".to_owned(),
-                    format!("unknown music button identifier: '{}'", x),
-                ))?,
+                "play" => play = Some(ButtonWidget::new(config.clone(), "play").with_icon("music_play").with_state(State::Info)),
+                "next" => next = Some(ButtonWidget::new(config.clone(), "next").with_icon("music_next").with_state(State::Info)),
+                "prev" => prev = Some(ButtonWidget::new(config.clone(), "prev").with_icon("music_prev").with_state(State::Info)),
+                x => Err(BlockError("music".to_owned(), format!("unknown music button identifier: '{}'", x)))?,
             };
         }
 
@@ -145,21 +123,20 @@ impl ConfigBlock for Music {
                 Duration::new(0, block_config.marquee_speed.subsec_nanos()),
                 block_config.max_width,
                 config.clone(),
-            ).with_icon("music")
-                .with_state(State::Info),
+            )
+            .with_icon("music")
+            .with_state(State::Info),
             prev,
             play,
             next,
-            dbus_conn: Connection::get_private(BusType::Session)
-                .block_error("music", "failed to establish D-Bus connection")?,
+            dbus_conn: Connection::get_private(BusType::Session).block_error("music", "failed to establish D-Bus connection")?,
             player_avail: false,
             auto_discover: block_config.player.is_none(),
-            player: if block_config.player.is_none()
-                {
-                    block_config.player
-                } else {
-                    Some(format!("org.mpris.MediaPlayer2.{}", block_config.player.unwrap()))
-                },
+            player: if block_config.player.is_none() {
+                block_config.player
+            } else {
+                Some(format!("org.mpris.MediaPlayer2.{}", block_config.player.unwrap()))
+            },
             marquee: block_config.marquee,
         })
     }
@@ -171,20 +148,12 @@ impl Block for Music {
     }
 
     fn update(&mut self) -> Result<Option<Duration>> {
-        let (rotated, next) = if self.marquee {
-            self.current_song.next()?
-        } else {
-            (false, None)
-        };
+        let (rotated, next) = if self.marquee { self.current_song.next()? } else { (false, None) };
         if !rotated && self.player.is_none() {
             self.player = get_first_available_player(&self.dbus_conn)
         }
         if !(rotated || self.player.is_none()) {
-            let c = self.dbus_conn.with_path(
-                self.player.clone().unwrap(),
-                "/org/mpris/MediaPlayer2",
-                1000,
-            );
+            let c = self.dbus_conn.with_path(self.player.clone().unwrap(), "/org/mpris/MediaPlayer2", 1000);
             let data = c.get("org.mpris.MediaPlayer2.Player", "Metadata");
 
             if let Ok(metadata) = data {
@@ -195,8 +164,7 @@ impl Block for Music {
                     self.current_song.set_text(String::new());
                 } else {
                     self.player_avail = true;
-                    self.current_song
-                        .set_text(format!("{} | {}", title, artist));
+                    self.current_song.set_text(format!("{} | {}", title, artist));
                 }
             } else {
                 self.current_song.set_text(String::from(""));
@@ -224,7 +192,7 @@ impl Block for Music {
         }
         Ok(match (next, self.marquee) {
             (Some(_), _) => next,
-            (None, _) => Some(Duration::new(2, 0))
+            (None, _) => Some(Duration::new(2, 0)),
         })
     }
 
@@ -237,16 +205,9 @@ impl Block for Music {
                 _ => "",
             };
             if action != "" {
-                let m = Message::new_method_call(
-                    self.player.as_ref().unwrap(),
-                    "/org/mpris/MediaPlayer2",
-                    "org.mpris.MediaPlayer2.Player",
-                    action,
-                ).block_error("music", "failed to create D-Bus method call")?;
-                self.dbus_conn
-                    .send(m)
-                    .block_error("music", "failed to call method via D-Bus")
-                    .map(|_| ())
+                let m = Message::new_method_call(self.player.as_ref().unwrap(), "/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.Player", action)
+                    .block_error("music", "failed to create D-Bus method call")?;
+                self.dbus_conn.send(m).block_error("music", "failed to call method via D-Bus").map(|_| ())
             } else {
                 Ok(())
             }
@@ -279,38 +240,31 @@ fn extract_from_metadata(metadata: &Box<arg::RefArg>) -> Result<(String, String)
     let mut title = String::new();
     let mut artist = String::new();
 
-    let mut iter = metadata
-        .as_iter()
-        .block_error("music", "failed to extract metadata")?;
+    let mut iter = metadata.as_iter().block_error("music", "failed to extract metadata")?;
 
     while let Some(key) = iter.next() {
-        let value = iter.next()
-            .block_error("music", "failed to extract metadata")?;
-        match key.as_str()
-            .block_error("music", "failed to extract metadata")?
-        {
+        let value = iter.next().block_error("music", "failed to extract metadata")?;
+        match key.as_str().block_error("music", "failed to extract metadata")? {
             "xesam:artist" => {
-                artist = String::from(value
-                    .as_iter()
-                    .block_error("music", "failed to extract metadata")?
-                    .nth(0)
-                    .block_error("music", "failed to extract metadata")?
-                    .as_iter()
-                    .block_error("music", "failed to extract metadata")?
-                    .nth(0)
-                    .block_error("music", "failed to extract metadata")?
-                    .as_iter()
-                    .block_error("music", "failed to extract metadata")?
-                    .nth(0)
-                    .block_error("music", "failed to extract metadata")?
-                    .as_str()
-                    .block_error("music", "failed to extract metadata")?)
+                artist = String::from(
+                    value
+                        .as_iter()
+                        .block_error("music", "failed to extract metadata")?
+                        .nth(0)
+                        .block_error("music", "failed to extract metadata")?
+                        .as_iter()
+                        .block_error("music", "failed to extract metadata")?
+                        .nth(0)
+                        .block_error("music", "failed to extract metadata")?
+                        .as_iter()
+                        .block_error("music", "failed to extract metadata")?
+                        .nth(0)
+                        .block_error("music", "failed to extract metadata")?
+                        .as_str()
+                        .block_error("music", "failed to extract metadata")?,
+                )
             }
-            "xesam:title" => {
-                title = String::from(value
-                    .as_str()
-                    .block_error("music", "failed to extract metadata")?)
-            }
+            "xesam:title" => title = String::from(value.as_str().block_error("music", "failed to extract metadata")?),
             _ => {}
         };
     }
@@ -321,7 +275,7 @@ fn get_first_available_player(connection: &Connection) -> Option<String> {
     let m = Message::new_method_call("org.freedesktop.DBus", "/", "org.freedesktop.DBus", "ListNames").unwrap();
     let r = connection.send_with_reply_and_block(m, 2000).unwrap();
     // ListNames returns one argument, which is an array of strings.
-    let mut arr: Array<&str, _>  = r.get1().unwrap();
+    let mut arr: Array<&str, _> = r.get1().unwrap();
     if let Some(name) = arr.find(|entry| entry.starts_with("org.mpris.MediaPlayer2")) {
         Some(String::from(name))
     } else {

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -24,10 +24,10 @@ pub struct NetworkDevice {
 
 impl NetworkDevice {
     /// Use the network device `device`. Raises an error if a directory for that
-    /// device is not found.
-    pub fn from_device(device: String) -> Result<Self> {
+    /// device is not found unless `allow_missing` is true.
+    pub fn from_device(device: String, allow_missing: bool) -> Result<Self> {
         let device_path = Path::new("/sys/class/net").join(device.clone());
-        if !device_path.exists() {
+        if !allow_missing && !device_path.exists() {
             return Err(BlockError("net".to_string(), format!("Network device '{}' does not exist", device_path.to_string_lossy())));
         }
 
@@ -154,6 +154,7 @@ pub struct Net {
     rx_bytes: u64,
     active: bool,
     hide_inactive: bool,
+    hide_missing: bool,
     last_update: Instant,
 }
 
@@ -188,6 +189,10 @@ pub struct NetConfig {
     #[serde(default = "NetConfig::default_hide_inactive")]
     pub hide_inactive: bool,
 
+    /// Whether to hide networks that are missing completely.
+    #[serde(default = "NetConfig::default_hide_missing")]
+    pub hide_missing: bool,
+
     /// Whether to show the upload throughput indicator of active networks.
     #[serde(default = "NetConfig::default_speed_up")]
     pub speed_up: bool,
@@ -215,6 +220,10 @@ impl NetConfig {
     }
 
     fn default_hide_inactive() -> bool {
+        false
+    }
+
+    fn default_hide_missing() -> bool {
         false
     }
 
@@ -255,9 +264,9 @@ impl ConfigBlock for Net {
     type Config = NetConfig;
 
     fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
-        let device = NetworkDevice::from_device(block_config.device)?;
-        let init_rx_bytes = device.rx_bytes()?;
-        let init_tx_bytes = device.tx_bytes()?;
+        let device = NetworkDevice::from_device(block_config.device, block_config.hide_missing)?;
+        let init_rx_bytes = device.rx_bytes().unwrap_or(0);
+        let init_tx_bytes = device.tx_bytes().unwrap_or(0);
         let wireless = device.is_wireless();
         Ok(Net {
             id: Uuid::new_v4().simple().to_string(),
@@ -284,6 +293,7 @@ impl ConfigBlock for Net {
             tx_bytes: init_tx_bytes,
             active: true,
             hide_inactive: block_config.hide_inactive,
+            hide_missing: block_config.hide_missing,
             last_update: Instant::now() - Duration::from_secs(30),
         })
     }
@@ -425,7 +435,7 @@ impl Block for Net {
                 widgets.push(graph_rx_widget);
             }
             widgets
-        } else if !self.hide_inactive {
+        } else if !(self.hide_inactive || self.hide_missing) {
             vec![&self.network]
         } else {
             vec![]

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -1,6 +1,6 @@
-use std::time::Duration;
-use std::process::Command;
 use chan::Sender;
+use std::process::Command;
+use std::time::Duration;
 
 use block::{Block, ConfigBlock};
 use config::Config;
@@ -113,13 +113,7 @@ impl ConfigBlock for NvidiaGpu {
         let id_memory = Uuid::new_v4().simple().to_string();
         let id_fans = Uuid::new_v4().simple().to_string();
         let mut output = Command::new("nvidia-smi")
-            .args(
-                &[
-                    "-i", &block_config.gpu_id.to_string(),
-                    "--query-gpu=name,memory.total",
-                    "--format=csv,noheader,nounits"
-                ],
-            )
+            .args(&["-i", &block_config.gpu_id.to_string(), "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"])
             .output()
             .block_error("gpu", "Failed to execute nvidia-smi.")?
             .stdout;
@@ -138,30 +132,15 @@ impl ConfigBlock for NvidiaGpu {
             gpu_name_displayed: false,
             gpu_id: block_config.gpu_id,
             label: block_config.label,
-            show_utilization: if block_config.show_utilization {
-                Some(TextWidget::new(config.clone())) } else {
-                None
-            },
-            show_memory: if block_config.show_memory {
-                Some(ButtonWidget::new(config.clone(), &id_memory)) } else {
-                None
-            },
+            show_utilization: if block_config.show_utilization { Some(TextWidget::new(config.clone())) } else { None },
+            show_memory: if block_config.show_memory { Some(ButtonWidget::new(config.clone(), &id_memory)) } else { None },
             memory_total: result[1].to_string(),
             memory_total_displayed: false,
-            show_temperature: if block_config.show_temperature {
-                Some(TextWidget::new(config.clone())) } else {
-                None
-            },
-            show_fan: if block_config.show_fan_speed {
-                Some(ButtonWidget::new(config.clone(), &id_fans)) } else {
-                None
-            },
+            show_temperature: if block_config.show_temperature { Some(TextWidget::new(config.clone())) } else { None },
+            show_fan: if block_config.show_fan_speed { Some(ButtonWidget::new(config.clone(), &id_fans)) } else { None },
             fan_speed: 0,
             fan_speed_controlled: false,
-            show_clocks: if block_config.show_clocks {
-                 Some(TextWidget::new(config.clone())) } else {
-                None
-            },
+            show_clocks: if block_config.show_clocks { Some(TextWidget::new(config.clone())) } else { None },
         })
     }
 }
@@ -186,13 +165,7 @@ impl Block for NvidiaGpu {
         }
 
         let mut output = Command::new("nvidia-smi")
-            .args(
-                &[
-                    "-i", &self.gpu_id.to_string(),
-                    &format!("--query-gpu={}", params),
-                    "--format=csv,noheader,nounits"
-                ],
-            )
+            .args(&["-i", &self.gpu_id.to_string(), &format!("--query-gpu={}", params), "--format=csv,noheader,nounits"])
             .output()
             .block_error("gpu", "Failed to execute nvidia-smi.")?
             .stdout;
@@ -273,7 +246,7 @@ impl Block for NvidiaGpu {
             if event_name == self.id {
                 self.gpu_name_displayed = match e.button {
                     MouseButton::Left => !self.gpu_name_displayed,
-                    _ => self.gpu_name_displayed
+                    _ => self.gpu_name_displayed,
                 };
 
                 if self.gpu_name_displayed {
@@ -286,7 +259,7 @@ impl Block for NvidiaGpu {
             if event_name == self.id_memory {
                 self.memory_total_displayed = match e.button {
                     MouseButton::Left => !self.memory_total_displayed,
-                    _ => self.gpu_name_displayed
+                    _ => self.gpu_name_displayed,
                 };
 
                 if let Some(ref mut memory_widget) = self.show_memory {
@@ -294,13 +267,7 @@ impl Block for NvidiaGpu {
                         memory_widget.set_text(format!("{}MB", self.memory_total));
                     } else {
                         let mut output = Command::new("nvidia-smi")
-                            .args(
-                                &[
-                                    "-i", &self.gpu_id.to_string(),
-                                    "--query-gpu=memory.used",
-                                    "--format=csv,noheader,nounits"
-                                ],
-                            )
+                            .args(&["-i", &self.gpu_id.to_string(), "--query-gpu=memory.used", "--format=csv,noheader,nounits"])
                             .output()
                             .block_error("gpu", "Failed to execute nvidia-smi.")?
                             .stdout;
@@ -336,44 +303,26 @@ impl Block for NvidiaGpu {
                     if controlled_changed {
                         if self.fan_speed_controlled {
                             Command::new("nvidia-settings")
-                                .args(
-                                    &[
-                                        "-a",
-                                        &format!("[gpu:{}]/GPUFanControlState=1",
-                                                 self.gpu_id),
-                                        "-a",
-                                        &format!("[fan:{}]/GPUTargetFanSpeed={}",
-                                                 self.gpu_id,
-                                                 self.fan_speed),
-                                    ],
-                                )
+                                .args(&[
+                                    "-a",
+                                    &format!("[gpu:{}]/GPUFanControlState=1", self.gpu_id),
+                                    "-a",
+                                    &format!("[fan:{}]/GPUTargetFanSpeed={}", self.gpu_id, self.fan_speed),
+                                ])
                                 .output()
                                 .block_error("gpu", "Failed to execute nvidia-settings.")?;
                             fan_widget.set_text(format!("{:02}%", self.fan_speed));
                             fan_widget.set_state(State::Warning);
                         } else {
                             Command::new("nvidia-settings")
-                                .args(
-                                    &[
-                                        "-a",
-                                        &format!("[gpu:{}]/GPUFanControlState=0",
-                                                 self.gpu_id),
-                                    ],
-                                )
+                                .args(&["-a", &format!("[gpu:{}]/GPUFanControlState=0", self.gpu_id)])
                                 .output()
                                 .block_error("gpu", "Failed to execute nvidia-settings.")?;
                             fan_widget.set_state(State::Idle);
                         }
                     } else if self.fan_speed_controlled {
                         Command::new("nvidia-settings")
-                            .args(
-                                &[
-                                    "-a",
-                                    &format!("[fan:{}]/GPUTargetFanSpeed={}",
-                                             self.gpu_id,
-                                             new_fan_speed),
-                                ],
-                            )
+                            .args(&["-a", &format!("[fan:{}]/GPUTargetFanSpeed={}", self.gpu_id, new_fan_speed)])
                             .output()
                             .block_error("gpu", "Failed to execute nvidia-settings.")?;
                         self.fan_speed = new_fan_speed;

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -1,20 +1,20 @@
-use std::fs;
-use std::path::Path;
-use std::os::unix::fs::symlink;
-use std::time::Duration;
-use std::process::Command;
-use std::env;
-use std::ffi::OsString;
 use chan::Sender;
 use scheduler::Task;
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
 
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
 use input::{I3BarEvent, MouseButton};
-use widgets::button::ButtonWidget;
 use widget::{I3BarWidget, State};
+use widgets::button::ButtonWidget;
 
 use uuid::Uuid;
 
@@ -61,16 +61,16 @@ fn run_command(var: &str) -> Result<()> {
 }
 
 fn has_fake_root() -> Result<bool> {
-    Ok(
-        String::from_utf8(
-            Command::new("sh")
-                .args(&["-c", "type -P fakeroot"])
-                .output()
-                .block_error("pacman", "failed to start command to check for fakeroot")?
-                .stdout,
-        ).block_error("pacman", "failed to check for fakeroot")?
-            .trim() != "",
+    Ok(String::from_utf8(
+        Command::new("sh")
+            .args(&["-c", "type -P fakeroot"])
+            .output()
+            .block_error("pacman", "failed to start command to check for fakeroot")?
+            .stdout,
     )
+    .block_error("pacman", "failed to check for fakeroot")?
+    .trim()
+        != "")
 }
 
 fn get_update_count() -> Result<usize> {
@@ -86,55 +86,39 @@ fn get_update_count() -> Result<usize> {
         .into_string()
         .block_error("pacman", "There's a problem with your $USER")?;
     let updates_db = env::var_os("CHECKUPDATES_DB")
-        .unwrap_or_else(|| {
-            OsString::from(format!("{}/checkup-db-{}", tmp_dir, user))
-        })
+        .unwrap_or_else(|| OsString::from(format!("{}/checkup-db-{}", tmp_dir, user)))
         .into_string()
         .block_error("pacman", "There's a problem with your $CHECKUPDATES_DB")?;
 
     // Determine pacman database path
-    let db_path = env::var_os("DBPath")
-        .map(Into::into)
-        .unwrap_or_else(|| Path::new("/var/lib/pacman/").to_path_buf());
+    let db_path = env::var_os("DBPath").map(Into::into).unwrap_or_else(|| Path::new("/var/lib/pacman/").to_path_buf());
 
     // Create the determined `checkup-db` path recursively
-    fs::create_dir_all(&updates_db).block_error(
-        "pacman",
-        &format!("Failed to create checkup-db path '{}'", updates_db),
-    )?;
+    fs::create_dir_all(&updates_db).block_error("pacman", &format!("Failed to create checkup-db path '{}'", updates_db))?;
 
     // Create symlink to local cache in `checkup-db` if required
     let local_cache = Path::new(&updates_db).join("local");
     if !local_cache.exists() {
-        symlink(db_path.join("local"), local_cache)
-            .block_error("pacman", "Failed to created required symlink")?;
+        symlink(db_path.join("local"), local_cache).block_error("pacman", "Failed to created required symlink")?;
     }
 
     // Update database
-    run_command(&format!(
-        "fakeroot -- pacman -Sy --dbpath \"{}\" --logfile /dev/null &> /dev/null",
-        updates_db
-    ))?;
+    run_command(&format!("fakeroot -- pacman -Sy --dbpath \"{}\" --logfile /dev/null &> /dev/null", updates_db))?;
 
     // Get update count
-    Ok(
-        String::from_utf8(
-            Command::new("sh")
-                .env("LC_ALL", "C")
-                .args(&[
-                    "-c",
-                    &format!("fakeroot pacman -Qu --dbpath \"{}\"", updates_db),
-                ])
-                .output()
-                .block_error("pacman", "There was a problem running the pacman commands")?
-                .stdout,
-        ).block_error("pacman", "there was a problem parsing the output")?
-            .lines()
-            .filter(|line| !line.contains("[ignored]"))
-            .count(),
+    Ok(String::from_utf8(
+        Command::new("sh")
+            .env("LC_ALL", "C")
+            .args(&["-c", &format!("fakeroot pacman -Qu --dbpath \"{}\"", updates_db)])
+            .output()
+            .block_error("pacman", "There was a problem running the pacman commands")?
+            .stdout,
     )
+    .block_error("pacman", "there was a problem parsing the output")?
+    .lines()
+    .filter(|line| !line.contains("[ignored]"))
+    .count())
 }
-
 
 impl Block for Pacman {
     fn update(&mut self) -> Result<Option<Duration>> {
@@ -145,7 +129,6 @@ impl Block for Pacman {
             _ => State::Info,
         });
         Ok(Some(self.update_interval))
-
     }
 
     fn view(&self) -> Vec<&I3BarWidget> {

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -1,17 +1,17 @@
-use std::time::{Duration, Instant};
-use std::process::Command;
-use std::thread::spawn;
-use std::sync::{Arc, Mutex};
 use chan::{async, Receiver, Sender};
 use scheduler::Task;
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::thread::spawn;
+use std::time::{Duration, Instant};
 
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
-use widgets::button::ButtonWidget;
-use widget::{I3BarWidget, State};
 use input::{I3BarEvent, MouseButton};
+use widget::{I3BarWidget, State};
+use widgets::button::ButtonWidget;
 
 use uuid::Uuid;
 
@@ -51,11 +51,7 @@ fn get_values(bytes: bool) -> Result<String> {
     if bytes {
         cmd.arg("--bytes");
     }
-    String::from_utf8(
-        cmd.output()
-            .block_error("speedtest", "could not get speedtest-cli output")?
-            .stdout,
-    ).block_error("speedtest", "could not parse speedtest-cli output")
+    String::from_utf8(cmd.output().block_error("speedtest", "could not get speedtest-cli output")?.stdout).block_error("speedtest", "could not parse speedtest-cli output")
 }
 
 fn parse_values(output: &str) -> Result<Vec<f32>> {
@@ -64,10 +60,7 @@ fn parse_values(output: &str) -> Result<Vec<f32>> {
     for line in output.lines() {
         let mut word = line.split_whitespace();
         word.next();
-        vals.push(word.next()
-            .block_error("speedtest", "missing data")?
-            .parse::<f32>()
-            .block_error("speedtest", "Unable to parse data")?);
+        vals.push(word.next().block_error("speedtest", "missing data")?.parse::<f32>().block_error("speedtest", "Unable to parse data")?);
     }
 
     Ok(vals)
@@ -79,9 +72,7 @@ fn make_thread(recv: Receiver<()>, done: Sender<Task>, values: Arc<Mutex<(bool, 
             if let Ok(output) = get_values(config.bytes) {
                 if let Ok(vals) = parse_values(&output) {
                     if vals.len() == 3 {
-                        let (ref mut update, ref mut values) = *values
-                            .lock()
-                            .expect("main thread paniced while holding speedtest-values mutex");
+                        let (ref mut update, ref mut values) = *values.lock().expect("main thread paniced while holding speedtest-values mutex");
                         *values = vals;
 
                         *update = true;
@@ -113,15 +104,9 @@ impl ConfigBlock for SpeedTest {
         Ok(SpeedTest {
             vals,
             text: vec![
-                ButtonWidget::new(config.clone(), &id)
-                    .with_icon("ping")
-                    .with_text("0ms"),
-                ButtonWidget::new(config.clone(), &id)
-                    .with_icon("net_down")
-                    .with_text(&format!("0{}", ty)),
-                ButtonWidget::new(config.clone(), &id)
-                    .with_icon("net_up")
-                    .with_text(&format!("0{}", ty)),
+                ButtonWidget::new(config.clone(), &id).with_icon("ping").with_text("0ms"),
+                ButtonWidget::new(config.clone(), &id).with_icon("net_down").with_text(&format!("0{}", ty)),
+                ButtonWidget::new(config.clone(), &id).with_icon("net_up").with_text(&format!("0{}", ty)),
             ],
             id,
             send,
@@ -132,9 +117,7 @@ impl ConfigBlock for SpeedTest {
 
 impl Block for SpeedTest {
     fn update(&mut self) -> Result<Option<Duration>> {
-        let (ref mut updated, ref vals) = *self.vals
-            .lock()
-            .block_error("speedtest", "mutext poisoned")?;
+        let (ref mut updated, ref vals) = *self.vals.lock().block_error("speedtest", "mutext poisoned")?;
 
         if *updated {
             *updated = false;

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -1,16 +1,16 @@
-use std::time::Duration;
-use std::process::Command;
-use util::FormatTemplate;
 use chan::Sender;
 use scheduler::Task;
+use std::process::Command;
+use std::time::Duration;
+use util::FormatTemplate;
 
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
-use widgets::button::ButtonWidget;
-use widget::{I3BarWidget, State};
 use input::{I3BarEvent, MouseButton};
+use widget::{I3BarWidget, State};
+use widgets::button::ButtonWidget;
 
 use uuid::Uuid;
 
@@ -87,7 +87,6 @@ impl TemperatureConfig {
     fn default_warning() -> i64 {
         80
     }
-
 }
 
 impl ConfigBlock for Temperature {
@@ -105,8 +104,7 @@ impl ConfigBlock for Temperature {
             maximum_idle: block_config.idle,
             maximum_info: block_config.info,
             maximum_warning: block_config.warning,
-            format: FormatTemplate::from_string(&block_config.format)
-                .block_error("temperature", "Invalid format specified for temperature")?,
+            format: FormatTemplate::from_string(&block_config.format).block_error("temperature", "Invalid format specified for temperature")?,
         })
     }
 }
@@ -123,11 +121,7 @@ impl Block for Temperature {
 
         for line in output.lines() {
             if line.starts_with("  temp") {
-                let rest = &line[6..]
-                    .split('_')
-                    .flat_map(|x| x.split(' '))
-                    .flat_map(|x| x.split('.'))
-                    .collect::<Vec<_>>();
+                let rest = &line[6..].split('_').flat_map(|x| x.split(' ')).flat_map(|x| x.split('.')).collect::<Vec<_>>();
 
                 if rest[1].starts_with("input") {
                     match rest[2].parse::<i64>() {
@@ -140,24 +134,15 @@ impl Block for Temperature {
                             eprintln!("Temperature ({}) outside of range ([-100, 150])", t);
                             Ok(())
                         }
-                        Err(_) => Err(BlockError(
-                            "temperature".to_owned(),
-                            "failed to parse temperature as an integer".to_owned(),
-                        )),
+                        Err(_) => Err(BlockError("temperature".to_owned(), "failed to parse temperature as an integer".to_owned())),
                     }?
                 }
             }
         }
 
         if !temperatures.is_empty() {
-            let max: i64 = *temperatures
-                .iter()
-                .max()
-                .block_error("temperature", "failed to get max temperature")?;
-            let min: i64 = *temperatures
-                .iter()
-                .min()
-                .block_error("temperature", "failed to get min temperature")?;
+            let max: i64 = *temperatures.iter().max().block_error("temperature", "failed to get max temperature")?;
+            let min: i64 = *temperatures.iter().min().block_error("temperature", "failed to get min temperature")?;
             let avg: i64 = (temperatures.iter().sum::<i64>() as f64 / temperatures.len() as f64).round() as i64;
 
             let values = map!("{average}" => avg,

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -1,14 +1,14 @@
-use std::time::Duration;
 use chan::Sender;
+use std::time::Duration;
 
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
-use widgets::text::TextWidget;
-use widget::I3BarWidget;
 use input::I3BarEvent;
 use scheduler::Task;
+use widget::I3BarWidget;
+use widgets::text::TextWidget;
 
 use uuid::Uuid;
 

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -1,19 +1,19 @@
-use std::time::Duration;
-use std::process::Command;
 use std::ffi::OsStr;
+use std::process::Command;
+use std::time::Duration;
 
 use block::{Block, ConfigBlock};
+use chan::Sender;
+use chrono::offset::{Local, Utc};
+use chrono_tz::Tz;
 use config::Config;
 use de::{deserialize_duration, deserialize_timezone};
 use errors::*;
-use chrono::offset::{Utc, Local};
-use chrono_tz::Tz;
-use scheduler::Task;
-use chan::Sender;
-use widgets::button::ButtonWidget;
-use widget::I3BarWidget;
 use input::I3BarEvent;
+use scheduler::Task;
 use uuid::Uuid;
+use widget::I3BarWidget;
+use widgets::button::ButtonWidget;
 
 pub struct Time {
     time: ButtonWidget,
@@ -68,9 +68,7 @@ impl ConfigBlock for Time {
         Ok(Time {
             id: i.clone(),
             format: block_config.format,
-            time: ButtonWidget::new(config, i.as_str())
-                .with_text("")
-                .with_icon("time"),
+            time: ButtonWidget::new(config, i.as_str()).with_text("").with_icon("time"),
             update_interval: block_config.interval,
             on_click: block_config.on_click,
             timezone: block_config.timezone,
@@ -88,22 +86,14 @@ impl Block for Time {
         Ok(Some(self.update_interval))
     }
 
-
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        let command = if self.on_click.is_some() {
-            self.on_click.clone().unwrap()
-        } else {
-            "".to_string()
-        };
-
+        let command = if self.on_click.is_some() { self.on_click.clone().unwrap() } else { "".to_string() };
 
         if let Some(ref name) = e.name {
             if name.as_str() == self.id && self.on_click.is_some() {
                 let command_broken: Vec<&str> = command.split_whitespace().collect();
                 let mut itr = command_broken.iter();
-                let mut _cmd = Command::new(OsStr::new(&itr.next().unwrap()))
-                    .args(itr)
-                    .spawn();
+                let mut _cmd = Command::new(OsStr::new(&itr.next().unwrap())).args(itr).spawn();
             }
         }
         Ok(())

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -1,16 +1,16 @@
-use std::env;
-use std::time::Duration;
-use std::process::Command;
 use chan::Sender;
 use scheduler::Task;
+use std::env;
+use std::process::Command;
+use std::time::Duration;
 
 use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_opt_duration;
 use errors::*;
-use widgets::button::ButtonWidget;
-use widget::I3BarWidget;
 use input::I3BarEvent;
+use widget::I3BarWidget;
+use widgets::button::ButtonWidget;
 
 use uuid::Uuid;
 

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -10,8 +10,8 @@ use de::deserialize_duration;
 use errors::*;
 use scheduler::Task;
 use util::read_file;
-use widgets::text::TextWidget;
 use widget::I3BarWidget;
+use widgets::text::TextWidget;
 
 pub struct Uptime {
     text: TextWidget,
@@ -19,8 +19,10 @@ pub struct Uptime {
     update_interval: Duration,
 
     //useful, but optional
-    #[allow(dead_code)] config: Config,
-    #[allow(dead_code)] tx_update_request: Sender<Task>,
+    #[allow(dead_code)]
+    config: Config,
+    #[allow(dead_code)]
+    tx_update_request: Sender<Task>,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -56,29 +58,20 @@ impl Block for Uptime {
         let uptime_raw = match read_file("uptime", Path::new("/proc/uptime")) {
             Ok(file) => file,
             Err(e) => {
-                return Err(BlockError(
-                    "Uptime".to_owned(),
-                    format!("Uptime failed to read /proc/uptime: '{}'", e),
-                ));
+                return Err(BlockError("Uptime".to_owned(), format!("Uptime failed to read /proc/uptime: '{}'", e)));
             }
         };
         let uptime = match uptime_raw.split_whitespace().nth(0) {
             Some(uptime) => uptime,
             None => {
-                return Err(BlockError(
-                    "Uptime".to_owned(),
-                    "Uptime failed to read uptime string.".to_owned(),
-                ));
+                return Err(BlockError("Uptime".to_owned(), "Uptime failed to read uptime string.".to_owned()));
             }
         };
 
         let total_seconds = match uptime.parse::<f64>() {
             Ok(uptime) => uptime as u32,
             Err(e) => {
-                return Err(BlockError(
-                    "Uptime".to_owned(),
-                    format!("Uptime failed to convert uptime float to integer: '{}')", e),
-                ));
+                return Err(BlockError("Uptime".to_owned(), format!("Uptime failed to convert uptime float to integer: '{}')", e)));
             }
         };
 

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -1,8 +1,8 @@
+use chan::Sender;
+use serde_json;
 use std::collections::HashMap;
 use std::process::Command;
 use std::time::Duration;
-use chan::Sender;
-use serde_json;
 use uuid::Uuid;
 
 use block::{Block, ConfigBlock};
@@ -12,8 +12,8 @@ use errors::*;
 use input::{I3BarEvent, MouseButton};
 use scheduler::Task;
 use util::FormatTemplate;
-use widgets::button::ButtonWidget;
 use widget::I3BarWidget;
+use widgets::button::ButtonWidget;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(tag = "name", rename_all = "lowercase")]
@@ -25,11 +25,7 @@ pub enum WeatherService {
     //     longitude: f64,
     //     units: Option<InputUnit>
     // },
-    OpenWeatherMap {
-        api_key: String,
-        city_id: String,
-        units: OpenWeatherMapUnits,
-    },
+    OpenWeatherMap { api_key: String, city_id: String, units: OpenWeatherMapUnits },
 }
 
 #[derive(Copy, Clone, Debug, Deserialize)]
@@ -51,31 +47,23 @@ pub struct Weather {
 impl Weather {
     fn update_weather(&mut self) -> Result<()> {
         match self.service {
-            WeatherService::OpenWeatherMap {
-                ref api_key,
-                ref city_id,
-                ref units,
-            } => {
+            WeatherService::OpenWeatherMap { ref api_key, ref city_id, ref units } => {
                 let output = Command::new("sh")
-                    .args(
-                        &[
-                            "-c",
-                            &format!(
-                                "curl -m 3 \"http://api.openweathermap.org/data/2.5/weather?id={city_id}&appid={api_key}&units={units}\" 2> /dev/null",
-                                city_id = city_id,
-                                api_key = api_key,
-                                units = match *units {
-                                    OpenWeatherMapUnits::Metric => "metric",
-                                    OpenWeatherMapUnits::Imperial => "imperial",
-                                },
-                            ),
-                        ],
-                    )
+                    .args(&[
+                        "-c",
+                        &format!(
+                            "curl -m 3 \"http://api.openweathermap.org/data/2.5/weather?id={city_id}&appid={api_key}&units={units}\" 2> /dev/null",
+                            city_id = city_id,
+                            api_key = api_key,
+                            units = match *units {
+                                OpenWeatherMapUnits::Metric => "metric",
+                                OpenWeatherMapUnits::Imperial => "imperial",
+                            },
+                        ),
+                    ])
                     .output()
                     .block_error("weather", "Failed to exectute curl.")
-                    .and_then(|raw_output| {
-                        String::from_utf8(raw_output.stdout).block_error("weather", "Non-UTF8 SSID.")
-                    })?;
+                    .and_then(|raw_output| String::from_utf8(raw_output.stdout).block_error("weather", "Non-UTF8 SSID."))?;
 
                 // Don't error out on empty responses e.g. for when not
                 // connected to the internet.
@@ -85,79 +73,54 @@ impl Weather {
                     return Ok(());
                 }
 
-                let json: serde_json::value::Value = serde_json::from_str(&output).block_error(
-                    "weather",
-                    "Failed to parse JSON response.",
-                )?;
+                let json: serde_json::value::Value = serde_json::from_str(&output).block_error("weather", "Failed to parse JSON response.")?;
 
                 // Try to convert an API error into a block error.
                 if let Some(val) = json.get("message") {
-                    return Err(BlockError(
-                        "weather".to_string(),
-                        format!("API Error: {}", val.as_str().unwrap()),
-                    ));
+                    return Err(BlockError("weather".to_string(), format!("API Error: {}", val.as_str().unwrap())));
                 };
-                let raw_weather = match json.pointer("/weather/0/main")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()) {
+                let raw_weather = match json.pointer("/weather/0/main").and_then(|v| v.as_str()).map(|s| s.to_string()) {
                     Some(v) => v,
                     None => {
-                        return Err(BlockError(
-                            "weather".to_string(),
-                            "Malformed JSON.".to_string(),
-                        ));
+                        return Err(BlockError("weather".to_string(), "Malformed JSON.".to_string()));
                     }
                 };
                 let raw_temp = match json.pointer("/main/temp").and_then(|v| v.as_f64()) {
                     Some(v) => v,
                     None => {
-                        return Err(BlockError(
-                            "weather".to_string(),
-                            "Malformed JSON.".to_string(),
-                        ));
+                        return Err(BlockError("weather".to_string(), "Malformed JSON.".to_string()));
                     }
                 };
                 let raw_wind_speed = match json.pointer("/wind/speed").and_then(|v| v.as_f64()) {
                     Some(v) => v,
                     None => {
-                        return Err(BlockError(
-                            "weather".to_string(),
-                            "Malformed JSON.".to_string(),
-                        ));
+                        return Err(BlockError("weather".to_string(), "Malformed JSON.".to_string()));
                     }
                 };
                 let raw_wind_direction = match json.pointer("/wind/deg").and_then(|v| v.as_f64()) {
                     Some(v) => v,
                     None => {
-                        return Err(BlockError(
-                            "weather".to_string(),
-                            "Malformed JSON.".to_string(),
-                        ));
+                        return Err(BlockError("weather".to_string(), "Malformed JSON.".to_string()));
                     }
                 };
-                let raw_location = match json.pointer("/name").and_then(|v| v.as_str()).map(|s| {
-                    s.to_string()
-                }) {
+                let raw_location = match json.pointer("/name").and_then(|v| v.as_str()).map(|s| s.to_string()) {
                     Some(v) => v,
                     None => {
-                        return Err(BlockError(
-                            "weather".to_string(),
-                            "Malformed JSON.".to_string(),
-                        ));
+                        return Err(BlockError("weather".to_string(), "Malformed JSON.".to_string()));
                     }
                 };
 
                 // Convert wind direction in azimuth degrees to abbreviation names
                 fn convert_wind_direction(direction: f64) -> String {
                     match direction.round() as i64 {
-                        24 ... 68 => "NE".to_string(),
-                        69 ... 113 => "E".to_string(),
-                        114 ... 158 => "SE".to_string(),
-                        159 ... 203 => "S".to_string(),
-                        204 ... 248 => "SW".to_string(),
-                        249 ... 293 => "W".to_string(),
-                        294 ... 338 => "NW".to_string(),
-                        _ => "N".to_string()
+                        24...68 => "NE".to_string(),
+                        69...113 => "E".to_string(),
+                        114...158 => "SE".to_string(),
+                        159...203 => "S".to_string(),
+                        204...248 => "SW".to_string(),
+                        249...293 => "W".to_string(),
+                        294...338 => "NW".to_string(),
+                        _ => "N".to_string(),
                     }
                 }
 
@@ -170,8 +133,7 @@ impl Weather {
                     _ => "weather_default",
                 });
 
-                self.weather_keys =
-                    map_to_owned!("{weather}" => raw_weather,
+                self.weather_keys = map_to_owned!("{weather}" => raw_weather,
                                   "{temp}" => format!("{:.0}", raw_temp),
                                   "{wind}" => format!("{:.1}", raw_wind_speed),
                                   "{direction}" => convert_wind_direction(raw_wind_direction),
@@ -239,7 +201,7 @@ impl Block for Weather {
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
         if event.matches_name(self.id()) {
             if let MouseButton::Left = event.button {
-                    self.update()?;
+                self.update()?;
             }
         }
         Ok(())

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -1,8 +1,8 @@
-use std::time::Duration;
-use std::process::Command;
-use std::str::FromStr;
 use chan::Sender;
 use scheduler::Task;
+use std::process::Command;
+use std::str::FromStr;
+use std::time::Duration;
 
 use util::FormatTemplate;
 
@@ -10,9 +10,9 @@ use block::{Block, ConfigBlock};
 use config::Config;
 use de::deserialize_duration;
 use errors::*;
-use widgets::button::ButtonWidget;
-use widget::I3BarWidget;
 use input::{I3BarEvent, MouseButton};
+use widget::I3BarWidget;
+use widgets::button::ButtonWidget;
 
 use uuid::Uuid;
 
@@ -33,14 +33,7 @@ impl Monitor {
 
     fn set_brightness(&mut self, step: i32) {
         Command::new("sh")
-            .args(&[
-                "-c",
-                format!(
-                    "xrandr --output {} --brightness {}",
-                    self.name,
-                    (self.brightness as i32 + step) as f32 / 100.0
-                ).as_str(),
-            ])
+            .args(&["-c", format!("xrandr --output {} --brightness {}", self.name, (self.brightness as i32 + step) as f32 / 100.0).as_str()])
             .spawn()
             .expect("Failed to set xrandr output.");
         self.brightness = (self.brightness as i32 + step) as u32;
@@ -100,12 +93,12 @@ impl XrandrConfig {
 }
 
 macro_rules! unwrap_or_continue {
-    ($e: expr) => (
+    ($e: expr) => {
         match $e {
             Some(e) => e,
             None => continue,
         }
-    )
+    };
 }
 
 impl Xrandr {
@@ -116,15 +109,12 @@ impl Xrandr {
                 .output()
                 .block_error("xrandr", "couldn't collect active xrandr monitors")?
                 .stdout,
-        ).block_error("xrandr", "couldn't parse xrandr monitor list")?;
+        )
+        .block_error("xrandr", "couldn't parse xrandr monitor list")?;
         let monitors: Vec<&str> = active_montiors_cli.split('\n').collect();
         let mut active_monitors: Vec<String> = Vec::new();
         for monitor in monitors {
-            if let Some((name, _)) = monitor
-                .split_whitespace()
-                .collect::<Vec<&str>>()
-                .split_last()
-            {
+            if let Some((name, _)) = monitor.split_whitespace().collect::<Vec<&str>>().split_last() {
                 active_monitors.push(String::from(*name));
             }
         }
@@ -137,17 +127,15 @@ impl Xrandr {
 
     fn get_monitor_metrics(monitor_names: &[String]) -> Result<Option<Vec<Monitor>>> {
         let mut monitor_metrics: Vec<Monitor> = Vec::new();
-        let grep_arg = format!(
-            "xrandr --verbose | grep -w '{} connected\\|Brightness'",
-            monitor_names.join(" connected\\|")
-        );
+        let grep_arg = format!("xrandr --verbose | grep -w '{} connected\\|Brightness'", monitor_names.join(" connected\\|"));
         let monitor_info_cli = String::from_utf8(
             Command::new("sh")
                 .args(&["-c", grep_arg.as_str()])
                 .output()
                 .block_error("xrandr", "couldn't collect xrandr monitor info")?
                 .stdout,
-        ).block_error("xrandr", "couldn't parse xrandr monitor info")?;
+        )
+        .block_error("xrandr", "couldn't parse xrandr monitor info")?;
 
         let monitor_infos: Vec<&str> = monitor_info_cli.split('\n').collect();
         for i in 0..monitor_infos.len() {
@@ -162,9 +150,7 @@ impl Xrandr {
             if let Some(name) = mi_line_args.get(0) {
                 display = name.trim();
                 if let Some(brightness_raw) = b_line.split(':').collect::<Vec<&str>>().get(1) {
-                    brightness = (f32::from_str(brightness_raw.trim())
-                        .block_error("xrandr", "unable to parse brightness")? * 100.0)
-                        .floor() as u32;
+                    brightness = (f32::from_str(brightness_raw.trim()).block_error("xrandr", "unable to parse brightness")? * 100.0).floor() as u32;
                 }
             }
             if let Some(mut res) = mi_line_args.get(2) {
@@ -202,7 +188,6 @@ impl Xrandr {
             } else {
                 "{display}: {brightness}"
             };
-
 
             if let Ok(fmt_template) = FormatTemplate::from_string(format_str) {
                 self.text.set_text(fmt_template.render_static_str(&values)?);
@@ -256,21 +241,27 @@ impl Block for Xrandr {
         if let Some(ref name) = e.name {
             if name.as_str() == self.id {
                 match e.button {
-                    MouseButton::Left => if self.current_idx < self.monitors.len() - 1 {
-                        self.current_idx += 1;
-                    } else {
-                        self.current_idx = 0;
-                    },
-                    MouseButton::WheelUp => if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
-                        if monitor.brightness <= (100 - self.step_width) {
-                            monitor.set_brightness(self.step_width as i32);
+                    MouseButton::Left => {
+                        if self.current_idx < self.monitors.len() - 1 {
+                            self.current_idx += 1;
+                        } else {
+                            self.current_idx = 0;
                         }
-                    },
-                    MouseButton::WheelDown => if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
-                        if monitor.brightness >= self.step_width {
-                            monitor.set_brightness(-(self.step_width as i32));
+                    }
+                    MouseButton::WheelUp => {
+                        if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
+                            if monitor.brightness <= (100 - self.step_width) {
+                                monitor.set_brightness(self.step_width as i32);
+                            }
                         }
-                    },
+                    }
+                    MouseButton::WheelDown => {
+                        if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
+                            if monitor.brightness >= self.step_width {
+                                monitor.set_brightness(-(self.step_width as i32));
+                            }
+                        }
+                    }
                     _ => {}
                 }
                 self.display()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,12 @@
 use de::*;
 use icons;
 use serde::de::{self, Deserialize, Deserializer};
-use toml::value;
 use std::collections::HashMap as Map;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::str::FromStr;
 use themes::{self, Theme};
+use toml::value;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {
@@ -62,11 +62,7 @@ where
     map_type!(ThemeIntermediary, String;
               s => Ok(ThemeIntermediary(themes::get_theme(s).ok_or_else(|| "cannot find specified theme")?.owned_map())));
 
-    let intermediary: Map<String, String> = deserializer
-        .deserialize_any(MapType::<ThemeIntermediary, String>(
-            PhantomData,
-            PhantomData,
-        ))?;
+    let intermediary: Map<String, String> = deserializer.deserialize_any(MapType::<ThemeIntermediary, String>(PhantomData, PhantomData))?;
 
     Deserialize::deserialize(de::value::MapDeserializer::new(intermediary.into_iter()))
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,3 +1,4 @@
+use chrono_tz::Tz;
 use serde::de::{self, Deserialize, DeserializeSeed, Deserializer};
 use std::collections::{BTreeMap, HashMap as Map};
 use std::error::Error;
@@ -7,7 +8,6 @@ use std::ops::Deref;
 use std::str::FromStr;
 use std::time::Duration;
 use toml::{self, value};
-use chrono_tz::Tz;
 
 pub fn deserialize_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
@@ -82,7 +82,7 @@ macro_rules! map_type {
                 $fromstr_expr
             }
         }
-    }
+    };
 }
 
 impl<'de, T, V> DeserializeSeed<'de> for MapType<T, V>
@@ -124,9 +124,7 @@ where
         A: de::SeqAccess<'de>,
     {
         let mut vec: Vec<Self::Value> = Vec::new();
-        while let Some(element) = visitor
-            .next_element_seed(MapType::<T, V>(PhantomData, PhantomData))?
-        {
+        while let Some(element) = visitor.next_element_seed(MapType::<T, V>(PhantomData, PhantomData))? {
             vec.push(element);
         }
 
@@ -169,15 +167,12 @@ where
             );
         }
         if let Some(raw_overrides) = map.remove("overrides") {
-            let overrides: Map<String, V> = Map::<String, V>::deserialize(raw_overrides)
-                .map_err(|e: toml::de::Error| de::Error::custom(e.description()))?;
+            let overrides: Map<String, V> = Map::<String, V>::deserialize(raw_overrides).map_err(|e: toml::de::Error| de::Error::custom(e.description()))?;
             combined.extend(overrides);
         }
 
         if combined.is_empty() {
-            Err(de::Error::custom(
-                "missing all fields (`name`, `overrides`)",
-            ))
+            Err(de::Error::custom("missing all fields (`name`, `overrides`)"))
         } else {
             Ok(combined)
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,19 +26,11 @@ where
     E: fmt::Display + fmt::Debug,
 {
     fn configuration_error(self, message: &str) -> Result<T> {
-        self.map_err(|e| {
-            ConfigurationError(message.to_owned(), (format!("{}", e), format!("{:?}", e)))
-        })
+        self.map_err(|e| ConfigurationError(message.to_owned(), (format!("{}", e), format!("{:?}", e))))
     }
 
     fn internal_error(self, context: &str, message: &str) -> Result<T> {
-        self.map_err(|e| {
-            InternalError(
-                context.to_owned(),
-                message.to_owned(),
-                Some((format!("{}", e), format!("{:?}", e))),
-            )
-        })
+        self.map_err(|e| InternalError(context.to_owned(), message.to_owned(), Some((format!("{}", e), format!("{:?}", e)))))
     }
 }
 
@@ -53,9 +45,7 @@ impl<T> OptionExt<T> for ::std::option::Option<T> {
     }
 
     fn internal_error(self, context: &str, message: &str) -> Result<T> {
-        self.ok_or_else(|| {
-            InternalError(context.to_owned(), message.to_owned(), None)
-        })
+        self.ok_or_else(|| InternalError(context.to_owned(), message.to_owned(), None))
     }
 }
 
@@ -71,11 +61,7 @@ impl fmt::Display for Error {
         match *self {
             BlockError(ref block, ref message) => f.write_str(&format!("Error in block '{}': {}", block, message)),
             ConfigurationError(ref message, _) => f.write_str(&format!("Configuration error: {}", message)),
-            InternalError(ref context, ref message, _) => f.write_str(&format!(
-                "Internal error in context '{}': {}",
-                context,
-                message
-            )),
+            InternalError(ref context, ref message, _) => f.write_str(&format!("Internal error in context '{}': {}", context, message)),
         }
     }
 }
@@ -84,22 +70,9 @@ impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             BlockError(ref block, ref message) => f.write_str(&format!("Error in block '{}': {}", block, message)),
-            ConfigurationError(ref message, (ref cause, _)) => f.write_str(&format!(
-                "Configuration error: {}.\nCause: {}",
-                message,
-                cause
-            )),
-            InternalError(ref context, ref message, Some((ref cause, _))) => f.write_str(&format!(
-                "Internal error in context '{}': {}.\nCause: {}",
-                context,
-                message,
-                cause
-            )),
-            InternalError(ref context, ref message, None) => f.write_str(&format!(
-                "Internal error in context '{}': {}",
-                context,
-                message
-            )),
+            ConfigurationError(ref message, (ref cause, _)) => f.write_str(&format!("Configuration error: {}.\nCause: {}", message, cause)),
+            InternalError(ref context, ref message, Some((ref cause, _))) => f.write_str(&format!("Internal error in context '{}': {}.\nCause: {}", context, message, cause)),
+            InternalError(ref context, ref message, None) => f.write_str(&format!("Internal error in context '{}': {}", context, message)),
         }
     }
 }
@@ -125,10 +98,6 @@ where
     T: fmt::Display + Send,
 {
     fn from(err: ::std::sync::mpsc::SendError<T>) -> Error {
-        InternalError(
-            "unknown".to_owned(),
-            format!("send error for '{}'", err.0),
-            None,
-        )
+        InternalError("unknown".to_owned(), format!("send error for '{}'", err.0), None)
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,10 +1,10 @@
+use chan::Sender;
 use serde::{de, Deserializer};
 use serde_json;
 use std::fmt;
 use std::io;
 use std::option::Option;
 use std::string::*;
-use chan::Sender;
 use std::thread;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,17 +7,17 @@ extern crate serde;
 extern crate serde_json;
 #[macro_use]
 extern crate chan;
-extern crate toml;
-extern crate clap;
-extern crate uuid;
-extern crate regex;
-extern crate num;
-extern crate inotify;
-extern crate maildir;
 extern crate chrono;
 extern crate chrono_tz;
+extern crate clap;
+extern crate inotify;
 #[cfg(feature = "pulseaudio")]
 extern crate libpulse_binding as pulse;
+extern crate maildir;
+extern crate num;
+extern crate regex;
+extern crate toml;
+extern crate uuid;
 
 #[macro_use]
 mod de;
@@ -27,10 +27,10 @@ mod block;
 pub mod blocks;
 mod config;
 mod errors;
-mod input;
 mod icons;
-mod themes;
+mod input;
 mod scheduler;
+mod themes;
 mod widget;
 mod widgets;
 
@@ -42,8 +42,8 @@ use cpuprofiler::PROFILER;
 extern crate progress;
 
 use std::collections::HashMap;
-use std::time::Duration;
 use std::ops::DerefMut;
+use std::time::Duration;
 
 use block::Block;
 
@@ -57,8 +57,8 @@ use widgets::text::TextWidget;
 
 use util::deserialize_file;
 
-use self::clap::{App, Arg, ArgMatches};
 use self::chan::{Receiver, Sender};
+use self::clap::{App, Arg, ArgMatches};
 
 fn main() {
     let mut builder = App::new("i3status-rs")
@@ -68,18 +68,10 @@ fn main() {
              https://github.com/greshake/i3status-rust/graphs/contributors",
         )
         .about("Replacement for i3status for Linux, written in Rust")
-        .arg(
-            Arg::with_name("config")
-                .value_name("CONFIG_FILE")
-                .help("sets a toml config file")
-                .required(true)
-                .index(1),
-        )
+        .arg(Arg::with_name("config").value_name("CONFIG_FILE").help("sets a toml config file").required(true).index(1))
         .arg(
             Arg::with_name("exit-on-error")
-                .help(
-                    "exit on error rather than printing the error to i3bar and keep running",
-                )
+                .help("exit on error rather than printing the error to i3bar and keep running")
                 .long("exit-on-error")
                 .takes_value(false),
         );
@@ -111,14 +103,9 @@ fn main() {
             ::std::process::exit(1);
         }
 
-        let error_widget = TextWidget::new(Default::default())
-            .with_state(State::Critical)
-            .with_text(&format!("{:?}", error));
+        let error_widget = TextWidget::new(Default::default()).with_state(State::Critical).with_text(&format!("{:?}", error));
         let error_rendered = error_widget.get_rendered();
-        println!(
-            "{}",
-            serde_json::to_string(&[error_rendered]).expect("failed to serialize error message")
-        );
+        println!("{}", serde_json::to_string(&[error_rendered]).expect("failed to serialize error message"));
 
         eprintln!("\n\n{:?}", error);
         // Do nothing, so the error message keeps displayed
@@ -148,28 +135,18 @@ fn run(matches: &ArgMatches) -> Result<()> {
     let mut config_alternating_tint = config.clone();
     {
         let tint_bg = &config.theme.alternating_tint_bg;
-        config_alternating_tint.theme.idle_bg = util::add_colors(&config_alternating_tint.theme.idle_bg, tint_bg)
-            .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.info_bg = util::add_colors(&config_alternating_tint.theme.info_bg, tint_bg)
-            .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.good_bg = util::add_colors(&config_alternating_tint.theme.good_bg, tint_bg)
-            .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.warning_bg = util::add_colors(&config_alternating_tint.theme.warning_bg, tint_bg)
-            .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.critical_bg = util::add_colors(&config_alternating_tint.theme.critical_bg, tint_bg)
-            .configuration_error("can't parse alternative_tint color code")?;
+        config_alternating_tint.theme.idle_bg = util::add_colors(&config_alternating_tint.theme.idle_bg, tint_bg).configuration_error("can't parse alternative_tint color code")?;
+        config_alternating_tint.theme.info_bg = util::add_colors(&config_alternating_tint.theme.info_bg, tint_bg).configuration_error("can't parse alternative_tint color code")?;
+        config_alternating_tint.theme.good_bg = util::add_colors(&config_alternating_tint.theme.good_bg, tint_bg).configuration_error("can't parse alternative_tint color code")?;
+        config_alternating_tint.theme.warning_bg = util::add_colors(&config_alternating_tint.theme.warning_bg, tint_bg).configuration_error("can't parse alternative_tint color code")?;
+        config_alternating_tint.theme.critical_bg = util::add_colors(&config_alternating_tint.theme.critical_bg, tint_bg).configuration_error("can't parse alternative_tint color code")?;
 
         let tint_fg = &config.theme.alternating_tint_fg;
-        config_alternating_tint.theme.idle_fg = util::add_colors(&config_alternating_tint.theme.idle_fg, tint_fg)
-            .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.info_fg = util::add_colors(&config_alternating_tint.theme.info_fg, tint_fg)
-            .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.good_fg = util::add_colors(&config_alternating_tint.theme.good_fg, tint_fg)
-            .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.warning_fg = util::add_colors(&config_alternating_tint.theme.warning_fg, tint_fg)
-            .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.critical_fg = util::add_colors(&config_alternating_tint.theme.critical_fg, tint_fg)
-            .configuration_error("can't parse alternative_tint color code")?;
+        config_alternating_tint.theme.idle_fg = util::add_colors(&config_alternating_tint.theme.idle_fg, tint_fg).configuration_error("can't parse alternative_tint color code")?;
+        config_alternating_tint.theme.info_fg = util::add_colors(&config_alternating_tint.theme.info_fg, tint_fg).configuration_error("can't parse alternative_tint color code")?;
+        config_alternating_tint.theme.good_fg = util::add_colors(&config_alternating_tint.theme.good_fg, tint_fg).configuration_error("can't parse alternative_tint color code")?;
+        config_alternating_tint.theme.warning_fg = util::add_colors(&config_alternating_tint.theme.warning_fg, tint_fg).configuration_error("can't parse alternative_tint color code")?;
+        config_alternating_tint.theme.critical_fg = util::add_colors(&config_alternating_tint.theme.critical_fg, tint_fg).configuration_error("can't parse alternative_tint color code")?;
     }
 
     let mut blocks: Vec<Box<Block>> = Vec::new();
@@ -180,11 +157,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
         blocks.push(create_block(
             block_name,
             block_config.clone(),
-            if alternator {
-                config_alternating_tint.clone()
-            } else {
-                config.clone()
-            },
+            if alternator { config_alternating_tint.clone() } else { config.clone() },
             tx_update_requests.clone(),
         )?);
         alternator = !alternator;
@@ -254,15 +227,10 @@ fn profile(iterations: i32, name: &str, block: &mut Block) {
     println!(
         "Now profiling the {0} block by executing {1} updates.\n \
          Use pprof to analyze {0}.profile later.",
-        name,
-        iterations
+        name, iterations
     );
 
-    PROFILER
-        .lock()
-        .unwrap()
-        .start(format!("./{}.profile", name))
-        .unwrap();
+    PROFILER.lock().unwrap().start(format!("./{}.profile", name)).unwrap();
 
     bar.set_job_title("Profiling...");
 
@@ -276,16 +244,10 @@ fn profile(iterations: i32, name: &str, block: &mut Block) {
 
 #[cfg(feature = "profiling")]
 fn profile_config(name: &str, runs: &str, config: &Config, update: Sender<Task>) -> Result<()> {
-    let profile_runs = runs.parse::<i32>()
-        .configuration_error("failed to parse --profile-runs as an integer")?;
+    let profile_runs = runs.parse::<i32>().configuration_error("failed to parse --profile-runs as an integer")?;
     for &(ref block_name, ref block_config) in &config.blocks {
         if block_name == name {
-            let mut block = create_block(
-                &block_name,
-                block_config.clone(),
-                config.clone(),
-                update.clone(),
-            )?;
+            let mut block = create_block(&block_name, block_config.clone(), config.clone(), update.clone())?;
             profile(profile_runs, &block_name, block.deref_mut());
             break;
         }
@@ -296,9 +258,5 @@ fn profile_config(name: &str, runs: &str, config: &Config, update: Sender<Task>)
 #[cfg(not(feature = "profiling"))]
 fn profile_config(_name: &str, _runs: &str, _config: &Config, _update: &Sender<Task>) -> Result<()> {
     // TODO: Maybe we should just panic! here.
-    Err(InternalError(
-        "profile".to_string(),
-        "The 'profiling' feature was not enabled at compile time.".to_string(),
-        None,
-    ))
+    Err(InternalError("profile".to_string(), "The 'profiling' feature was not enabled at compile time.".to_string(), None))
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,9 +1,9 @@
 use block::Block;
 use errors::*;
+use std::cmp;
 use std::collections::{BinaryHeap, HashMap};
 use std::fmt;
 use std::thread;
-use std::cmp;
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone)]
@@ -73,21 +73,11 @@ impl UpdateScheduler {
     }
 
     pub fn do_scheduled_updates(&mut self, block_map: &mut HashMap<String, &mut Block>) -> Result<()> {
-        let t = self.schedule
-            .pop()
-            .internal_error("scheduler", "schedule is empty")?;
+        let t = self.schedule.pop().internal_error("scheduler", "schedule is empty")?;
         let mut tasks_next = vec![t.clone()];
 
-        while !self.schedule.is_empty() &&
-            t.update_time ==
-                self.schedule
-                    .peek()
-                    .internal_error("scheduler", "schedule is empty")?
-                    .update_time
-        {
-            tasks_next.push(self.schedule
-                .pop()
-                .internal_error("scheduler", "schedule is empty")?)
+        while !self.schedule.is_empty() && t.update_time == self.schedule.peek().internal_error("scheduler", "schedule is empty")?.update_time {
+            tasks_next.push(self.schedule.pop().internal_error("scheduler", "schedule is empty")?)
         }
 
         let now = Instant::now();
@@ -98,15 +88,8 @@ impl UpdateScheduler {
         let now = Instant::now();
 
         for task in tasks_next {
-            if let Some(dur) = block_map
-                .get_mut(&task.id)
-                .internal_error("scheduler", "could not get required block")?
-                .update()?
-            {
-                self.schedule.push(Task {
-                    id: task.id,
-                    update_time: now + dur,
-                })
+            if let Some(dur) = block_map.get_mut(&task.id).internal_error("scheduler", "could not get required block")?.update()? {
+                self.schedule.push(Task { id: task.id, update_time: now + dur })
             }
         }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,28 +1,26 @@
 use block::Block;
 use config::Config;
 use errors::*;
-use std::collections::HashMap;
+use regex::Regex;
 use serde::de::DeserializeOwned;
 use serde_json::value::Value;
-use toml;
-use regex::Regex;
-use std::prelude::v1::String;
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs::{File, OpenOptions};
-use std::io::BufReader;
 use std::io::prelude::*;
+use std::io::BufReader;
 use std::num::ParseIntError;
 use std::path::Path;
+use std::prelude::v1::String;
+use toml;
 
 pub fn deserialize_file<T>(file: &str) -> Result<T>
 where
     T: DeserializeOwned,
 {
     let mut contents = String::new();
-    let mut file = BufReader::new(File::open(file)
-        .internal_error("util", "failed to open file")?);
-    file.read_to_string(&mut contents)
-        .internal_error("util", "failed to read file")?;
+    let mut file = BufReader::new(File::open(file).internal_error("util", "failed to open file")?);
+    file.read_to_string(&mut contents).internal_error("util", "failed to read file")?;
     toml::from_str(&contents).configuration_error("failed to parse TOML from file contents")
 }
 
@@ -32,8 +30,7 @@ pub fn read_file(blockname: &str, path: &Path) -> Result<String> {
         .open(path)
         .block_error(blockname, &format!("failed to open file {}", path.to_string_lossy()))?;
     let mut content = String::new();
-    f.read_to_string(&mut content)
-        .block_error(blockname, &format!("failed to read {}", path.to_string_lossy()))?;
+    f.read_to_string(&mut content).block_error(blockname, &format!("failed to read {}", path.to_string_lossy()))?;
     // Removes trailing newline
     content.pop();
     Ok(content)
@@ -42,10 +39,8 @@ pub fn read_file(blockname: &str, path: &Path) -> Result<String> {
 #[allow(dead_code)]
 pub fn get_file(name: &str) -> Result<String> {
     let mut file_contents = String::new();
-    let mut file = File::open(name)
-        .internal_error("util", &format!("Unable to open {}", name))?;
-    file.read_to_string(&mut file_contents)
-        .internal_error("util", &format!("Unable to read {}", name))?;
+    let mut file = File::open(name).internal_error("util", &format!("Unable to open {}", name))?;
+    file.read_to_string(&mut file_contents).internal_error("util", &format!("Unable to read {}", name))?;
     Ok(file_contents)
 }
 
@@ -106,23 +101,15 @@ pub fn print_blocks(order: &[String], block_map: &HashMap<String, &mut Block>, c
 
     print!("[");
     for block_id in order {
-        let block = &(*(block_map
-            .get(block_id)
-            .internal_error("util", "couldn't get block by id")?));
+        let block = &(*(block_map.get(block_id).internal_error("util", "couldn't get block by id")?));
         let widgets = block.view();
         if widgets.is_empty() {
             continue;
         }
         let first = widgets[0];
-        let color = first.get_rendered()["background"]
-            .as_str()
-            .internal_error("util", "couldn't get background color")?;
+        let color = first.get_rendered()["background"].as_str().internal_error("util", "couldn't get background color")?;
 
-        let sep_fg = if config.theme.separator_fg == "auto" {
-            color
-        } else {
-            &config.theme.separator_fg
-        };
+        let sep_fg = if config.theme.separator_fg == "auto" { color } else { &config.theme.separator_fg };
 
         let sep_bg = if config.theme.separator_bg == "auto" {
             state.last_bg.clone()
@@ -131,27 +118,21 @@ pub fn print_blocks(order: &[String], block_map: &HashMap<String, &mut Block>, c
         };
 
         let separator = json!({
-                    "full_text": config.theme.separator,
-                    "separator": false,
-                    "separator_block_width": 0,
-                    "background": if sep_bg.is_some() { Value::String(sep_bg.unwrap()) } else { Value::Null },
-                    "color": sep_fg,
-                    "markup": "pango"
-                });
-        print!("{}{},", if state.has_predecessor { "," } else { "" },
-               separator.to_string());
+            "full_text": config.theme.separator,
+            "separator": false,
+            "separator_block_width": 0,
+            "background": if sep_bg.is_some() { Value::String(sep_bg.unwrap()) } else { Value::Null },
+            "color": sep_fg,
+            "markup": "pango"
+        });
+        print!("{}{},", if state.has_predecessor { "," } else { "" }, separator.to_string());
         print!("{}", first.to_string());
         state.set_last_bg(color.to_owned());
         state.set_predecessor(true);
 
         for widget in widgets.iter().skip(1) {
-            print!("{}{}", if state.has_predecessor { "," } else { "" },
-                   widget.to_string());
-            state.set_last_bg(String::from(
-                widget.get_rendered()["background"]
-                    .as_str()
-                    .internal_error("util", "couldn't get background color")?,
-            ));
+            print!("{}{}", if state.has_predecessor { "," } else { "" }, widget.to_string());
+            state.set_last_bg(String::from(widget.get_rendered()["background"].as_str().internal_error("util", "couldn't get background color")?));
             state.set_predecessor(true);
         }
     }
@@ -197,8 +178,7 @@ impl FormatTemplate {
         let s_as_bytes = s.as_bytes();
 
         //valid var tokens: {} containing any amount of alphanumericals
-        let re = Regex::new(r"\{[a-zA-Z0-9]+?\}")
-            .internal_error("util", "invalid regex")?;
+        let re = Regex::new(r"\{[a-zA-Z0-9]+?\}").internal_error("util", "invalid regex")?;
 
         let mut token_vec: Vec<FormatTemplate> = vec![];
         let mut start: usize = 0;
@@ -206,21 +186,13 @@ impl FormatTemplate {
         for re_match in re.find_iter(&s) {
             if re_match.start() != start {
                 let str_vec: Vec<u8> = (&s_as_bytes)[start..re_match.start()].to_vec();
-                token_vec.push(FormatTemplate::Str(
-                    String::from_utf8(str_vec)
-                        .internal_error("util", "failed to convert string from UTF8")?,
-                    None,
-                ));
+                token_vec.push(FormatTemplate::Str(String::from_utf8(str_vec).internal_error("util", "failed to convert string from UTF8")?, None));
             }
             token_vec.push(FormatTemplate::Var(re_match.as_str().to_string(), None));
             start = re_match.end();
         }
         let str_vec: Vec<u8> = (&s_as_bytes)[start..].to_vec();
-        token_vec.push(FormatTemplate::Str(
-            String::from_utf8(str_vec)
-                .internal_error("util", "failed to convert string from UTF8")?,
-            None,
-        ));
+        token_vec.push(FormatTemplate::Str(String::from_utf8(str_vec).internal_error("util", "failed to convert string from UTF8")?, None));
         let mut template: FormatTemplate = match token_vec.pop() {
             Some(token) => token,
             _ => FormatTemplate::Str("".to_string(), None),
@@ -246,9 +218,7 @@ impl FormatTemplate {
                 };
             }
             Var(ref key, ref next) => {
-                rendered.push_str(
-                    &format!("{}", vars.get(key).unwrap_or_else(|| panic!("Unknown placeholder in format string: {}", key))),
-                );
+                rendered.push_str(&format!("{}", vars.get(key).unwrap_or_else(|| panic!("Unknown placeholder in format string: {}", key))));
                 if let Some(ref next) = *next {
                     rendered.push_str(&*next.render(vars));
                 };
@@ -268,9 +238,7 @@ impl FormatTemplate {
                 };
             }
             Var(ref key, ref next) => {
-                rendered.push_str(&format!("{}",
-                                           vars.get(&**key)
-                                               .internal_error("util", &format!("Unknown placeholder in format string: {}", key))?));
+                rendered.push_str(&format!("{}", vars.get(&**key).internal_error("util", &format!("Unknown placeholder in format string: {}", key))?));
                 if let Some(ref next) = *next {
                     rendered.push_str(&*next.render_static_str(vars)?);
                 };

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,5 +1,5 @@
-use themes::Theme;
 use serde_json::value::Value;
+use themes::Theme;
 
 #[derive(Debug, Copy, Clone)]
 pub enum State {

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -1,7 +1,7 @@
-use config::Config;
-use widget::State;
-use serde_json::value::Value;
 use super::super::widget::I3BarWidget;
+use config::Config;
+use serde_json::value::Value;
+use widget::State;
 
 #[derive(Clone, Debug)]
 pub struct ButtonWidget {
@@ -92,9 +92,7 @@ impl ButtonWidget {
 
 impl I3BarWidget for ButtonWidget {
     fn to_string(&self) -> String {
-        self.cached_output
-            .clone()
-            .unwrap_or_else(|| self.rendered.to_string())
+        self.cached_output.clone().unwrap_or_else(|| self.rendered.to_string())
     }
 
     fn get_rendered(&self) -> &Value {

--- a/src/widgets/graph.rs
+++ b/src/widgets/graph.rs
@@ -1,8 +1,8 @@
-use config::Config;
-use widget::State;
-use serde_json::value::Value;
 use super::super::widget::I3BarWidget;
+use config::Config;
 use num::{clamp, ToPrimitive};
+use serde_json::value::Value;
+use widget::State;
 
 #[derive(Clone, Debug)]
 pub struct GraphWidget {
@@ -62,17 +62,12 @@ impl GraphWidget {
             let length = bars.len() as f64 - 1.0;
             let bar = content
                 .iter()
-                .map(|x| {
-                    bars[((clamp(x.to_f64().unwrap(), min, max) - min) / extant * length) as usize]
-                })
+                .map(|x| bars[((clamp(x.to_f64().unwrap(), min, max) - min) / extant * length) as usize])
                 .collect::<Vec<&'static str>>()
                 .concat();
             self.content = Some(bar);
         } else {
-            let bar = (0..content.len() - 1)
-                .map(|_| bars[0])
-                .collect::<Vec<&'static str>>()
-                .concat();
+            let bar = (0..content.len() - 1).map(|_| bars[0]).collect::<Vec<&'static str>>().concat();
             self.content = Some(bar);
         }
         self.update();
@@ -107,9 +102,7 @@ impl GraphWidget {
 
 impl I3BarWidget for GraphWidget {
     fn to_string(&self) -> String {
-        self.cached_output
-            .clone()
-            .unwrap_or_else(|| self.rendered.to_string())
+        self.cached_output.clone().unwrap_or_else(|| self.rendered.to_string())
     }
 
     fn get_rendered(&self) -> &Value {

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,4 +1,4 @@
-pub mod text;
-pub mod graph;
 pub mod button;
+pub mod graph;
 pub mod rotatingtext;
+pub mod text;

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -1,8 +1,8 @@
 use config::Config;
 use errors::*;
+use serde_json::value::Value;
 use std::time::{Duration, Instant};
 use widget::{I3BarWidget, State};
-use serde_json::value::Value;
 
 #[derive(Clone, Debug)]
 pub struct RotatingTextWidget {
@@ -96,22 +96,13 @@ impl RotatingTextWidget {
         if self.content.len() > self.width {
             let missing = (self.rotation_pos + self.width).saturating_sub(self.content.len());
             if missing == 0 {
-                self.content
-                    .chars()
-                    .skip(self.rotation_pos)
-                    .take(self.width)
-                    .collect()
+                self.content.chars().skip(self.rotation_pos).take(self.width).collect()
             } else {
-                let mut avail: String = self.content
-                    .chars()
-                    .skip(self.rotation_pos)
-                    .take(self.width)
-                    .collect();
+                let mut avail: String = self.content.chars().skip(self.rotation_pos).take(self.width).collect();
                 avail.push_str("|");
                 avail.push_str(&self.content.chars().take(missing - 1).collect::<String>());
                 avail
             }
-
         } else {
             self.content.clone()
         }
@@ -165,9 +156,7 @@ impl RotatingTextWidget {
 
 impl I3BarWidget for RotatingTextWidget {
     fn to_string(&self) -> String {
-        self.cached_output
-            .clone()
-            .unwrap_or_else(|| self.rendered.to_string())
+        self.cached_output.clone().unwrap_or_else(|| self.rendered.to_string())
     }
 
     fn get_rendered(&self) -> &Value {

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -1,7 +1,7 @@
-use config::Config;
-use widget::State;
-use serde_json::value::Value;
 use super::super::widget::I3BarWidget;
+use config::Config;
+use serde_json::value::Value;
+use widget::State;
 
 #[derive(Clone, Debug)]
 pub struct TextWidget {
@@ -83,9 +83,7 @@ impl TextWidget {
 
 impl I3BarWidget for TextWidget {
     fn to_string(&self) -> String {
-        self.cached_output
-            .clone()
-            .unwrap_or_else(|| self.rendered.to_string())
+        self.cached_output.clone().unwrap_or_else(|| self.rendered.to_string())
     }
 
     fn get_rendered(&self) -> &Value {


### PR DESCRIPTION
This pull requests adds a new option for the network block: `hide_missing`.  If set to `true` (`false` by default), a missing network device will not raise an error.

This is useful if the device is not always present (such as a USB ethernet adapter for example).

This pull request closes #121.

This pull request should be merged after my other pull request (#332).