### PR TITLE
Add CPU barchart (ref #379)

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -153,7 +153,7 @@ Update CPU usage every second:
 [[block]]
 block = "cpu"
 interval = 1
-frequency = true
+format = "{barchart} {utilization}% {frequency}GHz"
 ```
 
 ### Options
@@ -164,7 +164,7 @@ Key | Values | Required | Default
 `warning` | Minimum usage, where state is set to warning. | No | `60`
 `critical` | Minimum usage, where state is set to critical. | No | `90`
 `interval` | Update interval, in seconds. | No | `1`
-`frequency` | Shows avg cpu frequency in GHz | No | `false`
+`format` | A format string. Possible placeholders: `{barchart}` (barchart of each CPU's core utilization), `{utilization}` (average CPU utilization in percent) and `{frequency}` (CPU frequency). | No | `"{barchart} {utilization}% {frequency}GHz"`
 
 ## Custom
 

--- a/blocks.md
+++ b/blocks.md
@@ -164,7 +164,9 @@ Key | Values | Required | Default
 `warning` | Minimum usage, where state is set to warning. | No | `60`
 `critical` | Minimum usage, where state is set to critical. | No | `90`
 `interval` | Update interval, in seconds. | No | `1`
-`format` | A format string. Possible placeholders: `{barchart}` (barchart of each CPU's core utilization), `{utilization}` (average CPU utilization in percent) and `{frequency}` (CPU frequency). | No | `"{barchart} {utilization}% {frequency}GHz"`
+`format` | A format string. Possible placeholders: `{barchart}` (barchart of each CPU's core utilization), `{utilization}` (average CPU utilization in percent) and `{frequency}` (CPU frequency). | No | `"{utilization}%"`
+`frequency` | Deprecated in favour of `format`. Sets format to `{utilization}% {frequency}GHz` | No | `false`
+
 
 ## Custom
 


### PR DESCRIPTION
As discussed in #379, this pull request adds a `format` key to the cpu block, and removes the `frequency` key. The format key can have the placeholders barchart, utilization and frequency.

The default of the format key is currently `{barchart} {utilization}% {frequency}GHz`.

The barchart displays UTF8 block characters for up to 31 distinct CPU cores, each of which has 8 different states ('▁', '▂', '▃', '▄', '▅', '▆', '▇', '█').

Result:
![image](https://user-images.githubusercontent.com/516060/57809942-a44c9d80-7734-11e9-8016-330534e2ea61.png)
 