### PR TITLE
Replace trim_left/right with trim_start/end

### DIFF
--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -91,7 +91,7 @@ impl Block for Toggle {
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
             .unwrap_or_else(|e| e.description().to_owned());
 
-        self.text.set_icon(match output.trim_left() {
+        self.text.set_icon(match output.trim_start() {
             "" => {
                 self.toggled = false;
                 self.icon_off.as_str()

--- a/src/input.rs
+++ b/src/input.rs
@@ -45,8 +45,8 @@ pub fn process_events(sender: Sender<I3BarEvent>) {
         io::stdin().read_line(&mut input).unwrap();
 
         // Take only the valid JSON object betweem curly braces (cut off leading bracket, commas and whitespace)
-        let slice = input.trim_left_matches(|c| c != '{');
-        let slice = slice.trim_right_matches(|c| c != '}');
+        let slice = input.trim_start_matches(|c| c != '{');
+        let slice = slice.trim_end_matches(|c| c != '}');
 
         if !slice.is_empty() {
             let e: I3BarEvent = serde_json::from_str(slice).unwrap();


### PR DESCRIPTION
This should fix the deprecated trim_left/trim_right warnings.