### PR TITLE
block/time: Clean up zombie processes.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ mod input;
 mod icons;
 mod themes;
 mod scheduler;
+mod subprocess;
 mod widget;
 mod widgets;
 

--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -1,0 +1,18 @@
+use std::io;
+use std::process::Command;
+use std::thread;
+
+/// Splits a string into command name and arguments.
+pub fn parse_command(command: &str) -> (&str, Vec<&str>) {
+    let components: Vec<&str> = command.split_whitespace().collect();
+    let (names, args) = components.split_at(1);
+    let name = names.get(0).unwrap();
+    (name, args.to_vec())
+}
+
+// Spawns a new child process. This returns to the caller after the child has been started. A new thread waits for the child to exit.
+pub fn spawn_child_async(name: &str, args: &[&str]) -> io::Result<()> {
+    let mut child = Command::new(name).args(args).spawn()?;
+    thread::spawn(move || child.wait());
+    Ok(())
+}


### PR DESCRIPTION
Spawning a command without waiting for it leaves behind a zombie process. This pull request waits for the spawned commands.

The time and sound blocks use the same code to spawn a child process, so I moved this code to a new module `subprocess.rs`.

If spawning the child failed, an error is returned.

Fixes #355.