### PR TITLE
Migrate code to edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "i3status-rs"
 version = "0.9.0"
 authors = ["Kai Greshake <development@kai-greshake.de>",
            "Contributors on GitHub (https://github.com/greshake/i3status-rust/graphs/contributors)"]
+edition = "2018"
 
 [features]
 default = ["pulseaudio"]

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,10 +1,10 @@
-use config::Config;
-use errors::*;
-use scheduler::Task;
+use crate::config::Config;
+use crate::errors::*;
+use crate::scheduler::Task;
 use chan::Sender;
 use std::time::Duration;
-use input::I3BarEvent;
-use widget::I3BarWidget;
+use crate::input::I3BarEvent;
+use crate::widget::I3BarWidget;
 
 pub trait Block {
     /// Updates the internal state of a Block

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -17,13 +17,13 @@ use chan::Sender;
 use inotify::{EventMask, Inotify, WatchMask};
 use uuid::Uuid;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use errors::*;
-use input::{I3BarEvent, MouseButton};
-use scheduler::Task;
-use widget::I3BarWidget;
-use widgets::button::ButtonWidget;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::errors::*;
+use crate::input::{I3BarEvent, MouseButton};
+use crate::scheduler::Task;
+use crate::widget::I3BarWidget;
+use crate::widgets::button::ButtonWidget;
 
 /// Read a brightness value from the given path.
 fn read_brightness(device_file: &Path) -> Result<u64> {

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -5,23 +5,23 @@
 //! internal power supply.
 
 use std::path::{Path, PathBuf};
-use util::FormatTemplate;
+use crate::util::FormatTemplate;
 use std::time::{Duration, Instant};
 use std::thread;
 
 use chan::Sender;
 use uuid::Uuid;
 
-use block::{Block, ConfigBlock};
-use blocks::dbus;
-use blocks::dbus::stdintf::org_freedesktop_dbus::Properties;
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use scheduler::Task;
-use util::read_file;
-use widget::{I3BarWidget, State};
-use widgets::text::TextWidget;
+use crate::block::{Block, ConfigBlock};
+use crate::blocks::dbus;
+use crate::blocks::dbus::stdintf::org_freedesktop_dbus::Properties;
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::scheduler::Task;
+use crate::util::read_file;
+use crate::widget::{I3BarWidget, State};
+use crate::widgets::text::TextWidget;
 
 /// A battery device can be queried for a few properties relevant to the user.
 pub trait BatteryDevice {

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -4,15 +4,15 @@ use std::time::{Duration, Instant};
 use chan::Sender;
 use uuid::Uuid;
 
-use block::{Block, ConfigBlock};
-use blocks::dbus;
-use blocks::dbus::stdintf::org_freedesktop_dbus::{ObjectManager, Properties};
-use config::Config;
-use errors::*;
-use input::{I3BarEvent, MouseButton};
-use scheduler::Task;
-use widget::{I3BarWidget, State};
-use widgets::button::ButtonWidget;
+use crate::block::{Block, ConfigBlock};
+use crate::blocks::dbus;
+use crate::blocks::dbus::stdintf::org_freedesktop_dbus::{ObjectManager, Properties};
+use crate::config::Config;
+use crate::errors::*;
+use crate::input::{I3BarEvent, MouseButton};
+use crate::scheduler::Task;
+use crate::widget::{I3BarWidget, State};
+use crate::widgets::button::ButtonWidget;
 
 pub struct BluetoothDevice {
     pub path: String,

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -1,13 +1,13 @@
 use chan::Sender;
-use scheduler::Task;
+use crate::scheduler::Task;
 use std::time::Duration;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widget::{I3BarWidget, State};
-use widgets::text::TextWidget;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widget::{I3BarWidget, State};
+use crate::widgets::text::TextWidget;
 
 use std::fs::File;
 use std::io::prelude::*;

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -5,14 +5,14 @@ use std::vec;
 use std::env;
 use chan::Sender;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widgets::button::ButtonWidget;
-use widget::I3BarWidget;
-use input::I3BarEvent;
-use scheduler::Task;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widgets::button::ButtonWidget;
+use crate::widget::I3BarWidget;
+use crate::input::I3BarEvent;
+use crate::scheduler::Task;
 
 use uuid::Uuid;
 

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -1,14 +1,14 @@
 use std::time::Duration;
 use std::path::Path;
 use chan::Sender;
-use scheduler::Task;
+use crate::scheduler::Task;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widgets::text::TextWidget;
-use widget::{I3BarWidget, State};
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widgets::text::TextWidget;
+use crate::widget::{I3BarWidget, State};
 
 use uuid::Uuid;
 

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -3,12 +3,12 @@ use chan::Sender;
 use std::thread;
 use std::sync::{Arc, Mutex};
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use errors::*;
-use widgets::text::TextWidget;
-use widget::I3BarWidget;
-use scheduler::Task;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::errors::*;
+use crate::widgets::text::TextWidget;
+use crate::widget::I3BarWidget;
+use crate::scheduler::Task;
 
 use uuid::Uuid;
 

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -1,14 +1,14 @@
 use std::time::Duration;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widgets::text::TextWidget;
-use widget::{I3BarWidget, State};
-use util::FormatTemplate;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widgets::text::TextWidget;
+use crate::widget::{I3BarWidget, State};
+use crate::util::FormatTemplate;
 use chan::Sender;
-use scheduler::Task;
+use crate::scheduler::Task;
 
 use std::io::BufReader;
 use std::io::prelude::*;

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -1,14 +1,14 @@
 use std::time::Duration;
 use chan::Sender;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widgets::text::TextWidget;
-use widget::{I3BarWidget, State};
-use input::I3BarEvent;
-use scheduler::Task;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widgets::text::TextWidget;
+use crate::widget::{I3BarWidget, State};
+use crate::input::I3BarEvent;
+use crate::scheduler::Task;
 use maildir::Maildir as ExtMaildir;
 
 use uuid::Uuid;

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -74,22 +74,22 @@
 //!
 use std::time::{Duration, Instant};
 use std::collections::HashMap;
-use util::*;
+use crate::util::*;
 use chan::Sender;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use block::{Block, ConfigBlock};
-use input::{I3BarEvent, MouseButton};
+use crate::block::{Block, ConfigBlock};
+use crate::input::{I3BarEvent, MouseButton};
 use std::str::FromStr;
 use uuid::Uuid;
 use std::fmt;
 
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widgets::button::ButtonWidget;
-use widget::{I3BarWidget, State};
-use scheduler::Task;
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widgets::button::ButtonWidget;
+use crate::widget::{I3BarWidget, State};
+use crate::scheduler::Task;
 
 use std::io::Write;
 use std::fs::OpenOptions;

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -23,7 +23,7 @@ pub mod maildir;
 mod networkmanager;
 mod bluetooth;
 
-use config::Config;
+use crate::config::Config;
 use self::time::*;
 use self::template::*;
 use self::music::*;
@@ -50,7 +50,7 @@ use self::networkmanager::*;
 use self::bluetooth::*;
 
 use super::block::{Block, ConfigBlock};
-use errors::*;
+use crate::errors::*;
 use super::scheduler::Task;
 
 extern crate dbus;

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -3,18 +3,18 @@ use chan::Sender;
 use std::thread;
 use std::boxed::Box;
 
-use config::Config;
-use errors::*;
-use scheduler::Task;
-use input::I3BarEvent;
-use block::{Block, ConfigBlock};
-use de::deserialize_duration;
-use widgets::rotatingtext::RotatingTextWidget;
-use widgets::button::ButtonWidget;
-use widget::{I3BarWidget, State};
+use crate::config::Config;
+use crate::errors::*;
+use crate::scheduler::Task;
+use crate::input::I3BarEvent;
+use crate::block::{Block, ConfigBlock};
+use crate::de::deserialize_duration;
+use crate::widgets::rotatingtext::RotatingTextWidget;
+use crate::widgets::button::ButtonWidget;
+use crate::widget::{I3BarWidget, State};
 
-use blocks::dbus::{arg, stdintf, BusType, Connection, ConnectionItem, Message};
-use blocks::dbus::arg::{Array, RefArg};
+use crate::blocks::dbus::{arg, stdintf, BusType, Connection, ConnectionItem, Message};
+use crate::blocks::dbus::arg::{Array, RefArg};
 use self::stdintf::org_freedesktop_dbus::Properties;
 use uuid::Uuid;
 

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -5,14 +5,14 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 use chan::Sender;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widgets::text::TextWidget;
-use widgets::graph::GraphWidget;
-use widget::I3BarWidget;
-use scheduler::Task;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widgets::text::TextWidget;
+use crate::widgets::graph::GraphWidget;
+use crate::widget::I3BarWidget;
+use crate::scheduler::Task;
 
 use uuid::Uuid;
 

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -5,14 +5,14 @@ use std::thread;
 use chan::Sender;
 use uuid::Uuid;
 
-use config::Config;
-use errors::*;
-use scheduler::Task;
-use block::{Block, ConfigBlock};
-use widget::{I3BarWidget, State};
-use widgets::text::TextWidget;
-use blocks::dbus::{BusType, Connection, Message, MessageItem};
-use blocks::dbus::arg::Variant;
+use crate::config::Config;
+use crate::errors::*;
+use crate::scheduler::Task;
+use crate::block::{Block, ConfigBlock};
+use crate::widget::{I3BarWidget, State};
+use crate::widgets::text::TextWidget;
+use crate::blocks::dbus::{BusType, Connection, Message, MessageItem};
+use crate::blocks::dbus::arg::Variant;
 
 enum NetworkState {
     Unknown = 0,

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -2,16 +2,16 @@ use std::time::Duration;
 use std::process::Command;
 use chan::Sender;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use input::{I3BarEvent, MouseButton};
-use scheduler::Task;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::input::{I3BarEvent, MouseButton};
+use crate::scheduler::Task;
 use uuid::Uuid;
-use widget::{I3BarWidget, State};
-use widgets::button::ButtonWidget;
-use widgets::text::TextWidget;
+use crate::widget::{I3BarWidget, State};
+use crate::widgets::button::ButtonWidget;
+use crate::widgets::text::TextWidget;
 
 pub struct NvidiaGpu {
     gpu_widget: ButtonWidget,

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -6,15 +6,15 @@ use std::process::Command;
 use std::env;
 use std::ffi::OsString;
 use chan::Sender;
-use scheduler::Task;
+use crate::scheduler::Task;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use input::{I3BarEvent, MouseButton};
-use widgets::button::ButtonWidget;
-use widget::{I3BarWidget, State};
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::input::{I3BarEvent, MouseButton};
+use crate::widgets::button::ButtonWidget;
+use crate::widget::{I3BarWidget, State};
 
 use uuid::Uuid;
 

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -17,29 +17,29 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use chan::Sender;
 #[cfg(feature = "pulseaudio")]
-use chan::{async, sync};
+use chan::{r#async, sync};
 
-use scheduler::Task;
-use block::{Block, ConfigBlock};
-use config::Config;
-use errors::*;
-use widgets::button::ButtonWidget;
-use widget::{I3BarWidget, State};
-use input::{I3BarEvent, MouseButton};
-use subprocess::{parse_command, spawn_child_async};
+use crate::scheduler::Task;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::errors::*;
+use crate::widgets::button::ButtonWidget;
+use crate::widget::{I3BarWidget, State};
+use crate::input::{I3BarEvent, MouseButton};
+use crate::subprocess::{parse_command, spawn_child_async};
 
 #[cfg(feature = "pulseaudio")]
-use pulse::mainloop::standard::Mainloop;
+use crate::pulse::mainloop::standard::Mainloop;
 #[cfg(feature = "pulseaudio")]
-use pulse::callbacks::ListResult;
+use crate::pulse::callbacks::ListResult;
 #[cfg(feature = "pulseaudio")]
-use pulse::context::{Context, flags, State as PulseState, introspect::SinkInfo, introspect::ServerInfo, subscribe::Facility, subscribe::Operation as SubscribeOperation, subscribe::subscription_masks};
+use crate::pulse::context::{Context, flags, State as PulseState, introspect::SinkInfo, introspect::ServerInfo, subscribe::Facility, subscribe::Operation as SubscribeOperation, subscribe::subscription_masks};
 #[cfg(feature = "pulseaudio")]
-use pulse::proplist::{properties, Proplist};
+use crate::pulse::proplist::{properties, Proplist};
 #[cfg(feature = "pulseaudio")]
-use pulse::mainloop::standard::IterateResult;
+use crate::pulse::mainloop::standard::IterateResult;
 #[cfg(feature = "pulseaudio")]
-use pulse::volume::{ChannelVolumes, VOLUME_NORM, VOLUME_MAX};
+use crate::pulse::volume::{ChannelVolumes, VOLUME_NORM, VOLUME_MAX};
 
 use uuid::Uuid;
 
@@ -272,7 +272,7 @@ impl PulseAudioConnection {
 #[cfg(feature = "pulseaudio")]
 impl PulseAudioClient {
     fn new() -> Result<PulseAudioClient> {
-        let (send_req, recv_req) = async();
+        let (send_req, recv_req) = r#async();
         let (send_result, recv_result) = sync(0);
         let send_result2 = send_result.clone();
         let new_connection = |sender: Sender<Result<()>>| -> PulseAudioConnection {

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -2,16 +2,16 @@ use std::time::{Duration, Instant};
 use std::process::Command;
 use std::thread::spawn;
 use std::sync::{Arc, Mutex};
-use chan::{async, Receiver, Sender};
-use scheduler::Task;
+use chan::{r#async, Receiver, Sender};
+use crate::scheduler::Task;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widgets::button::ButtonWidget;
-use widget::{I3BarWidget, State};
-use input::{I3BarEvent, MouseButton};
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widgets::button::ButtonWidget;
+use crate::widget::{I3BarWidget, State};
+use crate::input::{I3BarEvent, MouseButton};
 
 use uuid::Uuid;
 
@@ -102,7 +102,7 @@ impl ConfigBlock for SpeedTest {
 
     fn new(block_config: Self::Config, config: Config, done: Sender<Task>) -> Result<Self> {
         // Create all the things we are going to send and take for ourselves.
-        let (send, recv): (Sender<()>, Receiver<()>) = async();
+        let (send, recv): (Sender<()>, Receiver<()>) = r#async();
         let vals = Arc::new(Mutex::new((false, vec![])));
         let id = Uuid::new_v4().simple().to_string();
 

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -1,16 +1,16 @@
 use std::time::Duration;
 use std::process::Command;
-use util::FormatTemplate;
+use crate::util::FormatTemplate;
 use chan::Sender;
-use scheduler::Task;
+use crate::scheduler::Task;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widgets::button::ButtonWidget;
-use widget::{I3BarWidget, State};
-use input::{I3BarEvent, MouseButton};
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widgets::button::ButtonWidget;
+use crate::widget::{I3BarWidget, State};
+use crate::input::{I3BarEvent, MouseButton};
 
 use uuid::Uuid;
 

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -1,14 +1,14 @@
 use std::time::Duration;
 use chan::Sender;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widgets::text::TextWidget;
-use widget::I3BarWidget;
-use input::I3BarEvent;
-use scheduler::Task;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widgets::text::TextWidget;
+use crate::widget::I3BarWidget;
+use crate::input::I3BarEvent;
+use crate::scheduler::Task;
 
 use uuid::Uuid;
 

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -1,18 +1,18 @@
 use std::time::Duration;
 
-use block::{Block, ConfigBlock};
+use crate::block::{Block, ConfigBlock};
 use chan::Sender;
 use chrono::offset::{Local, Utc};
 use chrono_tz::Tz;
-use config::Config;
-use de::{deserialize_duration, deserialize_timezone};
-use errors::*;
-use input::I3BarEvent;
-use scheduler::Task;
+use crate::config::Config;
+use crate::de::{deserialize_duration, deserialize_timezone};
+use crate::errors::*;
+use crate::input::I3BarEvent;
+use crate::scheduler::Task;
 use uuid::Uuid;
-use widget::I3BarWidget;
-use widgets::button::ButtonWidget;
-use subprocess::{parse_command, spawn_child_async};
+use crate::widget::I3BarWidget;
+use crate::widgets::button::ButtonWidget;
+use crate::subprocess::{parse_command, spawn_child_async};
 
 pub struct Time {
     time: ButtonWidget,

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -2,15 +2,15 @@ use std::env;
 use std::time::Duration;
 use std::process::Command;
 use chan::Sender;
-use scheduler::Task;
+use crate::scheduler::Task;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_opt_duration;
-use errors::*;
-use widgets::button::ButtonWidget;
-use widget::I3BarWidget;
-use input::I3BarEvent;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_opt_duration;
+use crate::errors::*;
+use crate::widgets::button::ButtonWidget;
+use crate::widget::I3BarWidget;
+use crate::input::I3BarEvent;
 
 use uuid::Uuid;
 

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -4,14 +4,14 @@ use std::time::Duration;
 use chan::Sender;
 use uuid::Uuid;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use scheduler::Task;
-use util::read_file;
-use widgets::text::TextWidget;
-use widget::I3BarWidget;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::scheduler::Task;
+use crate::util::read_file;
+use crate::widgets::text::TextWidget;
+use crate::widget::I3BarWidget;
 
 pub struct Uptime {
     text: TextWidget,

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -5,15 +5,15 @@ use chan::Sender;
 use serde_json;
 use uuid::Uuid;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use input::{I3BarEvent, MouseButton};
-use scheduler::Task;
-use util::FormatTemplate;
-use widgets::button::ButtonWidget;
-use widget::I3BarWidget;
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::input::{I3BarEvent, MouseButton};
+use crate::scheduler::Task;
+use crate::util::FormatTemplate;
+use crate::widgets::button::ButtonWidget;
+use crate::widget::I3BarWidget;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(tag = "name", rename_all = "lowercase")]

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -2,17 +2,17 @@ use std::time::Duration;
 use std::process::Command;
 use std::str::FromStr;
 use chan::Sender;
-use scheduler::Task;
+use crate::scheduler::Task;
 
-use util::FormatTemplate;
+use crate::util::FormatTemplate;
 
-use block::{Block, ConfigBlock};
-use config::Config;
-use de::deserialize_duration;
-use errors::*;
-use widgets::button::ButtonWidget;
-use widget::I3BarWidget;
-use input::{I3BarEvent, MouseButton};
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::widgets::button::ButtonWidget;
+use crate::widget::I3BarWidget;
+use crate::input::{I3BarEvent, MouseButton};
 
 use uuid::Uuid;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,12 @@
-use de::*;
-use icons;
+use crate::de::*;
+use crate::icons;
 use serde::de::{self, Deserialize, Deserializer};
 use toml::value;
 use std::collections::HashMap as Map;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::str::FromStr;
-use themes::{self, Theme};
+use crate::themes::{self, Theme};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,17 +46,17 @@ use std::collections::HashMap;
 use std::time::Duration;
 use std::ops::DerefMut;
 
-use block::Block;
+use crate::block::Block;
 
-use blocks::create_block;
-use config::Config;
-use errors::*;
-use input::{process_events, I3BarEvent};
-use scheduler::{Task, UpdateScheduler};
-use widget::{I3BarWidget, State};
-use widgets::text::TextWidget;
+use crate::blocks::create_block;
+use crate::config::Config;
+use crate::errors::*;
+use crate::input::{process_events, I3BarEvent};
+use crate::scheduler::{Task, UpdateScheduler};
+use crate::widget::{I3BarWidget, State};
+use crate::widgets::text::TextWidget;
 
-use util::deserialize_file;
+use crate::util::deserialize_file;
 
 use self::clap::{App, Arg, ArgMatches};
 use self::chan::{Receiver, Sender};
@@ -138,7 +138,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
     let config: Config = deserialize_file(matches.value_of("config").unwrap())?;
 
     // Update request channel
-    let (tx_update_requests, rx_update_requests): (Sender<Task>, Receiver<Task>) = chan::async();
+    let (tx_update_requests, rx_update_requests): (Sender<Task>, Receiver<Task>) = chan::r#async();
 
     // In dev build, we might diverge into profiling blocks here
     if let Some(name) = matches.value_of("profile") {
@@ -204,7 +204,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
     }
 
     // We wait for click events in a separate thread, to avoid blocking to wait for stdin
-    let (tx_clicks, rx_clicks): (Sender<I3BarEvent>, Receiver<I3BarEvent>) = chan::async();
+    let (tx_clicks, rx_clicks): (Sender<I3BarEvent>, Receiver<I3BarEvent>) = chan::r#async();
     process_events(tx_clicks);
 
     // Time to next update channel.

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,5 +1,5 @@
-use block::Block;
-use errors::*;
+use crate::block::Block;
+use crate::errors::*;
 use std::collections::{BinaryHeap, HashMap};
 use std::fmt;
 use std::thread;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
-use block::Block;
-use config::Config;
-use errors::*;
+use crate::block::Block;
+use crate::config::Config;
+use crate::errors::*;
 use std::collections::HashMap;
 use serde::de::DeserializeOwned;
 use serde_json::value::Value;

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,4 +1,4 @@
-use themes::Theme;
+use crate::themes::Theme;
 use serde_json::value::Value;
 
 #[derive(Debug, Copy, Clone)]

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -1,5 +1,5 @@
-use config::Config;
-use widget::State;
+use crate::config::Config;
+use crate::widget::State;
 use serde_json::value::Value;
 use super::super::widget::I3BarWidget;
 

--- a/src/widgets/graph.rs
+++ b/src/widgets/graph.rs
@@ -1,5 +1,5 @@
-use config::Config;
-use widget::State;
+use crate::config::Config;
+use crate::widget::State;
 use serde_json::value::Value;
 use super::super::widget::I3BarWidget;
 use num::{clamp, ToPrimitive};

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -1,7 +1,7 @@
-use config::Config;
-use errors::*;
+use crate::config::Config;
+use crate::errors::*;
 use std::time::{Duration, Instant};
-use widget::{I3BarWidget, State};
+use crate::widget::{I3BarWidget, State};
 use serde_json::value::Value;
 
 #[derive(Clone, Debug)]

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -1,5 +1,5 @@
-use config::Config;
-use widget::State;
+use crate::config::Config;
+use crate::widget::State;
 use serde_json::value::Value;
 use super::super::widget::I3BarWidget;
 


### PR DESCRIPTION
This enables to remove now useless `extern crate` statements.
I ran cargo fix --edition.