### PR TITLE
Add basic support for wireguard devices

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -38,17 +38,11 @@ impl NetworkDevice {
         let wireless = device_path.join("wireless").exists();
         let tun = device_path.join("tun_flags").exists() || device.starts_with("tun") || device.starts_with("tap");
 
-        fn is_wg_device(wg_uevent_path: &PathBuf) -> bool {
-            if wg_uevent_path.exists() {
-                let uevent_data = read_to_string(&wg_uevent_path).expect("Unable to read file");
-                return uevent_data.contains("wireguard");
-            } else {
-                return false;
-            };
-        };
-
         let wg_uevent_path = device_path.join("uevent");
-        let wg = is_wg_device(&wg_uevent_path);
+        let wg = match read_to_string(&wg_uevent_path) {
+                Ok(s) => s.contains("wireguard"),
+                Err(_e) => false,
+        };
 
         NetworkDevice {
             device,


### PR DESCRIPTION
This is only basic support, because wireguard device can be named at will:
```
[root@tokk wireguard]# ip -4 a s
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: enp6s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    inet 192.168.2.3/24 brd 192.168.2.255 scope global noprefixroute enp6s0
       valid_lft forever preferred_lft forever
33: vpnwireguarg0: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1420 qdisc noqueue state UNKNOWN group default qlen 1000
    inet 10.0.0.3/24 scope global vpnwireguarg0
       valid_lft forever preferred_lft forever
[root@tokk wireguard]# grep wireguard /sys/class/net/vpnwireguarg0/uevent
DEVTYPE=wireguard
```
And the only way to (as far as I understand) distinguish wg device from any other - is to read file /sys/class/net/$DEVICE/uevent, and find there `wireguard` string.

I tried to do it this way:
```rust        
        let wg_uevent_path = device_path.join("uevent");
        // pseudocode
        if wg_uevent_path.exists() then { 
            let uevent_data = read_to_string(&wg_uevent_path);
            let wg = uevent_data.contains("wireguard");
       } else { 
            let wg = false;
       };
```
but I never had any experience with Rust, so nothing happened...