### PR TITLE
blocks/net: join all IP addresses of an interface in one line

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -137,7 +137,7 @@ impl NetworkDevice {
                 &[
                     "-c",
                     &format!(
-                        "ip -oneline -family inet address show {} | sed -rn \"s/.*inet ([\\.0-9/]+).*/\\1/p\"",
+                        "ip -oneline -family inet address show {} | sed -rn -e \"s/.*inet ([\\.0-9/]+).*/\\1/; G; s/\\n/ /;h\" -e \"$ P;\"",
                         self.device
                     ),
                 ],


### PR DESCRIPTION
When IP aliasing is configured on the selected NIC, 'ip' will print
each address on separate line. If the lines are not joined, it results
in being unreadable in the status line.

Closes #386