### PR TITLE
Add support for UPower's DisplayDevice.

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -72,7 +72,7 @@ Creates a block which displays the current battery state (Full, Charging or Disc
 
 The battery block collapses when the battery is fully charged -- or, in the case of some Thinkpad batteries, when it reports "Not charging".
 
-The battery block supports reading charging and status information from `sysfs`, or optionally through the [Upower](https://upower.freedesktop.org/) D-Bus interface on systems where that is available.
+The battery block supports reading charging and status information from `sysfs`, or optionally through the [UPower](https://upower.freedesktop.org/) D-Bus interface on systems where that is available. Note that UPower has the notion of a DisplayDevice, which is a single logical power source representing all physical power sources. This is for example useful if your system has multiple batteries, in which case the DisplayDevice behaves as if you had a single larger battery.
 
 ### Examples
 
@@ -98,7 +98,7 @@ format = "{percentage}% {time}"
 
 Key | Values | Required | Default
 ----|--------|----------|--------
-`device` | The device in `/sys/class/power_supply/` to read from. | No | `"BAT0"`
+`device` | The device in `/sys/class/power_supply/` to read from. When using UPower, this can also be `"DisplayDevice"`. | No | `"BAT0"`
 `interval` | Update interval, in seconds. | No | `10`
 `format` | A format string. See below for available placeholders. | No | `"{percentage}%"`
 `show` | Deprecated in favour of `format`. Show remaining `"time"`, `"percentage"` or `"both"` | No | `"percentage"`

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -235,11 +235,14 @@ pub struct UpowerDevice {
 
 impl UpowerDevice {
     /// Create the UPower device from the `device` string, which is converted to
-    /// the path `"/org/freedesktop/UPower/devices/battery_<device>"`. Raises an
-    /// error if D-Bus cannot connect to this device, or if the device is not a
+    /// the path `"/org/freedesktop/UPower/devices/battery_<device>"`, except if
+    /// `device` equals `"DisplayDevice"`, in which case it is converted to the
+    /// path `"/org/freedesktop/UPower/devices/DisplayDevice"`. Raises an error
+    /// if D-Bus cannot connect to this device, or if the device is not a
     /// battery.
     pub fn from_device(device: &str) -> Result<Self> {
-        let device_path = format!("/org/freedesktop/UPower/devices/battery_{}", device);
+        let device_name = if device == "DisplayDevice" { device.to_string() } else { format!("battery_{}", device) };
+        let device_path = format!("/org/freedesktop/UPower/devices/{}", device_name);
         let con = dbus::Connection::get_private(dbus::BusType::System)
             .block_error("battery", "Failed to establish D-Bus connection.")?;
 


### PR DESCRIPTION
I have a laptop with two batteries. I am not interested in the charge and time remaining of the individual batteries, but would rather see aggregate values. In particular, how long do I have until both are empty?

UPower supports this out of the box, via the concept of a DisplayDevice. From what I understand, this is basically a logical power supply representing all currently relevant power supplies. From the UPower documentation:

> [...] The "display device" [is] a composite device that represents the status icon to show in desktop environments.

For more information see https://upower.freedesktop.org/docs/UPower.html#UPower.GetDisplayDevice.

The current battery block does not allow using the DisplayDevice, because of how the D-Bus path for the battery is constructed. For the device `BAT0`, the D-Bus path `/org/freedesktop/UPower/devices/battery_BAT0` is used, but the path for the DisplayDevice is `/org/freedesktop/UPower/devices/DisplayDevice` (and not `/org/freedesktop/UPower/devices/battery_DisplayDevice`).

This PR changes how the configuration option `device` of the battery block is handled. All values of `device` that are not `"DisplayDevice"` are handled exactly as before. But if `device` has the value `"DisplayDevice"` and UPower is enabled (i.e., `upower = true` in the block configuration), the `UpowerDevice` is instantiated with the correct path to the DisplayDevice, i.e. with `/org/freedesktop/UPower/devices/DisplayDevice` instead of `/org/freedesktop/UPower/devices/battery_DisplayDevice`.