### PR TITLE
blocks/net: parse SSID containing whitespace correctly

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -101,7 +101,7 @@ impl NetworkDevice {
             .args(&[
                 "-c",
                 &format!(
-                    "iw dev {} link | awk '/^\\s+SSID:/ {{ print $2 }}'",
+                    "iw dev {} link | sed -n 's/^\\s\\+SSID: \\(.*\\)/\\1/p'",
                     self.device
                 ),
             ])


### PR DESCRIPTION
While being connected to an SSID containing whitespace, I noticed that the current method only shows the first word of the SSID. Here's a more universal solution (discussion welcome on a better command accomplishing the same goal)