### PR TITLE
Add a block for Bluetooth devices

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -2,6 +2,7 @@
 
 - [Backlight](#backlight)
 - [Battery](#battery)
+- [Bluetooth](#bluetooth)
 - [CPU Utilization](#cpu-utilization)
 - [Custom](#custom)
 - [Disk Space](#disk-space)
@@ -113,6 +114,30 @@ Placeholder | Description
 `{percentage}` | Battery level, in percent.
 `{time}` | Time remaining until (dis)charge is complete.
 `{power}` | Power consumption (in watts) by the battery or from the power supply when charging.
+
+## Bluetooth
+
+Creates a block which displays the connectivity of a given Bluetooth device, or the battery level if this is supported. Relies on the Bluez D-Bus API, and is therefore asynchronous.
+
+When the device can be identified as an audio headset, a keyboard, joystick, or mouse, use the relevant icon. Otherwise, fall back on the generic Bluetooth symbol.
+
+Right-clicking the block will attempt to connect (or disconnect) the device.
+
+### Examples
+
+A block for a Bluetooth device with the given MAC address:
+
+```toml
+[[block]]
+block = "bluetooth"
+mac = "A0:8A:F5:B8:01:FD"
+```
+
+### Options
+
+Key | Values | Required | Default
+----|--------|----------|--------
+`mac` | MAC address of the Bluetooth device. | Yes | None
 
 ## CPU Utilization
 

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -1,0 +1,196 @@
+use std::thread;
+use std::time::{Duration, Instant};
+
+use chan::Sender;
+use uuid::Uuid;
+
+use block::{Block, ConfigBlock};
+use blocks::dbus;
+use blocks::dbus::stdintf::org_freedesktop_dbus::{ObjectManager, Properties};
+use config::Config;
+use errors::*;
+use scheduler::Task;
+use widget::{I3BarWidget, State};
+use widgets::text::TextWidget;
+
+pub struct BluetoothDevice {
+    pub path: String,
+    pub icon: Option<String>,
+    con: dbus::Connection,
+}
+
+impl BluetoothDevice {
+    pub fn from_mac(mac: String) -> Result<Self> {
+        let con = dbus::Connection::get_private(dbus::BusType::System)
+            .block_error("bluetooth", "Failed to establish D-Bus connection.")?;
+
+        // Bluez does not provide a convenient way to, say, list devices, so we
+        // have to employ a rather verbose workaround.
+
+        let objects = con
+            .with_path("org.bluez", "/", 1000)
+            .get_managed_objects()
+            .block_error("bluetooth", "Failed to decode D-Bus property.")?;
+
+        let devices: Vec<(dbus::Path, String)> = objects
+            .into_iter()
+            .filter(|(_, interfaces)| interfaces.contains_key("org.bluez.Device1"))
+            .map(|(path, interfaces)| {
+                let props = interfaces.get("org.bluez.Device1").unwrap();
+                // This could be made safer; however, this is the documented
+                // D-Bus API format, so it's not a terrible idea to panic if it
+                // is violated.
+                let address: String = props
+                    .get("Address")
+                    .unwrap()
+                    .0
+                    .as_str()
+                    .unwrap()
+                    .to_string();
+                (path, address)
+            }).collect();
+
+        // If we need to suppress errors from missing devices, this is the place
+        // to do it. We could also pick the "default" device here, although that
+        // does not make much sense to me in the context of Bluetooth.
+
+        let path = devices
+            .into_iter()
+            .filter(|(_, address)| address == &mac)
+            .map(|(path, _)| path)
+            .next()
+            .block_error(
+                "bluetooth",
+                "Failed find a device with matching MAC address.",
+            )?.to_string();
+
+        // Swallow errors, since this is optional.
+        let icon: Option<String> = con
+            .with_path("org.bluez", &path, 1000)
+            .get("org.bluez.Device1", "Icon")
+            .ok();
+
+        Ok(BluetoothDevice {
+            path: path,
+            icon: icon,
+            con: con,
+        })
+    }
+
+    pub fn battery(&self) -> Option<u8> {
+        // Swallow errors here; not all devices implement this API.
+        self.con
+            .with_path("org.bluez", &self.path, 1000)
+            .get("org.bluez.Battery1", "Percentage")
+            .ok()
+    }
+
+    pub fn connected(&self) -> Result<bool> {
+        self.con
+            .with_path("org.bluez", &self.path, 1000)
+            .get("org.bluez.Device1", "Connected")
+            .block_error("bluetooth", "Failed to decode D-Bus property.")
+    }
+
+    /// Monitor Bluetooth property changes in a separate thread and send updates
+    /// via the `update_request` channel.
+    pub fn monitor(&self, id: String, update_request: Sender<Task>) {
+        let path = self.path.clone();
+        thread::spawn(move || {
+            let con = dbus::Connection::get_private(dbus::BusType::System)
+                .expect("Failed to establish D-Bus connection.");
+            let rule = format!(
+                "type='signal',\
+                 path='{}',\
+                 interface='org.freedesktop.DBus.Properties',\
+                 member='PropertiesChanged'",
+                path
+            );
+
+            // Skip the NameAcquired event.
+            con.incoming(10_000).next();
+
+            con.add_match(&rule)
+                .expect("Failed to add D-Bus match rule.");
+
+            loop {
+                if con.incoming(10_000).next().is_some() {
+                    update_request.send(Task {
+                        id: id.clone(),
+                        update_time: Instant::now(),
+                    });
+                }
+            }
+        });
+    }
+}
+
+pub struct Bluetooth {
+    id: String,
+    output: TextWidget,
+    device: BluetoothDevice,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct BluetoothConfig {
+    pub mac: String,
+}
+
+impl ConfigBlock for Bluetooth {
+    type Config = BluetoothConfig;
+
+    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
+        let id: String = Uuid::new_v4().simple().to_string();
+        let device = BluetoothDevice::from_mac(block_config.mac)?;
+        device.monitor(id.clone(), send);
+
+        Ok(Bluetooth {
+            id: id,
+            output: TextWidget::new(config).with_icon(match device.icon {
+                Some(ref icon) if icon == "audio-card" => "headphones",
+                Some(ref icon) if icon == "input-gaming" => "joystick",
+                Some(ref icon) if icon == "input-keyboard" => "keyboard",
+                Some(ref icon) if icon == "input-mouse" => "mouse",
+                _ => "bluetooth",
+            }),
+            device,
+        })
+    }
+}
+
+impl Block for Bluetooth {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let connected = self.device.connected()?;
+        self.output.set_text(match connected {
+            true => "".to_string(),
+            false => " ×".to_string(),
+        });
+        self.output.set_state(match connected {
+            true => State::Good,
+            false => State::Idle,
+        });
+
+        // Use battery info, when available.
+        if let Some(value) = self.device.battery() {
+            self.output.set_state(match value {
+                0...15 => State::Critical,
+                16...30 => State::Warning,
+                31...60 => State::Info,
+                61...100 => State::Good,
+                _ => State::Warning,
+            });
+            self.output.set_text(format!(" {}%", value));
+        }
+
+        Ok(None)
+    }
+
+    fn view(&self) -> Vec<&I3BarWidget> {
+        vec![&self.output]
+    }
+}

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -21,6 +21,7 @@ mod uptime;
 pub mod nvidia_gpu;
 pub mod maildir;
 mod networkmanager;
+mod bluetooth;
 
 use config::Config;
 use self::time::*;
@@ -46,6 +47,7 @@ use self::uptime::*;
 use self::nvidia_gpu::*;
 use self::maildir::*;
 use self::networkmanager::*;
+use self::bluetooth::*;
 
 use super::block::{Block, ConfigBlock};
 use errors::*;
@@ -100,6 +102,7 @@ pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_r
             "uptime" => Uptime,
             "nvidia_gpu" => NvidiaGpu,
             "maildir" => Maildir,
-            "networkmanager" => NetworkManager
+            "networkmanager" => NetworkManager,
+            "bluetooth" => Bluetooth
     )
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -45,7 +45,12 @@ lazy_static! {
         "weather_default" => " WEATHER ",
         "uptime" => " UP ",
         "gpu" => " GPU ",
-        "mail" => " "
+        "mail" => " ",
+        "bluetooth" => " BT",
+        "headphones" => " HEAD",
+        "joystick" => " JOY",
+        "keyboard" => " KBD",
+        "mouse" => " MOUSE"
     };
 
     pub static ref AWESOME: Map<String, String> = map_to_owned! {
@@ -94,7 +99,12 @@ lazy_static! {
         // Same as time symbol.
         "uptime" => " \u{f017} ",
         "gpu" => " \u{f26c} ",
-        "mail" => " \u{f0e0} "
+        "mail" => " \u{f0e0} ",
+        "bluetooth" => " \u{f294}",
+        "headphones" => " \u{f025}",
+        "joystick" => " \u{f11b}",
+        "keyboard" => " \u{f11c}",
+        "mouse" => " \u{f245}"
     };
 
     pub static ref MATERIAL: Map<String, String> = map_to_owned! {
@@ -126,7 +136,12 @@ lazy_static! {
         // Same as time symbol.
         "uptime" => " \u{e192} ",
         "gpu" => " \u{e333} ",
-        "mail" => " \u{e0be} "
+        "mail" => " \u{e0be} ",
+        "bluetooth" => " \u{e1a7}",
+        "headphones" => " \u{e60f}",
+        "joystick" => " \u{e30f}",
+        "keyboard" => " \u{e312}",
+        "mouse" => " \u{e323}"
     };
 }
 


### PR DESCRIPTION
This PR adds a new block and the relevant documentation. I'm using the D-Bus API, so it should be extremely light on resources. No new dependencies, either.

(I am indebted to [this blog post](http://smartspacestuff.blogspot.com/2016/02/i-got-figurin-out-dbus-bluez.html) for figuring out some aspects of the D-Bus API.)

At the moment, the block recognizes headphones, keyboards, mice, and joysticks and chooses an appropriate icon. If the device supports the `org.bluez.Battery1` interface, the block will also report the battery level.

Note that since I don't actually own a device that supports the battery interface, I'm not actually sure that it works -- any testers would be much appreciated.

Otherwise, this block doesn't do much at the moment. It is possible that we could add e.g. (dis)connect on right click, for example, or auto hide/show behaviour to match some other blocks.

Closes #178. cc @srid