### PR TITLE
blocks/battery: When charging, show remaining time with UPower.

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -332,10 +332,11 @@ impl BatteryDevice for UpowerDevice {
     }
 
     fn time_remaining(&self) -> Result<u64> {
+        let property = if self.status()? == "Charging" { "TimeToFull" } else { "TimeToEmpty" };
         let time_to_empty: dbus::arg::Variant<i64> =
-            get_upower_property(&self.con, &self.device_path, "TimeToEmpty")?
+            get_upower_property(&self.con, &self.device_path, property)?
                 .get1()
-                .block_error("battery", "Failed to read UPower TimeToEmpty property.")?;
+                .block_error("battery", &format!("Failed to read UPower {} property.", property))?;
         Ok((time_to_empty.0 / 60) as u64)
     }
 


### PR DESCRIPTION
This is another small enhancement for the battery block with `upower = true`.

For a `PowerSupplyDevice`, the method `time_remaining` returns the time until the battery is empty if it is currently being drained, and it returns the time until the battery is full if it is currently being charged.

For a `UpowerDevice`, the method `time_remaining` always returns the time until the battery is empty, even when it is charging.

This PR changes the behavior of the `UpowerDevice` to match the `PowerSupplyDevice` w.r.t. the `time_remaining` method.

On a related note, how about changing the method `fn BatteryDevice::status(&self) -> Result<String>;` to return an enum `BatteryStatus` or so?