### PR TITLE
blocks/networkmanager: Upgrades

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -450,13 +450,13 @@ Placeholder | Description
 `{icon}` | The icon matching the device type.
 `{typename}` | The name of the device type.
 `{ssid}` | The connected SSID if available.
+`{ips}` | The list of IPs for this device.
 
 ### Connection format string
 
 Placeholder | Description
 ------------|-------------
 `{devices}` | The list of devices, each formatted with the device format string.
-`{ips}` | The list of IPs for this connection.
 
 ## Nvidia Gpu
 

--- a/blocks.md
+++ b/blocks.md
@@ -11,6 +11,7 @@
 - [Memory](#memory)
 - [Music](#music)
 - [Net](#net)
+- [NetworkManager](#networkmanager)
 - [Nvidia Gpu](#nvidia-gpu)
 - [Pacman](#pacman)
 - [Sound](#sound)
@@ -419,6 +420,43 @@ Key | Values | Required | Default
 `graph_up` | Display a bar graph for upload speed. | No | `false`
 `graph_down` | Display a bar graph for download speed. | No | `false`
 `interval` | Update interval, in seconds. | No | `1`
+
+## NetworkManager
+
+Creates a block which displays network connection information from NetworkManager.
+
+### Examples
+
+```toml
+[[block]]
+block = "networkmanager"
+on_click = "alacritty -e nmtui"
+```
+
+### Options
+
+Key | Values | Required | Default
+----|--------|----------|---------
+`primary_only` | Whether to show only the primary active connection or all active connections | No | `false`
+`max_ssid_width` | Truncation length for SSID | No | `21`
+`device_format` | Device string formatter. See below for available placeholders. | No | `"{icon}{ssid}"`
+`connection_format` | Connection string formatter. See below for available placeholders. | No | `"{devices} {ips}"`
+`on_click` | On-click handler | No | `""`
+
+### Device format string
+
+Placeholder | Description
+------------|-------------
+`{icon}` | The icon matching the device type.
+`{typename}` | The name of the device type.
+`{ssid}` | The connected SSID if available.
+
+### Connection format string
+
+Placeholder | Description
+------------|-------------
+`{devices}` | The list of devices, each formatted with the device format string.
+`{ips}` | The list of IPs for this connection.
 
 ## Nvidia Gpu
 

--- a/blocks.md
+++ b/blocks.md
@@ -443,13 +443,21 @@ Key | Values | Required | Default
 `connection_format` | Connection string formatter. See below for available placeholders. | No | `"{devices} {ips}"`
 `on_click` | On-click handler | No | `""`
 
+### AP format string
+
+Placeholder | Description
+------------|-------------
+`{ssid}` | The SSID for this AP.
+`{strength}` | The signal strength in percent for this AP.
+`{frequency}` | The frequency of this AP in MHz.
+
 ### Device format string
 
 Placeholder | Description
 ------------|-------------
 `{icon}` | The icon matching the device type.
 `{typename}` | The name of the device type.
-`{ssid}` | The connected SSID if available.
+`{ap}` | The connected AP if available, formatted with the AP format string.
 `{ips}` | The list of IPs for this device.
 
 ### Connection format string

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -1,18 +1,22 @@
+use std::ffi::OsStr;
 use std::fmt;
-use std::time::{Duration, Instant};
+use std::net::Ipv4Addr;
+use std::process::Command;
 use std::thread;
+use std::time::{Duration, Instant};
 
 use chan::Sender;
 use uuid::Uuid;
 
+use block::{Block, ConfigBlock};
+use blocks::dbus::arg::{Array, Iter, Variant};
+use blocks::dbus::{BusType, Connection, ConnectionItem, Message, MessageItem, Path};
 use config::Config;
 use errors::*;
+use input::{I3BarEvent, MouseButton};
 use scheduler::Task;
-use block::{Block, ConfigBlock};
 use widget::{I3BarWidget, State};
-use widgets::text::TextWidget;
-use blocks::dbus::{BusType, Connection, Message, MessageItem};
-use blocks::dbus::arg::Variant;
+use widgets::button::ButtonWidget;
 
 enum NetworkState {
     Unknown = 0,
@@ -28,7 +32,7 @@ enum NetworkState {
 impl From<u32> for NetworkState {
     fn from(id: u32) -> Self {
         match id {
-            // https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NMState
+            // https://developer.gnome.org/NetworkManager/stable/nm-dbus-types.html#NMState
             10 => NetworkState::Asleep,
             20 => NetworkState::Disconnected,
             30 => NetworkState::Disconnecting,
@@ -36,116 +40,362 @@ impl From<u32> for NetworkState {
             50 => NetworkState::ConnectedLocal,
             60 => NetworkState::ConnectedSite,
             70 => NetworkState::ConnectedGlobal,
-            _  => NetworkState::Unknown,
+            _ => NetworkState::Unknown,
         }
     }
 }
 
-impl fmt::Display for NetworkState {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+enum ActiveConnectionState {
+    Unknown = 0,
+    Activating = 1,
+    Activated = 2,
+    Deactivating = 3,
+    Deactivated = 4,
+}
+
+impl From<u32> for ActiveConnectionState {
+    fn from(id: u32) -> Self {
+        match id {
+            // https://developer.gnome.org/NetworkManager/stable/nm-dbus-types.html#NMActiveConnectionState
+            1 => ActiveConnectionState::Activating,
+            2 => ActiveConnectionState::Activated,
+            3 => ActiveConnectionState::Deactivating,
+            4 => ActiveConnectionState::Deactivated,
+            _ => ActiveConnectionState::Unknown,
+        }
+    }
+}
+
+impl ActiveConnectionState {
+    fn to_state(&self, good: &State) -> State {
         match self {
-            NetworkState::Unknown => write!(f, "DOWN"),
-            NetworkState::Asleep => write!(f, "DOWN"),
-            NetworkState::Disconnected => write!(f, "DOWN"),
-            NetworkState::Disconnecting => write!(f, "DOWN"),
-            NetworkState::Connecting => write!(f, "DOWN"),
-            NetworkState::ConnectedLocal => write!(f, "UP"),
-            NetworkState::ConnectedSite => write!(f, "UP"),
-            NetworkState::ConnectedGlobal => write!(f, "UP"),
+            ActiveConnectionState::Activated => good.clone(),
+            ActiveConnectionState::Activating => State::Warning,
+            ActiveConnectionState::Deactivating => State::Warning,
+            ActiveConnectionState::Deactivated => State::Critical,
+            ActiveConnectionState::Unknown => State::Critical,
         }
     }
 }
 
-enum ConnectionType {
-    Ethernet,
-    Wireless,
-    Other,
+#[derive(Debug)]
+enum DeviceType {
+    Unknown = 0,
+    Ethernet = 1,
+    Wifi = 2,
+    Unused1 = 3,
+    Unused2 = 4,
+    BT = 5,
+    OLPCMesh = 6,
+    WiMAX = 7,
+    Modem = 8,
+    InfiniBand = 9,
+    Bond = 10,
+    VLAN = 11,
+    ADLS = 12,
+    Bridge = 13,
+    Generic = 14,
+    Team = 15,
+    TUN = 16,
+    IPTunnel = 17,
+    MACVLAN = 18,
+    VXLAN = 19,
+    VETH = 20,
+    MACsec = 21,
+    Dummy = 22,
+    PPP = 23,
+    OVSInterface = 24,
+    OVSPort = 25,
+    OVSBridge = 26,
+    WPAN = 27,
+    IPv6LoWPAN = 28,
+    Wireguard = 29,
 }
 
-impl From<String> for ConnectionType {
-    fn from(name: String) -> Self {
-        match name.as_ref() {
-            // https://developer.gnome.org/NetworkManager/unstable/settings-connection.html
-            "802-3-ethernet" => ConnectionType::Ethernet,
-            "802-11-wireless" => ConnectionType::Wireless,
-            _  => ConnectionType::Other,
+impl From<u32> for DeviceType {
+    fn from(id: u32) -> Self {
+        match id {
+            // https://developer.gnome.org/NetworkManager/stable/nm-dbus-types.html#NMDeviceType
+            1 => DeviceType::Ethernet,
+            2 => DeviceType::Wifi,
+            3 => DeviceType::Unused1,
+            4 => DeviceType::Unused2,
+            5 => DeviceType::BT,
+            6 => DeviceType::OLPCMesh,
+            7 => DeviceType::WiMAX,
+            8 => DeviceType::Modem,
+            9 => DeviceType::InfiniBand,
+            10 => DeviceType::Bond,
+            11 => DeviceType::VLAN,
+            12 => DeviceType::ADLS,
+            13 => DeviceType::Bridge,
+            14 => DeviceType::Generic,
+            15 => DeviceType::Team,
+            16 => DeviceType::TUN,
+            17 => DeviceType::IPTunnel,
+            18 => DeviceType::MACVLAN,
+            19 => DeviceType::VXLAN,
+            20 => DeviceType::VETH,
+            21 => DeviceType::MACsec,
+            22 => DeviceType::Dummy,
+            23 => DeviceType::PPP,
+            24 => DeviceType::OVSInterface,
+            25 => DeviceType::OVSPort,
+            26 => DeviceType::OVSBridge,
+            27 => DeviceType::WPAN,
+            28 => DeviceType::IPv6LoWPAN,
+            29 => DeviceType::Wireguard,
+            _ => DeviceType::Unknown,
         }
     }
 }
 
-impl fmt::Display for ConnectionType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl DeviceType {
+    fn to_icon_name(&self) -> Option<String> {
         match self {
-            ConnectionType::Ethernet => write!(f, "net_wired"),
-            ConnectionType::Wireless => write!(f, "net_wireless"),
-            ConnectionType::Other => write!(f, "net_other"),
+            DeviceType::Ethernet => Some("net_wired".to_string()),
+            DeviceType::Wifi => Some("net_wireless".to_string()),
+            DeviceType::Modem => Some("net_modem".to_string()),
+            DeviceType::Bridge => Some("net_bridge".to_string()),
+            DeviceType::TUN => Some("net_bridge".to_string()),
+            DeviceType::Wireguard => Some("net_vpn".to_string()),
+            _ => None,
         }
     }
 }
 
-struct ConnectionManager {
+#[derive(Debug)]
+struct Ipv4Address {
+    address: Ipv4Addr,
+    prefix: u32,
+    gateway: Ipv4Addr,
 }
+
+trait ByteOrderSwap {
+    fn swap(&self) -> Self;
+}
+
+impl ByteOrderSwap for u32 {
+    fn swap(&self) -> u32 {
+        ((self & 0x000000FF) << 24) | ((self & 0x0000FF00) << 8) | ((self & 0x00FF0000) >> 8) | ((self & 0xFF000000) >> 24)
+    }
+}
+
+impl<'a> From<Array<'a, u32, Iter<'a>>> for Ipv4Address {
+    fn from(s: Array<'a, u32, Iter<'a>>) -> Ipv4Address {
+        let mut i = s.into_iter();
+        Ipv4Address {
+            address: Ipv4Addr::from(i.next().unwrap().swap()),
+            prefix: i.next().unwrap(),
+            gateway: Ipv4Addr::from(i.next().unwrap().swap()),
+        }
+    }
+}
+
+impl fmt::Display for Ipv4Address {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}/{}", self.address, self.prefix)
+    }
+}
+
+struct ConnectionManager {}
 
 impl ConnectionManager {
     pub fn new() -> Self {
         ConnectionManager {}
     }
 
-    fn get_property(c: &Connection, property: &str) -> Result<Message> {
-        let m = Message::new_method_call(
-            "org.freedesktop.NetworkManager",
-            "/org/freedesktop/NetworkManager",
-            "org.freedesktop.DBus.Properties",
-            "Get")
+    fn get(c: &Connection, path: Path, t: &str, property: &str) -> Result<Message> {
+        let m = Message::new_method_call("org.freedesktop.NetworkManager", path, "org.freedesktop.DBus.Properties", "Get")
             .block_error("networkmanager", "Failed to create message")?
-            .append2(
-                MessageItem::Str("org.freedesktop.NetworkManager".to_string()),
-                MessageItem::Str(property.to_string())
-            );
+            .append2(MessageItem::Str(t.to_string()), MessageItem::Str(property.to_string()));
 
         let r = c.send_with_reply_and_block(m, 1000);
 
         r.block_error("networkmanager", "Failed to retrieve property")
     }
 
-    pub fn state(&self, c: &Connection) -> Result<NetworkState> {
-        let m = Self::get_property(c, "State")?;
+    fn get_property(c: &Connection, property: &str) -> Result<Message> {
+        Self::get(c, "/org/freedesktop/NetworkManager".into(), "org.freedesktop.NetworkManager", property)
+    }
 
-        let state: Variant<u32> = m.get1()
-            .block_error("networkmanager", "Failed to read property")?;
+    pub fn state(&self, c: &Connection) -> Result<NetworkState> {
+        let m = Self::get_property(c, "State").block_error("networkmanager", "Failed to retrieve state")?;
+
+        let state: Variant<u32> = m.get1().block_error("networkmanager", "Failed to read property")?;
 
         Ok(NetworkState::from(state.0))
     }
 
-    pub fn connection_type(&self, c: &Connection) -> Result<ConnectionType> {
-        let m = Self::get_property(c, "PrimaryConnectionType")?;
+    pub fn primary_connection(&self, c: &Connection) -> Result<NMConnection> {
+        let m = Self::get_property(c, "PrimaryConnection").block_error("networkmanager", "Failed to retrieve primary connection")?;
 
-        let connection_type: Variant<String> = m.get1()
-            .block_error("networkmanager", "Failed to read property")?;
+        let primary_connection: Variant<Path> = m.get1().block_error("networkmanager", "Failed to read primary connection")?;
 
-        Ok(ConnectionType::from(connection_type.0))
+        if let Ok(conn) = primary_connection.0.as_cstr().to_str() {
+            if conn == "/" {
+                return Err(BlockError("networkmanager".to_string(), "No primary connection".to_string()));
+            }
+        }
+
+        Ok(NMConnection { path: primary_connection.0.clone() })
+    }
+
+    pub fn active_connections(&self, c: &Connection) -> Result<Vec<NMConnection>> {
+        let m = Self::get_property(c, "ActiveConnections").block_error("networkmanager", "Failed to retrieve active connections")?;
+
+        let active_connections: Variant<Array<Path, Iter>> = m.get1().block_error("networkmanager", "Failed to read active connections")?;
+
+        Ok(active_connections.0.into_iter().map(|x| NMConnection { path: x }).collect())
+    }
+}
+
+#[derive(Clone)]
+struct NMConnection<'a> {
+    path: Path<'a>,
+}
+
+impl<'a> NMConnection<'a> {
+    fn state(&self, c: &Connection) -> Result<ActiveConnectionState> {
+        let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Connection.Active", "State").block_error("networkmanager", "Failed to retrieve connection state")?;
+
+        let state: Variant<u32> = m.get1().block_error("networkmanager", "Failed to read connection state")?;
+        Ok(ActiveConnectionState::from(state.0))
+    }
+
+    fn ip4config(&self, c: &Connection) -> Result<NMIp4Config> {
+        let m =
+            ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Connection.Active", "Ip4Config").block_error("networkmanager", "Failed to retrieve connection ip4config")?;
+
+        let ip4config: Variant<Path> = m.get1().block_error("networkmanager", "Failed to read ip4config")?;
+        Ok(NMIp4Config { path: ip4config.0 })
+    }
+
+    fn devices(&self, c: &Connection) -> Result<Vec<NMDevice>> {
+        let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Connection.Active", "Devices").block_error("networkmanager", "Failed to retrieve connection device")?;
+
+        let devices: Variant<Array<Path, Iter>> = m.get1().block_error("networkmanager", "Failed to read devices")?;
+        Ok(devices.0.into_iter().map(|x| NMDevice { path: x }).collect())
+    }
+}
+
+#[derive(Clone)]
+struct NMDevice<'a> {
+    path: Path<'a>,
+}
+
+impl<'a> NMDevice<'a> {
+    fn device_type(&self, c: &Connection) -> Result<DeviceType> {
+        let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Device", "DeviceType").block_error("networkmanager", "Failed to retrieve device type")?;
+
+        let device_type: Variant<u32> = m.get1().block_error("networkmanager", "Failed to read device type")?;
+        Ok(DeviceType::from(device_type.0))
+    }
+
+    fn active_access_point(&self, c: &Connection) -> Result<NMAccessPoint> {
+        let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Device.Wireless", "ActiveAccessPoint")
+            .block_error("networkmanager", "Failed to retrieve device active access point")?;
+
+        let active_ap: Variant<Path> = m.get1().block_error("networkmanager", "Failed to read active access point")?;
+        Ok(NMAccessPoint { path: active_ap.0 })
+    }
+}
+
+#[derive(Clone)]
+struct NMAccessPoint<'a> {
+    path: Path<'a>,
+}
+
+impl<'a> NMAccessPoint<'a> {
+    fn ssid(&self, c: &Connection) -> Result<String> {
+        let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.AccessPoint", "Ssid").block_error("networkmanager", "Failed to retrieve SSID")?;
+
+        let ssid: Variant<Array<u8, Iter>> = m.get1().block_error("networkmanager", "Failed to read ssid")?;
+        Ok(std::str::from_utf8(&ssid.0.into_iter().collect::<Vec<u8>>())
+            .block_error("networkmanager", "Failed to parse ssid")?
+            .to_string())
+    }
+}
+
+#[derive(Clone)]
+struct NMIp4Config<'a> {
+    path: Path<'a>,
+}
+
+impl<'a> NMIp4Config<'a> {
+    fn addresses(&self, c: &Connection) -> Result<Vec<Ipv4Address>> {
+        let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.IP4Config", "Addresses").block_error("networkmanager", "Failed to retrieve addresses")?;
+
+        let addresses: Variant<Array<Array<u32, Iter>, Iter>> = m.get1().block_error("networkmanager", "Failed to read addresses")?;
+        Ok(addresses.0.into_iter().map(|addr| Ipv4Address::from(addr)).collect())
     }
 }
 
 pub struct NetworkManager {
     id: String,
-    output: TextWidget,
+    indicator: ButtonWidget,
+    output: Vec<ButtonWidget>,
     dbus_conn: Connection,
     manager: ConnectionManager,
-    show_type: bool,
+    config: Config,
+    on_click: Option<String>,
+    only_primary_connection: bool,
+    unknown_device_icon: bool,
+    ip: bool,
+    ssid: bool,
+    max_ssid_width: usize,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct NetworkManagerConfig {
-    /// Whether to show the connection type or not.
-    #[serde(default = "NetworkManagerConfig::default_show_type")]
-    pub show_type: bool,
+    #[serde(default = "NetworkManagerConfig::default_on_click")]
+    pub on_click: Option<String>,
+
+    /// Whether to only show the primary connection, or all active connections.
+    #[serde(default = "NetworkManagerConfig::default_only_primary_connection")]
+    pub only_primary_connection: bool,
+
+    /// Whether to show an unknown device icon instead of name for unknown devices.
+    #[serde(default = "NetworkManagerConfig::default_unknown_device_icon")]
+    pub unknown_device_icon: bool,
+
+    /// Whether to show the IP address of active networks.
+    #[serde(default = "NetworkManagerConfig::default_ip")]
+    pub ip: bool,
+
+    /// Whether to show the SSID of active wireless networks.
+    #[serde(default = "NetworkManagerConfig::default_ssid")]
+    pub ssid: bool,
+
+    /// Max SSID width, in characters.
+    #[serde(default = "NetworkManagerConfig::default_max_ssid_width")]
+    pub max_ssid_width: usize,
 }
 
 impl NetworkManagerConfig {
-    fn default_show_type() -> bool {
+    fn default_on_click() -> Option<String> {
+        None
+    }
+
+    fn default_only_primary_connection() -> bool {
+        false
+    }
+
+    fn default_unknown_device_icon() -> bool {
+        false
+    }
+
+    fn default_ip() -> bool {
         true
+    }
+
+    fn default_ssid() -> bool {
+        true
+    }
+
+    fn default_max_ssid_width() -> usize {
+        21
     }
 }
 
@@ -155,37 +405,46 @@ impl ConfigBlock for NetworkManager {
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
         let id: String = Uuid::new_v4().simple().to_string();
         let id_copy = id.clone();
-        let dbus_conn = Connection::get_private(BusType::System)
-            .block_error("networkmanager", "failed to establish D-Bus connection")?;
+        let dbus_conn = Connection::get_private(BusType::System).block_error("networkmanager", "failed to establish D-Bus connection")?;
         let manager = ConnectionManager::new();
 
         thread::spawn(move || {
             let c = Connection::get_private(BusType::System).unwrap();
             let rule = "type='signal',\
-                 path='/org/freedesktop/NetworkManager',\
-                 interface='org.freedesktop.NetworkManager',\
-                 member='StateChanged'";
+                        path='/org/freedesktop/NetworkManager',\
+                        interface='org.freedesktop.NetworkManager',\
+                        member='PropertiesChanged'";
 
             c.add_match(&rule).unwrap();
 
             loop {
-                let timeout = 100_000;
+                let timeout = 300_000;
 
-                for _event in c.iter(timeout) {
-                    send.send(Task {
-                        id: id.clone(),
-                        update_time: Instant::now(),
-                    });
+                for event in c.iter(timeout) {
+                    match event {
+                        ConnectionItem::Nothing => (),
+                        _ => send.send(Task {
+                            id: id_copy.clone(),
+                            update_time: Instant::now(),
+                        }),
+                    }
                 }
             }
         });
 
         Ok(NetworkManager {
-            id: id_copy,
-            output: TextWidget::new(config),
+            id: id.clone(),
+            config: config.clone(),
+            indicator: ButtonWidget::new(config.clone(), &id),
+            output: Vec::new(),
             dbus_conn,
             manager,
-            show_type: block_config.show_type,
+            on_click: block_config.on_click,
+            only_primary_connection: block_config.only_primary_connection,
+            unknown_device_icon: block_config.unknown_device_icon,
+            ip: block_config.ip,
+            ssid: block_config.ssid,
+            max_ssid_width: block_config.max_ssid_width,
         })
     }
 }
@@ -196,29 +455,144 @@ impl Block for NetworkManager {
     }
 
     fn update(&mut self) -> Result<Option<Duration>> {
-        let state = self.manager.state(&self.dbus_conn)?;
-        let connection_type = self.manager.connection_type(&self.dbus_conn)?;
+        let state = self.manager.state(&self.dbus_conn);
 
-        self.output.set_icon(&connection_type.to_string());
-        self.output.set_state(match state {
-            NetworkState::ConnectedGlobal => State::Good,
-            NetworkState::ConnectedSite => State::Info,
-            NetworkState::ConnectedLocal => State::Idle,
-            NetworkState::Connecting => State::Warning,
-            NetworkState::Disconnecting => State::Warning,
-            NetworkState::Asleep => State::Warning,
-            NetworkState::Disconnected => State::Critical,
-            NetworkState::Unknown => State::Critical,
+        self.indicator.set_state(match state {
+            Ok(NetworkState::ConnectedGlobal) => State::Good,
+            Ok(NetworkState::ConnectedSite) => State::Info,
+            Ok(NetworkState::ConnectedLocal) => State::Idle,
+            Ok(NetworkState::Connecting) => State::Warning,
+            Ok(NetworkState::Disconnecting) => State::Warning,
+            _ => State::Critical,
+        });
+        self.indicator.set_text(match state {
+            Ok(NetworkState::Disconnected) => "×",
+            Ok(NetworkState::Asleep) => "×",
+            Ok(NetworkState::Unknown) => "E",
+            _ => "",
         });
 
-        if self.show_type {
-            self.output.set_text(state.to_string());
-        }
+        self.output = match state {
+            // It would be a waste of time to bother NetworkManager in any of these states
+            Ok(NetworkState::Disconnected) | Ok(NetworkState::Asleep) | Ok(NetworkState::Unknown) => vec![],
+
+            _ => {
+                let good_state = match state {
+                    Ok(NetworkState::ConnectedGlobal) => State::Good,
+                    Ok(NetworkState::ConnectedSite) => State::Info,
+                    _ => State::Idle,
+                };
+
+                let connections = if self.only_primary_connection {
+                    match self.manager.primary_connection(&self.dbus_conn) {
+                        Ok(conn) => vec![conn],
+                        Err(_) => vec![],
+                    }
+                } else {
+                    // We sort things so that the primary connection comes first
+                    let active = self.manager.active_connections(&self.dbus_conn).unwrap_or_else(|_| Vec::new());
+                    match self.manager.primary_connection(&self.dbus_conn) {
+                        Ok(conn) => vec![conn.clone()].into_iter().chain(active.into_iter().filter(|ref x| x.path != conn.path)).collect(),
+                        Err(_) => active,
+                    }
+                };
+
+                connections
+                    .into_iter()
+                    .map(|conn| {
+                        let mut widget = ButtonWidget::new(self.config.clone(), &self.id);
+
+                        // Set the state for this connection
+                        widget.set_state(if let Ok(conn_state) = conn.state(&self.dbus_conn) {
+                            conn_state.to_state(&good_state)
+                        } else {
+                            ActiveConnectionState::Unknown.to_state(&good_state)
+                        });
+
+                        // Get all devices for this connection
+                        let mut devicevec: Vec<String> = Vec::new();
+                        if let Ok(devices) = conn.devices(&self.dbus_conn) {
+                            for device in devices {
+                                let iconstr = if let Ok(dev_type) = device.device_type(&self.dbus_conn) {
+                                    match dev_type.to_icon_name() {
+                                        Some(icon_name) => self.config.icons.get(&icon_name).cloned().unwrap_or("".to_string()),
+                                        None => {
+                                            if self.unknown_device_icon {
+                                                self.config.icons.get("unknown").cloned().unwrap_or("".to_string())
+                                            } else {
+                                                format!("{:?}", dev_type).to_string()
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    "".to_string()
+                                };
+
+                                let mut ssidstr = "".to_string();
+                                if self.ssid {
+                                    if let Ok(ap) = device.active_access_point(&self.dbus_conn) {
+                                        if let Ok(ssid) = ap.ssid(&self.dbus_conn) {
+                                            let mut truncated = ssid.to_string();
+                                            truncated.truncate(self.max_ssid_width);
+                                            ssidstr = truncated + " ";
+                                        }
+                                    }
+                                }
+
+                                devicevec.push(iconstr + &ssidstr);
+                            }
+                        };
+
+                        // Get all IPs for this connection
+                        let ip = if self.ip {
+                            let mut ip = "×".to_string();
+                            if let Ok(ip4config) = conn.ip4config(&self.dbus_conn) {
+                                if let Ok(addresses) = ip4config.addresses(&self.dbus_conn) {
+                                    if addresses.len() > 0 {
+                                        ip = addresses.into_iter().map(|x| x.to_string()).collect::<Vec<String>>().join(",")
+                                    }
+                                }
+                            }
+                            ip
+                        } else {
+                            "".to_string()
+                        };
+
+                        widget.set_text(devicevec.join(" ") + &ip);
+
+                        widget
+                    })
+                    .collect()
+            }
+        };
 
         Ok(None)
     }
 
     fn view(&self) -> Vec<&I3BarWidget> {
-        vec![&self.output]
+        if self.output.len() == 0 {
+            vec![&self.indicator]
+        } else {
+            self.output.iter().map(|x| x as &I3BarWidget).collect()
+        }
+    }
+
+    fn click(&mut self, e: &I3BarEvent) -> Result<()> {
+        if let Some(ref name) = e.name {
+            if name.as_str() == self.id {
+                match e.button {
+                    MouseButton::Left => {
+                        if let Some(ref cmd) = self.on_click {
+                            let command_broken: Vec<&str> = cmd.split_whitespace().collect();
+                            let mut itr = command_broken.iter();
+                            let mut _cmd = Command::new(OsStr::new(&itr.next().unwrap())).args(itr).spawn();
+                        }
+                    }
+                    _ => (),
+                }
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -15,6 +15,7 @@ use config::Config;
 use errors::*;
 use input::{I3BarEvent, MouseButton};
 use scheduler::Task;
+use util::FormatTemplate;
 use widget::{I3BarWidget, State};
 use widgets::button::ButtonWidget;
 
@@ -294,10 +295,9 @@ pub struct NetworkManager {
     config: Config,
     on_click: Option<String>,
     primary_only: bool,
-    unknown_device_icon: bool,
-    ip: bool,
-    ssid: bool,
     max_ssid_width: usize,
+    device_format: FormatTemplate,
+    connection_format: FormatTemplate,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -310,21 +310,17 @@ pub struct NetworkManagerConfig {
     #[serde(default = "NetworkManagerConfig::default_primary_only")]
     pub primary_only: bool,
 
-    /// Whether to show an unknown device icon instead of name for unknown devices.
-    #[serde(default = "NetworkManagerConfig::default_unknown_device_icon")]
-    pub unknown_device_icon: bool,
-
-    /// Whether to show the IP address of active networks.
-    #[serde(default = "NetworkManagerConfig::default_ip")]
-    pub ip: bool,
-
-    /// Whether to show the SSID of active wireless networks.
-    #[serde(default = "NetworkManagerConfig::default_ssid")]
-    pub ssid: bool,
-
     /// Max SSID width, in characters.
     #[serde(default = "NetworkManagerConfig::default_max_ssid_width")]
     pub max_ssid_width: usize,
+
+    /// Device formatter.
+    #[serde(default = "NetworkManagerConfig::default_device_format")]
+    pub device_format: String,
+
+    /// Connection formatter.
+    #[serde(default = "NetworkManagerConfig::default_connection_format")]
+    pub connection_format: String,
 }
 
 impl NetworkManagerConfig {
@@ -336,20 +332,16 @@ impl NetworkManagerConfig {
         false
     }
 
-    fn default_unknown_device_icon() -> bool {
-        false
-    }
-
-    fn default_ip() -> bool {
-        true
-    }
-
-    fn default_ssid() -> bool {
-        true
-    }
-
     fn default_max_ssid_width() -> usize {
         21
+    }
+
+    fn default_device_format() -> String {
+        "{icon}{ssid}".to_string()
+    }
+
+    fn default_connection_format() -> String {
+        "{devices} {ips}".to_string()
     }
 }
 
@@ -395,10 +387,9 @@ impl ConfigBlock for NetworkManager {
             manager,
             on_click: block_config.on_click,
             primary_only: block_config.primary_only,
-            unknown_device_icon: block_config.unknown_device_icon,
-            ip: block_config.ip,
-            ssid: block_config.ssid,
             max_ssid_width: block_config.max_ssid_width,
+            device_format: FormatTemplate::from_string(&block_config.device_format)?,
+            connection_format: FormatTemplate::from_string(&block_config.connection_format)?,
         })
     }
 }
@@ -467,53 +458,61 @@ impl Block for NetworkManager {
                         let mut devicevec: Vec<String> = Vec::new();
                         if let Ok(devices) = conn.devices(&self.dbus_conn) {
                             for device in devices {
-                                let iconstr = if let Ok(dev_type) = device.device_type(&self.dbus_conn) {
+                                let (icon, type_name) = if let Ok(dev_type) = device.device_type(&self.dbus_conn) {
                                     match dev_type.to_icon_name() {
-                                        Some(icon_name) => self.config.icons.get(&icon_name).cloned().unwrap_or("".to_string()),
-                                        None => {
-                                            if self.unknown_device_icon {
-                                                self.config.icons.get("unknown").cloned().unwrap_or("".to_string())
-                                            } else {
-                                                format!("{:?}", dev_type).to_string()
-                                            }
+                                        Some(icon_name) => {
+                                            let i = self.config.icons.get(&icon_name).cloned().unwrap_or("".to_string());
+                                            (i.to_string(), format!("{:?}", dev_type).to_string())
                                         }
+                                        None => (self.config.icons.get("unknown").cloned().unwrap_or("".to_string()), format!("{:?}", dev_type).to_string()),
+                                    }
+                                } else {
+                                    // TODO: Communicate the error to the user?
+                                    ("".to_string(), "".to_string())
+                                };
+
+                                let ssidstr = if let Ok(ap) = device.active_access_point(&self.dbus_conn) {
+                                    if let Ok(ssid) = ap.ssid(&self.dbus_conn) {
+                                        let mut truncated = ssid.to_string();
+                                        truncated.truncate(self.max_ssid_width);
+                                        truncated
+                                    } else {
+                                        "".to_string()
                                     }
                                 } else {
                                     "".to_string()
                                 };
 
-                                let mut ssidstr = "".to_string();
-                                if self.ssid {
-                                    if let Ok(ap) = device.active_access_point(&self.dbus_conn) {
-                                        if let Ok(ssid) = ap.ssid(&self.dbus_conn) {
-                                            let mut truncated = ssid.to_string();
-                                            truncated.truncate(self.max_ssid_width);
-                                            ssidstr = truncated + " ";
-                                        }
-                                    }
-                                }
+                                let values = map!("{icon}" => icon,
+                                                  "{typename}" => type_name,
+                                                  "{ssid}" => ssidstr);
 
-                                devicevec.push(iconstr + &ssidstr);
+                                if let Ok(s) = self.device_format.render_static_str(&values) {
+                                    devicevec.push(s);
+                                } else {
+                                    devicevec.push("[invalid device format string]".to_string())
+                                }
                             }
                         };
 
                         // Get all IPs for this connection
-                        let ip = if self.ip {
-                            let mut ip = "×".to_string();
-                            if let Ok(ip4config) = conn.ip4config(&self.dbus_conn) {
-                                if let Ok(addresses) = ip4config.addresses(&self.dbus_conn) {
-                                    if addresses.len() > 0 {
-                                        ip = addresses.into_iter().map(|x| x.to_string()).collect::<Vec<String>>().join(",")
-                                    }
+                        let mut ips = "×".to_string();
+                        if let Ok(ip4config) = conn.ip4config(&self.dbus_conn) {
+                            if let Ok(addresses) = ip4config.addresses(&self.dbus_conn) {
+                                if addresses.len() > 0 {
+                                    ips = addresses.into_iter().map(|x| x.to_string()).collect::<Vec<String>>().join(",");
                                 }
                             }
-                            ip
+                        }
+
+                        let values = map!("{devices}" => devicevec.join(" "),
+                                          "{ips}" => ips);
+
+                        if let Ok(s) = self.connection_format.render_static_str(&values) {
+                            widget.set_text(s);
                         } else {
-                            "".to_string()
-                        };
-
-                        widget.set_text(devicevec.join(" ") + &ip);
-
+                            widget.set_text("[invalid connection format string]");
+                        }
                         widget
                     })
                     .collect()

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -19,14 +19,14 @@ use widget::{I3BarWidget, State};
 use widgets::button::ButtonWidget;
 
 enum NetworkState {
-    Unknown = 0,
-    Asleep = 10,
-    Disconnected = 20,
-    Disconnecting = 30,
-    Connecting = 40,
-    ConnectedLocal = 50,
-    ConnectedSite = 60,
-    ConnectedGlobal = 70,
+    Unknown,
+    Asleep,
+    Disconnected,
+    Disconnecting,
+    Connecting,
+    ConnectedLocal,
+    ConnectedSite,
+    ConnectedGlobal,
 }
 
 impl From<u32> for NetworkState {
@@ -46,11 +46,11 @@ impl From<u32> for NetworkState {
 }
 
 enum ActiveConnectionState {
-    Unknown = 0,
-    Activating = 1,
-    Activated = 2,
-    Deactivating = 3,
-    Deactivated = 4,
+    Unknown,
+    Activating,
+    Activated,
+    Deactivating,
+    Deactivated,
 }
 
 impl From<u32> for ActiveConnectionState {
@@ -80,36 +80,13 @@ impl ActiveConnectionState {
 
 #[derive(Debug)]
 enum DeviceType {
-    Unknown = 0,
-    Ethernet = 1,
-    Wifi = 2,
-    Unused1 = 3,
-    Unused2 = 4,
-    BT = 5,
-    OLPCMesh = 6,
-    WiMAX = 7,
-    Modem = 8,
-    InfiniBand = 9,
-    Bond = 10,
-    VLAN = 11,
-    ADLS = 12,
-    Bridge = 13,
-    Generic = 14,
-    Team = 15,
-    TUN = 16,
-    IPTunnel = 17,
-    MACVLAN = 18,
-    VXLAN = 19,
-    VETH = 20,
-    MACsec = 21,
-    Dummy = 22,
-    PPP = 23,
-    OVSInterface = 24,
-    OVSPort = 25,
-    OVSBridge = 26,
-    WPAN = 27,
-    IPv6LoWPAN = 28,
-    Wireguard = 29,
+    Unknown,
+    Ethernet,
+    Wifi,
+    Modem,
+    Bridge,
+    TUN,
+    Wireguard,
 }
 
 impl From<u32> for DeviceType {
@@ -118,32 +95,9 @@ impl From<u32> for DeviceType {
             // https://developer.gnome.org/NetworkManager/stable/nm-dbus-types.html#NMDeviceType
             1 => DeviceType::Ethernet,
             2 => DeviceType::Wifi,
-            3 => DeviceType::Unused1,
-            4 => DeviceType::Unused2,
-            5 => DeviceType::BT,
-            6 => DeviceType::OLPCMesh,
-            7 => DeviceType::WiMAX,
             8 => DeviceType::Modem,
-            9 => DeviceType::InfiniBand,
-            10 => DeviceType::Bond,
-            11 => DeviceType::VLAN,
-            12 => DeviceType::ADLS,
             13 => DeviceType::Bridge,
-            14 => DeviceType::Generic,
-            15 => DeviceType::Team,
             16 => DeviceType::TUN,
-            17 => DeviceType::IPTunnel,
-            18 => DeviceType::MACVLAN,
-            19 => DeviceType::VXLAN,
-            20 => DeviceType::VETH,
-            21 => DeviceType::MACsec,
-            22 => DeviceType::Dummy,
-            23 => DeviceType::PPP,
-            24 => DeviceType::OVSInterface,
-            25 => DeviceType::OVSPort,
-            26 => DeviceType::OVSBridge,
-            27 => DeviceType::WPAN,
-            28 => DeviceType::IPv6LoWPAN,
             29 => DeviceType::Wireguard,
             _ => DeviceType::Unknown,
         }

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -181,7 +181,7 @@ impl ConnectionManager {
         Ok(NetworkState::from(state.0))
     }
 
-    pub fn primary_connection(&self, c: &Connection) -> Result<NMConnection> {
+    pub fn primary_connection(&self, c: &Connection) -> Result<NmConnection> {
         let m = Self::get_property(c, "PrimaryConnection").block_error("networkmanager", "Failed to retrieve primary connection")?;
 
         let primary_connection: Variant<Path> = m.get1().block_error("networkmanager", "Failed to read primary connection")?;
@@ -192,24 +192,24 @@ impl ConnectionManager {
             }
         }
 
-        Ok(NMConnection { path: primary_connection.0.clone() })
+        Ok(NmConnection { path: primary_connection.0.clone() })
     }
 
-    pub fn active_connections(&self, c: &Connection) -> Result<Vec<NMConnection>> {
+    pub fn active_connections(&self, c: &Connection) -> Result<Vec<NmConnection>> {
         let m = Self::get_property(c, "ActiveConnections").block_error("networkmanager", "Failed to retrieve active connections")?;
 
         let active_connections: Variant<Array<Path, Iter>> = m.get1().block_error("networkmanager", "Failed to read active connections")?;
 
-        Ok(active_connections.0.into_iter().map(|x| NMConnection { path: x }).collect())
+        Ok(active_connections.0.into_iter().map(|x| NmConnection { path: x }).collect())
     }
 }
 
 #[derive(Clone)]
-struct NMConnection<'a> {
+struct NmConnection<'a> {
     path: Path<'a>,
 }
 
-impl<'a> NMConnection<'a> {
+impl<'a> NmConnection<'a> {
     fn state(&self, c: &Connection) -> Result<ActiveConnectionState> {
         let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Connection.Active", "State").block_error("networkmanager", "Failed to retrieve connection state")?;
 
@@ -217,28 +217,28 @@ impl<'a> NMConnection<'a> {
         Ok(ActiveConnectionState::from(state.0))
     }
 
-    fn ip4config(&self, c: &Connection) -> Result<NMIp4Config> {
+    fn ip4config(&self, c: &Connection) -> Result<NmIp4Config> {
         let m =
             ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Connection.Active", "Ip4Config").block_error("networkmanager", "Failed to retrieve connection ip4config")?;
 
         let ip4config: Variant<Path> = m.get1().block_error("networkmanager", "Failed to read ip4config")?;
-        Ok(NMIp4Config { path: ip4config.0 })
+        Ok(NmIp4Config { path: ip4config.0 })
     }
 
-    fn devices(&self, c: &Connection) -> Result<Vec<NMDevice>> {
+    fn devices(&self, c: &Connection) -> Result<Vec<NmDevice>> {
         let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Connection.Active", "Devices").block_error("networkmanager", "Failed to retrieve connection device")?;
 
         let devices: Variant<Array<Path, Iter>> = m.get1().block_error("networkmanager", "Failed to read devices")?;
-        Ok(devices.0.into_iter().map(|x| NMDevice { path: x }).collect())
+        Ok(devices.0.into_iter().map(|x| NmDevice { path: x }).collect())
     }
 }
 
 #[derive(Clone)]
-struct NMDevice<'a> {
+struct NmDevice<'a> {
     path: Path<'a>,
 }
 
-impl<'a> NMDevice<'a> {
+impl<'a> NmDevice<'a> {
     fn device_type(&self, c: &Connection) -> Result<DeviceType> {
         let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Device", "DeviceType").block_error("networkmanager", "Failed to retrieve device type")?;
 
@@ -246,21 +246,21 @@ impl<'a> NMDevice<'a> {
         Ok(DeviceType::from(device_type.0))
     }
 
-    fn active_access_point(&self, c: &Connection) -> Result<NMAccessPoint> {
+    fn active_access_point(&self, c: &Connection) -> Result<NmAccessPoint> {
         let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Device.Wireless", "ActiveAccessPoint")
             .block_error("networkmanager", "Failed to retrieve device active access point")?;
 
         let active_ap: Variant<Path> = m.get1().block_error("networkmanager", "Failed to read active access point")?;
-        Ok(NMAccessPoint { path: active_ap.0 })
+        Ok(NmAccessPoint { path: active_ap.0 })
     }
 }
 
 #[derive(Clone)]
-struct NMAccessPoint<'a> {
+struct NmAccessPoint<'a> {
     path: Path<'a>,
 }
 
-impl<'a> NMAccessPoint<'a> {
+impl<'a> NmAccessPoint<'a> {
     fn ssid(&self, c: &Connection) -> Result<String> {
         let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.AccessPoint", "Ssid").block_error("networkmanager", "Failed to retrieve SSID")?;
 
@@ -272,11 +272,11 @@ impl<'a> NMAccessPoint<'a> {
 }
 
 #[derive(Clone)]
-struct NMIp4Config<'a> {
+struct NmIp4Config<'a> {
     path: Path<'a>,
 }
 
-impl<'a> NMIp4Config<'a> {
+impl<'a> NmIp4Config<'a> {
     fn addresses(&self, c: &Connection) -> Result<Vec<Ipv4Address>> {
         let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.IP4Config", "Addresses").block_error("networkmanager", "Failed to retrieve addresses")?;
 

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -293,7 +293,7 @@ pub struct NetworkManager {
     manager: ConnectionManager,
     config: Config,
     on_click: Option<String>,
-    only_primary_connection: bool,
+    primary_only: bool,
     unknown_device_icon: bool,
     ip: bool,
     ssid: bool,
@@ -307,8 +307,8 @@ pub struct NetworkManagerConfig {
     pub on_click: Option<String>,
 
     /// Whether to only show the primary connection, or all active connections.
-    #[serde(default = "NetworkManagerConfig::default_only_primary_connection")]
-    pub only_primary_connection: bool,
+    #[serde(default = "NetworkManagerConfig::default_primary_only")]
+    pub primary_only: bool,
 
     /// Whether to show an unknown device icon instead of name for unknown devices.
     #[serde(default = "NetworkManagerConfig::default_unknown_device_icon")]
@@ -332,7 +332,7 @@ impl NetworkManagerConfig {
         None
     }
 
-    fn default_only_primary_connection() -> bool {
+    fn default_primary_only() -> bool {
         false
     }
 
@@ -394,7 +394,7 @@ impl ConfigBlock for NetworkManager {
             dbus_conn,
             manager,
             on_click: block_config.on_click,
-            only_primary_connection: block_config.only_primary_connection,
+            primary_only: block_config.primary_only,
             unknown_device_icon: block_config.unknown_device_icon,
             ip: block_config.ip,
             ssid: block_config.ssid,
@@ -437,7 +437,7 @@ impl Block for NetworkManager {
                     _ => State::Idle,
                 };
 
-                let connections = if self.only_primary_connection {
+                let connections = if self.primary_only {
                     match self.manager.primary_connection(&self.dbus_conn) {
                         Ok(conn) => vec![conn],
                         Err(_) => vec![],

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -218,6 +218,13 @@ impl<'a> NmConnection<'a> {
         Ok(ActiveConnectionState::from(state.0))
     }
 
+    fn id(&self, c: &Connection) -> Result<String> {
+        let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Connection.Active", "Id").block_error("networkmanager", "Failed to retrieve connection ID")?;
+
+        let id: Variant<String> = m.get1().block_error("networkmanager", "Failed to read Id")?;
+        Ok(id.0)
+    }
+
     fn devices(&self, c: &Connection) -> Result<Vec<NmDevice>> {
         let m = ConnectionManager::get(c, self.path.clone(), "org.freedesktop.NetworkManager.Connection.Active", "Devices").block_error("networkmanager", "Failed to retrieve connection device")?;
 
@@ -504,7 +511,13 @@ impl Block for NetworkManager {
                             }
                         };
 
-                        let values = map!("{devices}" => devicevec.join(" ");
+                        let id = match conn.id(&self.dbus_conn) {
+                            Ok(id) => id,
+                            Err(v) => format!("{:?}", v).to_string(),
+                        };
+
+                        let values = map!("{devices}" => devicevec.join(" "),
+                                          "{id}" => id);
 
                         if let Ok(s) = self.connection_format.render_static_str(&values) {
                             widget.set_text(s);

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -78,6 +78,9 @@ lazy_static! {
         "net_down" => " \u{2b07} ",
         "net_wireless" => " \u{f1eb} ",
         "net_wired" => " \u{f0ac} ",
+        "net_bridge" => " \u{f0e8} ",
+        "net_vpn" => " \u{f023} ",
+        "net_modem" => " \u{f095} ",
         "ping" => " \u{21ba} ",
         "backlight_empty" => " \u{1f315} ",
         "backlight_partial1" => " \u{1f314} ",
@@ -94,7 +97,8 @@ lazy_static! {
         // Same as time symbol.
         "uptime" => " \u{f017} ",
         "gpu" => " \u{f26c} ",
-        "mail" => " \u{f0e0} "
+        "mail" => " \u{f0e0} ",
+        "unknown" => " \u{f128} "
     };
 
     pub static ref MATERIAL: Map<String, String> = map_to_owned! {


### PR DESCRIPTION
This PR gives the NetworkManager block the full treatment. It looks quite nice now, if I may say so myself.

Instead of simply showing primary device type and availability, we can now see all active connections, the types of their devices (and if applicable, SSID of connected AP), as well as their IPs. Configuration options exist to filter noise out, such as only showing the primary connection, showing SSIDs and showing IPs.

All information is pulled over D-Bus whenever we receive a PropertiesChanged event.

A click handler was also added, allowing one to easily open nmtui in a popup or similar.

The only things that the net block can do that we can't would be bitrate and current speed. The bitrate is accessible, but it might also get a bit noisy within the same block.