### PR TITLE
Allow for reading theme information from standalone files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,18 +1,18 @@
 use crate::de::*;
 use crate::icons;
-use serde::de::{self, Deserialize, Deserializer};
 use toml::value;
+use serde::de::{Deserialize, Deserializer, Error};
 use std::collections::HashMap as Map;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::str::FromStr;
-use crate::themes::{self, Theme};
+use crate::themes::{Theme, ThemeConfig};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {
     #[serde(default = "icons::default", deserialize_with = "deserialize_icons")]
     pub icons: Map<String, String>,
-    #[serde(default = "themes::default", deserialize_with = "deserialize_themes")]
+    #[serde(deserialize_with = "deserialize_themes")]
     pub theme: Theme,
     #[serde(rename = "block", deserialize_with = "deserialize_blocks")]
     pub blocks: Vec<(String, value::Value)>,
@@ -22,7 +22,7 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             icons: icons::default(),
-            theme: themes::default(),
+            theme: Theme::default(),
             blocks: Vec::new(),
         }
     }
@@ -59,14 +59,7 @@ fn deserialize_themes<'de, D>(deserializer: D) -> Result<Theme, D::Error>
 where
     D: Deserializer<'de>,
 {
-    map_type!(ThemeIntermediary, String;
-              s => Ok(ThemeIntermediary(themes::get_theme(s).ok_or_else(|| "cannot find specified theme")?.owned_map())));
-
-    let intermediary: Map<String, String> = deserializer
-        .deserialize_any(MapType::<ThemeIntermediary, String>(
-            PhantomData,
-            PhantomData,
-        ))?;
-
-    Deserialize::deserialize(de::value::MapDeserializer::new(intermediary.into_iter()))
+    ThemeConfig::deserialize(deserializer)?
+        .into_theme()
+        .ok_or_else(|| D::Error::custom("Unrecognized theme name."))
 }

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::default::Default;
 
 lazy_static! {
     pub static ref SLICK: Theme = Theme {
@@ -146,50 +146,97 @@ lazy_static! {
     };
 }
 
-mapped_struct! {
-    #[derive(Deserialize, Debug, Default, Clone)]
-    #[serde(deny_unknown_fields)]
-    pub struct Theme: String {
-        pub idle_bg,
-        pub idle_fg,
-        pub info_bg,
-        pub info_fg,
-        pub good_bg,
-        pub good_fg,
-        pub warning_bg,
-        pub warning_fg,
-        pub critical_bg,
-        pub critical_fg,
-        pub separator,
-        pub separator_bg,
-        pub separator_fg,
-        pub alternating_tint_bg,
-        pub alternating_tint_fg
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct Theme {
+    pub idle_bg: String,
+    pub idle_fg: String,
+    pub info_bg: String,
+    pub info_fg: String,
+    pub good_bg: String,
+    pub good_fg: String,
+    pub warning_bg: String,
+    pub warning_fg: String,
+    pub critical_bg: String,
+    pub critical_fg: String,
+    pub separator: String,
+    pub separator_bg: String,
+    pub separator_fg: String,
+    pub alternating_tint_bg: String,
+    pub alternating_tint_fg: String,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        PLAIN.clone()
     }
 }
 
-impl FromStr for Theme {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        get_theme(s).ok_or_else(|| "unknown theme".into())
+impl Theme {
+    pub fn from_name(name: &str) -> Option<Theme> {
+        match name {
+            "slick" => Some(SLICK.clone()),
+            "solarized-dark" => Some(SOLARIZED_DARK.clone()),
+            "solarized-light" => Some(SOLARIZED_LIGHT.clone()),
+            "plain" => Some(PLAIN.clone()),
+            "modern" => Some(MODERN.clone()),
+            "bad-wolf" => Some(BAD_WOLF.clone()),
+            "gruvbox-light" => Some(GRUVBOX_LIGHT.clone()),
+            "gruvbox-dark" => Some(GRUVBOX_DARK.clone()),
+            _ => None,
+        }
     }
 }
 
-pub fn get_theme(name: &str) -> Option<Theme> {
-    match name {
-        "slick" => Some(SLICK.clone()),
-        "solarized-dark" => Some(SOLARIZED_DARK.clone()),
-        "solarized-light" => Some(SOLARIZED_LIGHT.clone()),
-        "plain" => Some(PLAIN.clone()),
-        "modern" => Some(MODERN.clone()),
-        "bad-wolf" => Some(BAD_WOLF.clone()),
-        "gruvbox-light" => Some(GRUVBOX_LIGHT.clone()),
-        "gruvbox-dark" => Some(GRUVBOX_DARK.clone()),
-        _ => None,
-    }
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ThemeOverrides {
+    idle_bg: Option<String>,
+    idle_fg: Option<String>,
+    info_bg: Option<String>,
+    info_fg: Option<String>,
+    good_bg: Option<String>,
+    good_fg: Option<String>,
+    warning_bg: Option<String>,
+    warning_fg: Option<String>,
+    critical_bg: Option<String>,
+    critical_fg: Option<String>,
+    separator: Option<String>,
+    separator_bg: Option<String>,
+    separator_fg: Option<String>,
+    alternating_tint_bg: Option<String>,
+    alternating_tint_fg: Option<String>,
 }
 
-pub fn default() -> Theme {
-    PLAIN.clone()
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ThemeConfig {
+    name: String,
+    overrides: Option<ThemeOverrides>,
+}
+
+impl ThemeConfig {
+    pub fn into_theme(self) -> Option<Theme> {
+        let mut theme = Theme::from_name(&self.name)?;
+        if let Some(overrides) = self.overrides {
+            theme.idle_bg = overrides.idle_bg.unwrap_or(theme.idle_bg);
+            theme.idle_fg = overrides.idle_fg.unwrap_or(theme.idle_fg);
+            theme.info_bg = overrides.info_bg.unwrap_or(theme.info_bg);
+            theme.info_fg = overrides.info_fg.unwrap_or(theme.info_fg);
+            theme.warning_bg = overrides.warning_bg.unwrap_or(theme.warning_bg);
+            theme.warning_fg = overrides.warning_fg.unwrap_or(theme.warning_fg);
+            theme.critical_bg = overrides.critical_bg.unwrap_or(theme.critical_bg);
+            theme.critical_fg = overrides.critical_fg.unwrap_or(theme.critical_fg);
+            theme.separator = overrides.separator.unwrap_or(theme.separator);
+            theme.separator_bg = overrides.separator_bg.unwrap_or(theme.separator_bg);
+            theme.separator_fg = overrides.separator_fg.unwrap_or(theme.separator_fg);
+            theme.alternating_tint_bg = overrides
+                .alternating_tint_bg
+                .unwrap_or(theme.alternating_tint_bg);
+            theme.alternating_tint_fg = overrides
+                .alternating_tint_fg
+                .unwrap_or(theme.alternating_tint_fg);
+        }
+        Some(theme)
+    }
 }

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,4 +1,7 @@
 use std::default::Default;
+use std::path::Path;
+
+use crate::util;
 
 lazy_static! {
     pub static ref SLICK: Theme = Theme {
@@ -186,6 +189,22 @@ impl Theme {
             _ => None,
         }
     }
+
+    pub fn from_file(file: &str) -> Option<Theme> {
+        let full_path = Path::new(file);
+        let xdg_path = util::xdg_config_home().join("i3status-rs/themes").join(file);
+        let share_path = Path::new(util::USR_SHARE_PATH).join("themes").join(file);
+
+        if full_path.exists() {
+            util::deserialize_file(full_path.to_str().unwrap()).ok()
+        } else if xdg_path.exists() {
+            util::deserialize_file(xdg_path.to_str().unwrap()).ok()
+        } else if share_path.exists() {
+            util::deserialize_file(share_path.to_str().unwrap()).ok()
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -211,13 +230,20 @@ pub struct ThemeOverrides {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ThemeConfig {
-    name: String,
+    name: Option<String>,
+    file: Option<String>,
     overrides: Option<ThemeOverrides>,
 }
 
 impl ThemeConfig {
     pub fn into_theme(self) -> Option<Theme> {
-        let mut theme = Theme::from_name(&self.name)?;
+        let mut theme = if let Some(name) = self.name {
+            Theme::from_name(&name)
+        } else if let Some(file) = self.file {
+            Theme::from_file(&file)
+        } else {
+            None
+        }?;
         if let Some(overrides) = self.overrides {
             theme.idle_bg = overrides.idle_bg.unwrap_or(theme.idle_bg);
             theme.idle_fg = overrides.idle_fg.unwrap_or(theme.idle_fg);

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,6 +14,8 @@ use std::io::prelude::*;
 use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
 
+pub const USR_SHARE_PATH: &str = "/usr/share/i3status-rs";
+
 pub fn xdg_config_home() -> PathBuf {
     // In the unlikely event that $HOME is not set, it doesn't really matter
     // what we fall back on, so use /.config.

--- a/src/util.rs
+++ b/src/util.rs
@@ -291,27 +291,3 @@ impl FormatTemplate {
 macro_rules! if_debug {
     ($x:block) => (if cfg!(debug_assertions) $x)
 }
-
-macro_rules! mapped_struct {
-    ($( #[$attr:meta] )* pub struct $name:ident : $fieldtype:ty { $( pub $fname:ident ),* }) => {
-        $( #[$attr] )*
-        pub struct $name {
-            $( pub $fname : $fieldtype ),*
-        }
-
-        impl $name {
-            #[allow(dead_code)]
-            pub fn map(&self) -> ::std::collections::HashMap<&'static str, &$fieldtype> {
-                let mut m = ::std::collections::HashMap::new();
-                $( m.insert(stringify!($fname), &self.$fname); )*
-                m
-            }
-
-            pub fn owned_map(&self) -> ::std::collections::HashMap<String, $fieldtype> {
-                let mut m = ::std::collections::HashMap::new();
-                $( m.insert(stringify!($fname).to_owned(), self.$fname.to_owned()); )*
-                m
-            }
-        }
-    }
-}


### PR DESCRIPTION
This PR introduces a new `theme.file` key to the TOML configuration, which makes it possible to use complete themes not provided by `i3status-rs` itself. We look in the following locations for this file:

- The actual file location, if it is a real path.
- `$XDG_CONFIG_HOME/i3status-rs/themes`; and
- `/usr/share/i3status-rs/themes`

The theme file must be "complete", e.g. contain all of the keys, for it to be serialized correctly. 

In the process, I did a lot of cleanup for deserialization of the `[theme]` section itself to make it clearer and more transparent; it should be much easier to add functionality there in the future.

As an aside: this could make it possible for us to extract the built-in themes and install them in, e.g. `/usr/share/i3status-rs/themes`.