### PR TITLE
Fixes #387: Display WiFi signal strength in the net block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -485,6 +485,7 @@ Creates a block which displays the upload and download throughput for a network 
 block = "net"
 device = "wlp2s0"
 ssid = true
+signal_strength = true
 ip = true
 speed_up = false
 graph_up = true
@@ -497,6 +498,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `device` | Network interface to moniter (name from /sys/class/net) | Yes | `lo` (loopback interface)
 `ssid` | Display network SSID (wireless only). | No | `false`
+`signal_strength` | Display WiFi signal strength (wireless only). | No | `false`
 `bitrate` | Display connection bitrate. | No | `false`
 `ip` | Display connection IP address. | No | `false`
 `speed_up` | Display upload speed. | No | `true`


### PR DESCRIPTION
Hi! I wanted to see the Wifi signal strength in the status bar, and saw there was an open issue with some hints to do it. Turns out that `iw` provides this information too, so we can parse its output to figure it out. It's a bit inefficient because we may call iw several times to grep for some of its information, but I think it's fine since it doesn't happen a lot.

I've reused the formulas hinted at in the issue, and I can confirm they coincide with the results provided by the original i3status bar on my machine.