### PR TITLE
Fix SSID query in net block

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -95,7 +95,7 @@ impl NetworkDevice {
             .args(&[
                 "-c",
                 &format!(
-                    "iw dev {} link | awk '/^\\s+SSID:/ {{ print $2 }}",
+                    "iw dev {} link | awk '/^\\s+SSID:/ {{ print $2 }}'",
                     self.device
                 ),
             ])


### PR DESCRIPTION
SSID query that was changed in #339 was missing a `'` from the end of the command.