### PR TITLE
blocks/net: Command cleanup

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -92,15 +92,13 @@ impl NetworkDevice {
             ));
         }
         let mut iw_output = Command::new("sh")
-            .args(
-                &[
-                    "-c",
-                    &format!(
-                        "iw dev {} link | grep \"^\\sSSID:\" | sed \"s/^\\sSSID:\\s//g\"",
-                        self.device
-                    ),
-                ],
-            )
+            .args(&[
+                "-c",
+                &format!(
+                    "iw dev {} link | awk '/^\\s+SSID:/ {{ print $2 }}",
+                    self.device
+                ),
+            ])
             .output()
             .block_error("net", "Failed to execute SSID query.")?
             .stdout;
@@ -163,15 +161,13 @@ impl NetworkDevice {
             ));
         }
         let mut bitrate_output = Command::new("sh")
-            .args(
-                &[
-                    "-c",
-                    &format!(
-                        "iw dev {} link | grep \"tx bitrate\" | awk '{{print $3\" \"$4}}'",
-                        self.device
-                    ),
-                ],
-            )
+            .args(&[
+                "-c",
+                &format!(
+                    "iw dev {} link | awk '/tx bitrate/ {{print $3\" \"$4}}'",
+                    self.device
+                ),
+            ])
             .output()
             .block_error("net", "Failed to execute bitrate query.")?
             .stdout;

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -106,16 +106,8 @@ impl NetworkDevice {
             .stdout;
 
         if iw_output.is_empty() {
-            iw_output = Command::new("sh")
-                .args(
-                    &[
-                        "-c",
-                        &format!(
-                            "nmcli -g general.connection device show {}",
-                            self.device
-                        ),
-                    ],
-                )
+            iw_output = Command::new("nmcli")
+                .args(&["-g", "general.connection", "device", "show", &self.device])
                 .output()
                 .block_error("net", "Failed to execute SSID query.")?
                 .stdout;


### PR DESCRIPTION
Removes unnecessary shell instantiations, as well as silly "xyz | grep | awk" constructs.