### PR TITLE
Allow custom block to use pango formatting

### DIFF
--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -26,7 +26,8 @@ impl ButtonWidget {
                 "separator": false,
                 "separator_block_width": 0,
                 "background": "#000000",
-                "color": "#000000"
+                "color": "#000000",
+                "markup": "pango"
             }),
             config,
             cached_output: None,
@@ -83,7 +84,8 @@ impl ButtonWidget {
             "name": self.id.clone(),
             "separator_block_width": 0,
             "background": key_bg,
-            "color": key_fg
+            "color": key_fg,
+            "markup": "pango"
         });
 
         self.cached_output = Some(self.rendered.to_string());


### PR DESCRIPTION
This enables pango markup for the button widget so that users can add colour to their `custom block` output using their shell command output (example below).

![20190319_22h57m01s](https://user-images.githubusercontent.com/20397027/54612368-2fdee080-4a9c-11e9-9702-b0a86a9e802a.png)

More examples (background colour, different font all in the same output):
![20190319_23h23m36s](https://user-images.githubusercontent.com/20397027/54613452-1048b780-4a9e-11e9-887c-a7254f35159f.png)
