### PR TITLE
Weather Block: Provide default value for missing wind fields, fixes #395

### DIFF
--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -48,6 +48,13 @@ pub struct Weather {
     update_interval: Duration,
 }
 
+fn malformed_json_error() -> Error {
+    BlockError(
+            "weather".to_string(),
+            "Malformed JSON.".to_string(),
+    )
+}
+
 impl Weather {
     fn update_weather(&mut self) -> Result<()> {
         match self.service {
@@ -97,67 +104,41 @@ impl Weather {
                         format!("API Error: {}", val.as_str().unwrap()),
                     ));
                 };
-                let raw_weather = match json.pointer("/weather/0/main")
+                let raw_weather = json.pointer("/weather/0/main")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()) {
-                    Some(v) => v,
-                    None => {
-                        return Err(BlockError(
-                            "weather".to_string(),
-                            "Malformed JSON.".to_string(),
-                        ));
-                    }
-                };
-                let raw_temp = match json.pointer("/main/temp").and_then(|v| v.as_f64()) {
-                    Some(v) => v,
-                    None => {
-                        return Err(BlockError(
-                            "weather".to_string(),
-                            "Malformed JSON.".to_string(),
-                        ));
-                    }
-                };
-                let raw_wind_speed = match json.pointer("/wind/speed").and_then(|v| v.as_f64()) {
-                    Some(v) => v,
-                    None => {
-                        return Err(BlockError(
-                            "weather".to_string(),
-                            "Malformed JSON.".to_string(),
-                        ));
-                    }
-                };
-                let raw_wind_direction = match json.pointer("/wind/deg").and_then(|v| v.as_f64()) {
-                    Some(v) => v,
-                    None => {
-                        return Err(BlockError(
-                            "weather".to_string(),
-                            "Malformed JSON.".to_string(),
-                        ));
-                    }
-                };
-                let raw_location = match json.pointer("/name").and_then(|v| v.as_str()).map(|s| {
-                    s.to_string()
-                }) {
-                    Some(v) => v,
-                    None => {
-                        return Err(BlockError(
-                            "weather".to_string(),
-                            "Malformed JSON.".to_string(),
-                        ));
-                    }
-                };
+                    .map(|s| s.to_string())
+                    .ok_or_else(malformed_json_error)?;
+
+                let raw_temp = json.pointer("/main/temp").and_then(|v| v.as_f64()).ok_or_else(malformed_json_error)?;
+
+                let raw_wind_speed: f64= json.pointer("/wind/speed")
+                    .map_or(Some(0.0), |v| v.as_f64()) // provide default value 0.0
+                    .ok_or_else(malformed_json_error)?; // error when conversion to f64 fails
+
+                let raw_wind_direction: Option<f64>= json.pointer("/wind/deg")
+                    .map_or(Some(None), |v| v.as_f64().and_then(|v| Some(Some(v)))) // provide default value None
+                    .ok_or_else(malformed_json_error)?; // error when conversion to f64 fails
+
+
+                let raw_location = json.pointer("/name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .ok_or_else(malformed_json_error)?;
 
                 // Convert wind direction in azimuth degrees to abbreviation names
-                fn convert_wind_direction(direction: f64) -> String {
-                    match direction.round() as i64 {
-                        24 ... 68 => "NE".to_string(),
-                        69 ... 113 => "E".to_string(),
-                        114 ... 158 => "SE".to_string(),
-                        159 ... 203 => "S".to_string(),
-                        204 ... 248 => "SW".to_string(),
-                        249 ... 293 => "W".to_string(),
-                        294 ... 338 => "NW".to_string(),
-                        _ => "N".to_string()
+                fn convert_wind_direction(direction_opt: Option<f64>) -> String {
+                    match direction_opt {
+                        Some(direction) => match direction.round() as i64 {
+                            24 ... 68 => "NE".to_string(),
+                            69 ... 113 => "E".to_string(),
+                            114 ... 158 => "SE".to_string(),
+                            159 ... 203 => "S".to_string(),
+                            204 ... 248 => "SW".to_string(),
+                            249 ... 293 => "W".to_string(),
+                            294 ... 338 => "NW".to_string(),
+                            _ => "N".to_string()
+                        },
+                        None => "-".to_string()
                     }
                 }
 


### PR DESCRIPTION
This pull requests introduces changes to the weather block.

It takes the fact into account that some fields might not be present in the response of the OpenWeatherMap API (see issue #395). Specifically, it provides default values for the fields:

* speed (by default 0.0)
* deg (converted to an Option, displayed as the wind direction if Some(f64) or "-" if None)

Additionally, the pull request suggests some code changes in order to to reduce the amount of code duplication by abstracting the `malformed json` error into its own function, and by using a combination of  built-in operators on `Option`s and `Result`s and the `?` (try) operator.