### PR TITLE
Add a docker block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -794,3 +794,33 @@ Key | Values | Required | Default
 `resolution` | Shows the screens resolution | No | `false`
 `step_width` | The steps brightness is in/decreased for the selected screen (When greater than 50 it gets limited to 50) | No | `5`
 `interval` | Update interval, in seconds. | No | `5`
+
+## Docker
+
+Creates a block which shows the local docker daemon status (containers running, paused, stopped, total and image count).
+
+### Examples
+
+```toml
+[[block]]
+block = "docker"
+interval = 2
+format = "{running}/{total}"
+```
+
+### Options
+
+Key | Values | Required | Default
+----|--------|----------|--------
+`interval` | Update interval, in seconds. | No | `5`
+`format` | A format string. See below for available placeholders. | No | `"{running}"`
+
+### Available Format Keys
+
+Key | Value
+----|-------
+`{total}` | Total containers on the host.
+`{running}` | Containers running on the host.
+`{stopped}` | Containers stopped on the host.
+`{paused}` | Containers paused on the host.
+`{images}` | Total images on the host.

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -1,0 +1,118 @@
+use crossbeam_channel::Sender;
+use std::process::Command;
+use std::time::Duration;
+
+use crate::block::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::input::I3BarEvent;
+use crate::scheduler::Task;
+use crate::util::FormatTemplate;
+use crate::widget::I3BarWidget;
+use crate::widgets::text::TextWidget;
+
+use uuid::Uuid;
+
+pub struct Docker {
+    text: TextWidget,
+    id: String,
+    format: FormatTemplate,
+    update_interval: Duration,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct Status {
+    #[serde(rename = "Containers")]
+    total: i64,
+
+    #[serde(rename = "ContainersRunning")]
+    running: i64,
+
+    #[serde(rename = "ContainersStopped")]
+    stopped: i64,
+
+    #[serde(rename = "ContainersPaused")]
+    paused: i64,
+
+    #[serde(rename = "Images")]
+    images: i64,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct DockerConfig {
+    /// Update interval in seconds
+    #[serde(default = "DockerConfig::default_interval", deserialize_with = "deserialize_duration")]
+    pub interval: Duration,
+
+    /// Format override
+    #[serde(default = "DockerConfig::default_format")]
+    pub format: String,
+}
+
+impl DockerConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+    fn default_format() -> String {
+        "{running}%".to_owned()
+    }
+}
+
+impl ConfigBlock for Docker {
+    type Config = DockerConfig;
+
+    fn new(block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
+        Ok(Docker {
+            id: Uuid::new_v4().simple().to_string(),
+            text: TextWidget::new(config.clone()).with_text("N/A").with_icon("docker"),
+            format: FormatTemplate::from_string(&block_config.format).block_error("docker", "Invalid format specified")?,
+            update_interval: block_config.interval,
+        })
+    }
+}
+
+impl Block for Docker {
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let output = match Command::new("sh").args(&["-c", "curl --fail --unix-socket /var/run/docker.sock http:/api/info"]).output() {
+            Ok(raw_output) => String::from_utf8(raw_output.stdout).block_error("docker", "Failed to decode")?,
+            Err(_) => {
+                // We don't want the bar to crash if we can't reach the docker daemon.
+                self.text.set_text("N/A".to_string());
+                return Ok(Some(self.update_interval));
+            }
+        };
+
+        if output.is_empty() {
+            self.text.set_text("N/A".to_string());
+            return Ok(Some(self.update_interval));
+        }
+
+        let status: Status = serde_json::from_str(&output).block_error("docker", "Failed to parse JSON response.")?;
+
+        let values = map!(
+            "{total}" => format!("{}", status.total),
+            "{running}" => format!("{}", status.running),
+            "{paused}" => format!("{}", status.paused),
+            "{stopped}" => format!("{}", status.stopped),
+            "{images}" => format!("{}", status.images)
+        );
+
+        self.text.set_text(self.format.render_static_str(&values)?);
+
+        Ok(Some(self.update_interval))
+    }
+
+    fn view(&self) -> Vec<&I3BarWidget> {
+        vec![&self.text]
+    }
+
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -24,6 +24,7 @@ mod networkmanager;
 mod bluetooth;
 pub mod ibus;
 mod keyboard_layout;
+mod docker;
 
 use crate::config::Config;
 use self::time::*;
@@ -52,6 +53,7 @@ use self::networkmanager::*;
 use self::bluetooth::*;
 use self::ibus::*;
 use self::keyboard_layout::*;
+use self::docker::*;
 
 use super::block::{Block, ConfigBlock};
 use crate::errors::*;
@@ -109,6 +111,7 @@ pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_r
             "networkmanager" => NetworkManager,
             "bluetooth" => Bluetooth,
             "ibus" => IBus,
-            "keyboard_layout" => KeyboardLayout
+            "keyboard_layout" => KeyboardLayout,
+            "docker" => Docker
     )
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -51,7 +51,8 @@ lazy_static! {
         "headphones" => " HEAD",
         "joystick" => " JOY",
         "keyboard" => " KBD",
-        "mouse" => " MOUSE"
+        "mouse" => " MOUSE",
+        "docker" => " DOCKER "
     };
 
     pub static ref AWESOME: Map<String, String> = map_to_owned! {
@@ -106,7 +107,8 @@ lazy_static! {
         "headphones" => " \u{f025}",
         "joystick" => " \u{f11b}",
         "keyboard" => " \u{f11c}",
-        "mouse" => " \u{f245}"
+        "mouse" => " \u{f245}",
+        "docker" => " \u{f21a} "
     };
 
     pub static ref MATERIAL: Map<String, String> = map_to_owned! {
@@ -143,7 +145,8 @@ lazy_static! {
         "headphones" => " \u{e60f}",
         "joystick" => " \u{e30f}",
         "keyboard" => " \u{e312}",
-        "mouse" => " \u{e323}"
+        "mouse" => " \u{e323}",
+        "docker" => " \u{e532} "
     };
 }
 


### PR DESCRIPTION
## What does this PR do ? 

This PR adds a `docker` block which displays current counts of containers on the local docker host.

It works by calling the [system information](https://docs.docker.com/engine/api/v1.40/#operation/SystemInfo) through the local docker socket using `curl`.

Unfortunately I did not find a way to easily make this call using an in process HTTP client because of the unix socket. If there is any better solution, feel free to suggest it ^^.

## How to test this PR ? 

Add the following snippet to your status bar, and restart your bar.

```
[[block]]
block = "docker"
format = "{running}"
```

And here's a screenshot of  the block running on my setup :tada:.

![2019-07-29-192100_1297x103_scrot](https://user-images.githubusercontent.com/453265/62068207-e1093a80-b235-11e9-9888-3731656b8c1f.png)
