### PR TITLE
Add GitHub block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -361,7 +361,7 @@ Key | Values | Required | Default
 `interval` | Update interval, in seconds. | No | `30`
 `format` | A format string. See below for available placeholders. | No | `"{total}"`
 
-It requires a github token, which must be passed using the `GITHUB_TOKEN` environment variable.
+It requires a Github [personal access token](https://github.com/settings/tokens/new) with the "notifications" scope. It must be passed using the `GITHUB_TOKEN` environment variable.
 
 ### Available Format Keys
 

--- a/blocks.md
+++ b/blocks.md
@@ -360,13 +360,28 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `interval` | Update interval, in seconds. | No | `30`
 `format` | A format string. See below for available placeholders. | No | `"{total}"`
+`api_server`| API Server URL to use to fetch notifications. | No | `https://api.github.com`
 
-It requires a Github [personal access token](https://github.com/settings/tokens/new) with the "notifications" scope. It must be passed using the `GITHUB_TOKEN` environment variable.
+It requires a Github [personal access token](https://github.com/settings/tokens/new) with the "notifications" scope. It must be passed using the `I3RS_GITHUB_TOKEN` environment variable.
 
 ### Available Format Keys
 
-The block maintains a count of all notifications under the `total` format key.
-It also maintains count per "notification reason". All specified [reasons](https://developer.github.com/v3/activity/notifications/#notification-reasons) are available as format keys.
+ Key | Value
+-----|-------
+`{total}` | Total of all notifications
+`{assign}` | Total of notifications related to issues you're assigned on.
+`{author}` | Total of notifications related to threads you are the author of.
+`{comment}` | Total of notifications related to threads you commented on.
+`{invitation}` | Total of notifications related to invitations.
+`{manual}` | Total of notifications related to threads you manually subscribed on.
+`{mention}` | Total of notifications related to content you were specifically mentioned on.
+`{review_requested}` | Total of notifications related to PR you were requested to review.
+`{security_alert}` | Total of notifications related to security vulnerabilities found on your repositories.
+`{state_change}` | Total of notifications related to thread state change.
+`{subscribed}` | Total of notifications related to repositories you're watching.
+`{team_mention}` | Total of notification related to thread where your team was mentioned.
+
+For more information about reasons, please see the [API documentation](https://developer.github.com/v3/activity/notifications/#notification-reasons).
 
 ## IBus
 

--- a/blocks.md
+++ b/blocks.md
@@ -9,6 +9,7 @@
 - [Disk Space](#disk-space)
 - [Docker](#docker)
 - [Focused Window](#focused-window)
+- [Github](#github)
 - [IBus](#ibus)
 - [Keyboard Layout](#keyboard-layout)
 - [Load](#load)
@@ -340,6 +341,32 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `max_width` | Truncates titles to this length. | No | `21`
 `show_marks` | Display marks instead of the title, if there are some. Options are `"none"`, `"all"` or `"visible"`, the latter of which ignores marks that start with an underscore. | No | `"none"`
+
+## Github
+
+Creates a block which shows the unread notification count for a github account.
+
+### Examples
+
+```toml
+[[block]]
+block = "github"
+format = "{total}|{author}|{comment}|{mention}|{review_requested}"
+```
+
+### Options
+
+Key | Values | Required | Default
+----|--------|----------|--------
+`interval` | Update interval, in seconds. | No | `30`
+`format` | A format string. See below for available placeholders. | No | `"{total}"`
+
+It requires a github token, which must be passed using the `GITHUB_TOKEN` environment variable.
+
+### Available Format Keys
+
+The block maintains a count of all notifications under the `total` format key.
+It also maintains count per "notification reason". All specified [reasons](https://developer.github.com/v3/activity/notifications/#notification-reasons) are available as format keys.
 
 ## IBus
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -7,6 +7,7 @@ pub mod custom_dbus;
 pub mod disk_space;
 pub mod docker;
 pub mod focused_window;
+pub mod github;
 pub mod ibus;
 pub mod keyboard_layout;
 pub mod load;
@@ -41,6 +42,7 @@ use self::custom_dbus::*;
 use self::disk_space::*;
 use self::docker::*;
 use self::focused_window::*;
+use self::github::*;
 use self::ibus::*;
 use self::keyboard_layout::*;
 use self::load::*;
@@ -154,6 +156,7 @@ pub fn create_block(
         "disk_space" => block!(DiskSpace, block_config, config, update_request),
         "docker" => block!(Docker, block_config, config, update_request),
         "focused_window" => block!(FocusedWindow, block_config, config, update_request),
+        "github" => block!(Github, block_config, config, update_request),
         "ibus" => block!(IBus, block_config, config, update_request),
         "keyboard_layout" => block!(KeyboardLayout, block_config, config, update_request),
         "load" => block!(Load, block_config, config, update_request),

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -1,7 +1,4 @@
-extern crate lazy_static;
-
-use crate::blocks::Update;
-use crate::blocks::{Block, ConfigBlock};
+use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
@@ -19,7 +16,7 @@ use std::process::Command;
 use std::time::Duration;
 use uuid::Uuid;
 
-const GITHUB_TOKEN_ENV: &str = "GITHUB_TOKEN";
+const GITHUB_TOKEN_ENV: &str = "I3RS_GITHUB_TOKEN";
 
 pub struct Github {
     text: TextWidget,
@@ -71,7 +68,7 @@ impl ConfigBlock for Github {
             None => {
                 return Err(BlockError(
                     "github".to_owned(),
-                    "missing GITHUB_TOKEN environment variable".to_owned(),
+                    "missing I3RS_GITHUB_TOKEN environment variable".to_owned(),
                 ))
             }
         };
@@ -192,7 +189,7 @@ impl<'a> Notifications<'a> {
             .args(&[
                 "-c",
                 &format!(
-                    "curl -s -D - -H \"Authorization: Bearer {token}\" -m 3 \"{next_page_url}\"",
+                    "curl --silent --dump-header - --header \"Authorization: Bearer {token}\" -m 3 \"{next_page_url}\"",
                     token = self.token,
                     next_page_url = self.next_page_url,
                 ),

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -1,0 +1,279 @@
+extern crate lazy_static;
+
+use crate::blocks::Update;
+use crate::blocks::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::input::I3BarEvent;
+use crate::scheduler::Task;
+use crate::util::FormatTemplate;
+use crate::widget::I3BarWidget;
+use crate::widgets::text::TextWidget;
+use crossbeam_channel::Sender;
+use lazy_static::lazy_static;
+use regex::Regex;
+use serde_derive::Deserialize;
+use std::collections::HashMap;
+use std::process::Command;
+use std::time::Duration;
+use uuid::Uuid;
+
+const GITHUB_TOKEN_ENV: &str = "GITHUB_TOKEN";
+
+pub struct Github {
+    text: TextWidget,
+    id: String,
+    update_interval: Duration,
+    api_server: String,
+    token: String,
+    format: FormatTemplate,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct GithubConfig {
+    /// Update interval in seconds
+    #[serde(
+        default = "GithubConfig::default_interval",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub interval: Duration,
+
+    #[serde(default = "GithubConfig::default_api_server")]
+    pub api_server: String,
+
+    /// Format override
+    #[serde(default = "GithubConfig::default_format")]
+    pub format: String,
+}
+
+impl GithubConfig {
+    fn default_interval() -> Duration {
+        Duration::from_secs(30)
+    }
+
+    fn default_api_server() -> String {
+        "https://api.github.com".to_owned()
+    }
+
+    fn default_format() -> String {
+        "{total}".to_owned()
+    }
+}
+
+impl ConfigBlock for Github {
+    type Config = GithubConfig;
+
+    fn new(block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
+        let token = match std::env::var(GITHUB_TOKEN_ENV).ok() {
+            Some(v) => v,
+            None => {
+                return Err(BlockError(
+                    "github".to_owned(),
+                    "missing GITHUB_TOKEN environment variable".to_owned(),
+                ))
+            }
+        };
+
+        Ok(Github {
+            id: Uuid::new_v4().to_simple().to_string(),
+            update_interval: block_config.interval,
+            text: TextWidget::new(config.clone())
+                .with_text("N/A")
+                .with_icon("github"),
+            api_server: block_config.api_server,
+            token: token,
+            format: FormatTemplate::from_string(&block_config.format)
+                .block_error("github", "Invalid format specified")?,
+        })
+    }
+}
+
+impl Block for Github {
+    fn update(&mut self) -> Result<Option<Update>> {
+        let aggregations = match Notifications::new(&self.api_server, &self.token).try_fold(
+            map!("total".to_owned() => 0),
+            |mut acc,
+             notif|
+             -> std::result::Result<HashMap<String, u64>, Box<dyn std::error::Error>> {
+                let n = notif?;
+                acc.entry(n.reason).and_modify(|v| *v += 1).or_insert(1);
+                acc.entry("total".to_owned()).and_modify(|v| *v += 1);
+                Ok(acc)
+            },
+        ) {
+            Ok(v) => v,
+            Err(_) => {
+                // If there is a error reported, set the value to N/A
+                self.text.set_text("N/A".to_owned());
+                return Ok(Some(self.update_interval.into()));
+            }
+        };
+
+        let default: u64 = 0;
+        let values = map!(
+            "{total}" => format!("{}", aggregations.get("total").unwrap_or(&default)),
+            // As specified by:
+            // https://developer.github.com/v3/activity/notifications/#notification-reasons
+            "{assign}" => format!("{}", aggregations.get("assign").unwrap_or(&default)),
+            "{author}" => format!("{}", aggregations.get("author").unwrap_or(&default)),
+            "{comment}" => format!("{}", aggregations.get("comment").unwrap_or(&default)),
+            "{invitation}" => format!("{}", aggregations.get("invitation").unwrap_or(&default)),
+            "{manual}" => format!("{}", aggregations.get("manual").unwrap_or(&default)),
+            "{mention}" => format!("{}", aggregations.get("mention").unwrap_or(&default)),
+            "{review_requested}" => format!("{}", aggregations.get("review_requested").unwrap_or(&default)),
+            "{security_alert}" => format!("{}", aggregations.get("security_alert").unwrap_or(&default)),
+            "{state_change}" => format!("{}", aggregations.get("state_change").unwrap_or(&default)),
+            "{subscribed}" => format!("{}", aggregations.get("subscribed").unwrap_or(&default)),
+            "{team_mention}" => format!("{}", aggregations.get("team_mention").unwrap_or(&default))
+        );
+
+        self.text.set_text(self.format.render_static_str(&values)?);
+
+        Ok(Some(self.update_interval.into()))
+    }
+
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
+        vec![&self.text]
+    }
+
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+#[derive(Deserialize)]
+struct Notification {
+    reason: String,
+}
+
+struct Notifications<'a> {
+    notifications: <Vec<Notification> as IntoIterator>::IntoIter,
+    token: &'a str,
+    next_page_url: String,
+}
+
+impl<'a> Iterator for Notifications<'a> {
+    type Item = std::result::Result<Notification, Box<dyn std::error::Error>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.try_next() {
+            Ok(Some(notif)) => Some(Ok(notif)),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        }
+    }
+}
+
+impl<'a> Notifications<'a> {
+    fn new(api_server: &'a str, token: &'a str) -> Notifications<'a> {
+        Notifications {
+            next_page_url: format!("{}/notifications", api_server),
+            token: token,
+            notifications: vec![].into_iter(),
+        }
+    }
+
+    fn try_next(
+        &mut self,
+    ) -> std::result::Result<Option<Notification>, Box<dyn std::error::Error>> {
+        if let Some(notif) = self.notifications.next() {
+            return Ok(Some(notif));
+        }
+
+        if self.next_page_url == "" {
+            return Ok(None);
+        }
+
+        let result = Command::new("sh")
+            .args(&[
+                "-c",
+                &format!(
+                    "curl -s -D - -H \"Authorization: Bearer {token}\" -m 3 \"{next_page_url}\"",
+                    token = self.token,
+                    next_page_url = self.next_page_url,
+                ),
+            ])
+            .output()?;
+
+        // Catch all errors, if response status is not 200, then curl wont exit with status code 0.
+        if !result.status.success() {
+            return Err(Box::new(BlockError(
+                "github".to_owned(),
+                "curl status code different than 0".to_owned(),
+            )));
+        }
+
+        let output = String::from_utf8(result.stdout)?;
+
+        // Status / headers sections are separed by a blank line.
+        let split: Vec<&str> = output.split("\r\n\r\n").collect();
+        if split.len() != 2 {
+            return Err(Box::new(BlockError(
+                "github".to_owned(),
+                "unexpected curl output".to_owned(),
+            )));
+        }
+
+        let (meta, body) = (split[0], split[1]);
+
+        let next = match meta.lines().find(|&l| l.starts_with("Link:")) {
+            Some(v) => match parse_links_header(v).get("next") {
+                Some(next) => next,
+                None => "",
+            },
+            None => "",
+        };
+        self.next_page_url = next.to_owned();
+
+        let notifications: Vec<Notification> = serde_json::from_str(body)?;
+        self.notifications = notifications.into_iter();
+
+        Ok(self.notifications.next())
+    }
+}
+
+fn parse_links_header(raw_links: &str) -> HashMap<&str, &str> {
+    lazy_static! {
+        static ref LINKS_REGEX: Regex =
+            Regex::new(r#"(<(?P<url>http(s)?://[^>\s]+)>; rel="(?P<rel>[[:word:]]+))+"#).unwrap();
+    }
+
+    LINKS_REGEX
+        .captures_iter(raw_links)
+        .fold(HashMap::new(), |mut acc, cap| {
+            let groups = (cap.name("url"), cap.name("rel"));
+            match groups {
+                (Some(url), Some(rel)) => {
+                    acc.insert(rel.as_str(), url.as_str());
+                    acc
+                }
+                _ => acc,
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_parses_links_header() {
+        assert_eq!(
+            parse_links_header(
+                r#"Link: <https://api.github.com/notifications?page=1>; rel="prev", <https://api.github.com/notifications?page=3>; rel="next", <https://api.github.com/notifications?page=4>; rel="last", <https://api.github.com/notifications?page=1>; rel="first""#,
+            ),
+            map!(
+                "first" => "https://api.github.com/notifications?page=1",
+                "prev" => "https://api.github.com/notifications?page=1",
+                "next" => "https://api.github.com/notifications?page=3",
+                "last" => "https://api.github.com/notifications?page=4"
+            )
+        );
+    }
+}

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -79,11 +79,9 @@ impl ConfigBlock for Github {
         Ok(Github {
             id: Uuid::new_v4().to_simple().to_string(),
             update_interval: block_config.interval,
-            text: TextWidget::new(config.clone())
-                .with_text("N/A")
-                .with_icon("github"),
+            text: TextWidget::new(config).with_text("N/A").with_icon("github"),
             api_server: block_config.api_server,
-            token: token,
+            token,
             format: FormatTemplate::from_string(&block_config.format)
                 .block_error("github", "Invalid format specified")?,
         })
@@ -174,7 +172,7 @@ impl<'a> Notifications<'a> {
     fn new(api_server: &'a str, token: &'a str) -> Notifications<'a> {
         Notifications {
             next_page_url: format!("{}/notifications", api_server),
-            token: token,
+            token,
             notifications: vec![].into_iter(),
         }
     }

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -79,7 +79,7 @@ impl ConfigBlock for Github {
         Ok(Github {
             id: Uuid::new_v4().to_simple().to_string(),
             update_interval: block_config.interval,
-            text: TextWidget::new(config).with_text("N/A").with_icon("github"),
+            text: TextWidget::new(config).with_text("x").with_icon("github"),
             api_server: block_config.api_server,
             token,
             format: FormatTemplate::from_string(&block_config.format)
@@ -103,8 +103,8 @@ impl Block for Github {
         ) {
             Ok(v) => v,
             Err(_) => {
-                // If there is a error reported, set the value to N/A
-                self.text.set_text("N/A".to_owned());
+                // If there is a error reported, set the value to x
+                self.text.set_text("x".to_owned());
                 return Ok(Some(self.update_interval.into()));
             }
         };

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -57,7 +57,8 @@ lazy_static! {
         "keyboard" => " KBD",
         "mouse" => " MOUSE",
         "docker" => " DOCKER ",
-        "pomodoro" => " POMODORO "
+        "pomodoro" => " POMODORO ",
+        "github" => " GITHUB "
     };
 
     // FontAwesome 4
@@ -120,6 +121,7 @@ lazy_static! {
         "mouse" => " \u{f245}",
         "docker" => " \u{f21a} ",
         "pomodoro" => " \u{1f345} ",
+        "github" => " \u{f09b} ",
         "unknown" => " \u{f128} "
     };
 
@@ -182,6 +184,7 @@ lazy_static! {
         "mouse" => " \u{f245}",
         "docker" => " \u{f21a} ",
         "pomodoro" => " \u{1f345} ",
+        "github" => " \u{f09b} ",
         "unknown" => " \u{f128} "
     };
 
@@ -223,7 +226,8 @@ lazy_static! {
         "keyboard" => " \u{e312}",
         "mouse" => " \u{e323}",
         "docker" => " \u{e532} ",
-        "pomodoro" => " \u{1f345} "
+        "pomodoro" => " \u{1f345} ",
+        "github" => " \u{e86f} "
     };
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -286,7 +286,7 @@ impl FormatTemplate {
         let s_as_bytes = s.as_bytes();
 
         //valid var tokens: {} containing any amount of alphanumericals
-        let re = Regex::new(r"\{[a-zA-Z0-9]+?\}").internal_error("util", "invalid regex")?;
+        let re = Regex::new(r"\{[a-zA-Z0-9_-]+?\}").internal_error("util", "invalid regex")?;
 
         let mut token_vec: Vec<FormatTemplate> = vec![];
         let mut start: usize = 0;


### PR DESCRIPTION
## What does this PR do ? 

This PR adds a `github` block which displays current count of unread notifications for an user. 
It enables to display a total count of unread notifications and also a count per "notification reasons" [see here](https://developer.github.com/v3/activity/notifications/#notification-reasons).

To support this, I had to make a change on the token regexp of the `FormatTemplate`, to make it also support tokens with a `_` or a `-` character in it (see bf71cd0).

It relies on the [Notifications API](https://developer.github.com/v3/activity/notifications/) of the Github API v3 and iterates through all the notifications pages.

## How to test this PR ? 

Add the following snippet to your status bar, and restart your bar.

```
[[block]]
block = "github"
format = "{total}|{author}|{comment}|{mention}|{review_requested}"
```

And here's a screenshot of  the block running on my setup.

![2019-08-18-135311_338x97_scrot](https://user-images.githubusercontent.com/453265/63224073-6346a800-c1bf-11e9-817c-095c72faf164.png)
