### PR TITLE
Maildir enhancements

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -289,6 +289,7 @@ interval = 60
 inboxes = ["/home/user/mail/local", "/home/user/mail/gmail/Inbox"]
 threshold_warning = 1
 threshold_critical = 10
+display_type = "new"
 ```
 
 ### Options
@@ -299,6 +300,7 @@ Key | Values | Required | Default
 `threshold_warning` | Number of unread mails where state is set to warning | No | `1`
 `threshold_critical` | Number of unread mails where state is set to critical | No | `10`
 `interval` | Update interval, in seconds. | No | `5`
+`display_type` | Which part of the maildir to count. One of "new", "cur", or "all" | No | `"new"`
 
 ## Memory
 

--- a/blocks.md
+++ b/blocks.md
@@ -301,6 +301,7 @@ Key | Values | Required | Default
 `threshold_critical` | Number of unread mails where state is set to critical | No | `10`
 `interval` | Update interval, in seconds. | No | `5`
 `display_type` | Which part of the maildir to count. One of "new", "cur", or "all" | No | `"new"`
+`icon` | Whether or not to prepend the output with the mail icon | No | `true`
 
 ## Memory
 

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -60,6 +60,8 @@ pub struct MaildirConfig {
     pub threshold_critical: usize,
     #[serde(default)]
     pub display_type: MailType,
+    #[serde(default = "MaildirConfig::default_icon")]
+    pub icon: bool,
 }
 
 impl MaildirConfig {
@@ -72,18 +74,20 @@ impl MaildirConfig {
     fn default_threshold_critical() -> usize {
         10 as usize
     }
+    fn default_icon() -> bool {
+        true
+    }
 }
 
 impl ConfigBlock for Maildir {
     type Config = MaildirConfig;
 
     fn new(block_config: Self::Config, config: Config, _tx_update_request: Sender<Task>) -> Result<Self> {
+        let widget = TextWidget::new(config.clone()).with_text("");
         Ok(Maildir {
             id: Uuid::new_v4().simple().to_string(),
             update_interval: block_config.interval,
-            text: TextWidget::new(config.clone())
-                .with_icon("mail")
-                .with_text(""),
+            text: if block_config.icon { widget.with_icon("mail") } else { widget },
             inboxes: block_config.inboxes,
             threshold_warning: block_config.threshold_warning,
             threshold_critical: block_config.threshold_critical,


### PR DESCRIPTION
This PR adds two enhancement to the maildir block: 

1. It lets you choose whether to count the `new`, `cur`, or both folders of the maildir(s)
2. It lets you opt out of the icon.

I'm shooting for a pair of blocks that look like this: " :email: 1 | 10 ", where the first number is the unread mails (using the `new` option), and the other is all the mails in that folder (using the `all` option). Helps me go for inbox zero. Note how there's no mail icon on the second block.

I chose defaults that preserve the existing behavior of the maildir block, so these features are totally opt-in.