### PR TITLE
Fixes #427: Update bare trait objects and use inclusive range syntax.

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -12,7 +12,7 @@ pub trait Block {
         Ok(None)
     }
     /// Returns the view of the block, comprised of widgets
-    fn view(&self) -> Vec<&I3BarWidget>;
+    fn view(&self) -> Vec<&dyn I3BarWidget>;
 
     #[allow(unused_variables)]
     /// This function is called on every block for every click.

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -109,7 +109,7 @@ impl BacklitDevice {
         let raw = read_brightness(&self.brightness_file())?;
         let brightness = ((raw as f64 / self.max_brightness as f64) * 100.0).round() as u64;
         match brightness {
-            0...100 => Ok(brightness),
+            0..=100 => Ok(brightness),
             _ => Ok(100),
         }
     }
@@ -127,7 +127,7 @@ impl BacklitDevice {
             return Ok(());
         }
         let safe_value = match value {
-            0...100 => value,
+            0..=100 => value,
             _ => 100,
         };
         let raw = (((safe_value as f64) / 100.0) * (self.max_brightness as f64)).round() as u64;
@@ -228,16 +228,16 @@ impl Block for Backlight {
         let brightness = self.device.brightness()?;
         self.output.set_text(format!("{}%", brightness));
         match brightness {
-            0...19 => self.output.set_icon("backlight_empty"),
-            20...39 => self.output.set_icon("backlight_partial1"),
-            40...59 => self.output.set_icon("backlight_partial2"),
-            60...79 => self.output.set_icon("backlight_partial3"),
+            0..=19 => self.output.set_icon("backlight_empty"),
+            20..=39 => self.output.set_icon("backlight_partial1"),
+            40..=59 => self.output.set_icon("backlight_partial2"),
+            60..=79 => self.output.set_icon("backlight_partial3"),
             _ => self.output.set_icon("backlight_full"),
         }
         Ok(None)
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.output]
     }
 

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -123,7 +123,7 @@ impl BatteryDevice for PowerSupplyDevice {
         };
 
         match capacity {
-            0...100 => Ok(capacity),
+            0..=100 => Ok(capacity),
             // We need to cap it at 100, because the kernel may report
             // charge_now same as charge_full_design when the battery is full,
             // leading to >100% charge.
@@ -365,7 +365,7 @@ pub struct Battery {
     output: TextWidget,
     id: String,
     update_interval: Duration,
-    device: Box<BatteryDevice>,
+    device: Box<dyn BatteryDevice>,
     format: FormatTemplate,
     driver: BatteryDriver,
 }
@@ -459,7 +459,7 @@ impl ConfigBlock for Battery {
         };
 
         let id = Uuid::new_v4().simple().to_string();
-        let device: Box<BatteryDevice> = match driver {
+        let device: Box<dyn BatteryDevice> = match driver {
             BatteryDriver::Upower => {
                 let out = UpowerDevice::from_device(&block_config.device)?;
                 out.monitor(id.clone(), update_request);
@@ -514,10 +514,10 @@ impl Block for Battery {
                 "Charging" => { self.output.set_state(State::Good); },
                 _ =>
                     { self.output.set_state(match capacity {
-                    Ok(0...15) => State::Critical,
-                    Ok(16...30) => State::Warning,
-                    Ok(31...60) => State::Info,
-                    Ok(61...100) => State::Good,
+                    Ok(0..=15) => State::Critical,
+                    Ok(16..=30) => State::Warning,
+                    Ok(31..=60) => State::Info,
+                    Ok(61..=100) => State::Good,
                     _ => State::Warning,
                     });
                 }
@@ -536,7 +536,7 @@ impl Block for Battery {
         }
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.output]
     }
 

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -196,10 +196,10 @@ impl Block for Bluetooth {
         // Use battery info, when available.
         if let Some(value) = self.device.battery() {
             self.output.set_state(match value {
-                0...15 => State::Critical,
-                16...30 => State::Warning,
-                31...60 => State::Info,
-                61...100 => State::Good,
+                0..=15 => State::Critical,
+                16..=30 => State::Warning,
+                31..=60 => State::Info,
+                61..=100 => State::Good,
                 _ => State::Warning,
             });
             self.output.set_text(format!(" {}%", value));
@@ -220,7 +220,7 @@ impl Block for Bluetooth {
         Ok(())
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.output]
     }
 }

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -206,7 +206,7 @@ impl Block for Cpu {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.output]
     }
 

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -100,7 +100,7 @@ impl Block for Custom {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.output]
     }
 

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -252,7 +252,7 @@ impl Block for DiskSpace {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.disk_space]
     }
 

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -104,7 +104,7 @@ impl Block for Docker {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -129,7 +129,7 @@ impl Block for FocusedWindow {
         Ok(None)
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         let title = &*self.title.lock().unwrap();
         if String::is_empty(title) {
             vec![]

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -43,7 +43,7 @@ impl ConfigBlock for IBus {
             &format!("Failed to establish D-Bus connection to {}", ibus_address),
         )?;
         let p = c.with_path("org.freedesktop.IBus", "/org/freedesktop/IBus", 5000);
-        let info: arg::Variant<Box<arg::RefArg>> = p
+        let info: arg::Variant<Box<dyn arg::RefArg>> = p
             .get("org.freedesktop.IBus", "GlobalEngine")
             .block_error("ibus", "Failed to query IBus")?;
 
@@ -109,7 +109,7 @@ impl Block for IBus {
     }
 
     // Returns the view of the block, comprised of widgets.
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -167,7 +167,7 @@ impl KeyboardLayoutConfig {
 pub struct KeyboardLayout {
     id: String,
     output: TextWidget,
-    monitor: Box<KeyboardLayoutMonitor>,
+    monitor: Box<dyn KeyboardLayoutMonitor>,
     update_interval: Option<Duration>,
 }
 
@@ -176,7 +176,7 @@ impl ConfigBlock for KeyboardLayout {
 
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
         let id: String = Uuid::new_v4().simple().to_string();
-        let monitor: Box<KeyboardLayoutMonitor> = match block_config.driver {
+        let monitor: Box<dyn KeyboardLayoutMonitor> = match block_config.driver {
             KeyboardLayoutDriver::SetXkbMap => Box::new(SetXkbMap::new()?),
             KeyboardLayoutDriver::LocaleBus => {
                 let monitor = LocaleBus::new()?;
@@ -207,7 +207,7 @@ impl Block for KeyboardLayout {
         Ok(self.update_interval)
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.output]
     }
 }

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -114,7 +114,7 @@ impl Block for Load {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -115,7 +115,7 @@ impl Block for Maildir {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -664,7 +664,7 @@ impl Block for Memory {
         Ok(())
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![
             match self.memtype {
                 Memtype::Memory => &self.output.0,

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -69,7 +69,7 @@ macro_rules! block {
     ($block_type:ident, $block_config:expr, $config:expr, $tx_update_request:expr) => {{
         let block_config: <$block_type as ConfigBlock>::Config = <$block_type as ConfigBlock>::Config::deserialize($block_config)
             .configuration_error("failed to deserialize block config")?;
-        Ok(Box::new($block_type::new(block_config, $config, $tx_update_request)?) as Box<Block>)
+        Ok(Box::new($block_type::new(block_config, $config, $tx_update_request)?) as Box<dyn Block>)
     }}
 }
 
@@ -84,7 +84,7 @@ macro_rules! blocks {
     }
 }
 
-pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_request: Sender<Task>) -> Result<Box<Block>> {
+pub fn create_block(name: &str, block_config: Value, config: Config, tx_update_request: Sender<Task>) -> Result<Box<dyn Block>> {
     blocks!(name, block_config, config, tx_update_request;
             "time" => Time,
             "template" => Template,

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -228,7 +228,7 @@ impl Block for Music {
                 match data {
                     Err(_) => play.set_icon("music_play"),
                     Ok(data) => {
-                        let data: Box<RefArg> = data;
+                        let data: Box<dyn RefArg> = data;
                         let state = data;
                         if state.as_str().map(|s| s != "Playing").unwrap_or(false) {
                             play.set_icon("music_play")
@@ -280,9 +280,9 @@ impl Block for Music {
         }
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         if self.player_avail {
-            let mut elements: Vec<&I3BarWidget> = Vec::new();
+            let mut elements: Vec<&dyn I3BarWidget> = Vec::new();
             elements.push(&self.current_song);
             if let Some(ref prev) = self.prev {
                 elements.push(prev);
@@ -304,7 +304,7 @@ impl Block for Music {
     }
 }
 
-fn extract_from_metadata(metadata: &Box<arg::RefArg>) -> Result<(String, String)> {
+fn extract_from_metadata(metadata: &Box<dyn arg::RefArg>) -> Result<(String, String)> {
     let mut title = String::new();
     let mut artist = String::new();
 

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -288,10 +288,10 @@ impl Block for Music {
                 elements.push(prev);
             }
             if let Some(ref play) = self.play {
-                elements.push(play);;
+                elements.push(play);
             }
             if let Some(ref next) = self.next {
-                elements.push(next);;
+                elements.push(next);
             }
             elements
         } else {

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -583,9 +583,9 @@ impl Block for Net {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         if self.active {
-            let mut widgets: Vec<&I3BarWidget> = Vec::with_capacity(8);
+            let mut widgets: Vec<&dyn I3BarWidget> = Vec::with_capacity(8);
             widgets.push(&self.network);
             if let Some(ref ssid_widget) = self.ssid {
                 widgets.push(ssid_widget);

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -218,7 +218,7 @@ impl Block for NetworkManager {
         Ok(None)
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.output]
     }
 }

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -218,10 +218,10 @@ impl Block for NvidiaGpu {
         if let Some(ref mut temperature_widget) = self.show_temperature {
             let temp = result[count].parse::<u64>().unwrap();
             temperature_widget.set_state(match temp {
-                0...50 => State::Good,
-                51...70 => State::Idle,
-                71...75 => State::Info,
-                76...80 => State::Warning,
+                0..=50 => State::Good,
+                51..=70 => State::Idle,
+                71..=75 => State::Info,
+                76..=80 => State::Warning,
                 _ => State::Critical,
             });
             temperature_widget.set_text(format!("{:02}°C", temp));
@@ -245,8 +245,8 @@ impl Block for NvidiaGpu {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
-        let mut widgets: Vec<&I3BarWidget> = Vec::new();
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
+        let mut widgets: Vec<&dyn I3BarWidget> = Vec::new();
         widgets.push(&self.gpu_widget);
         if let Some(ref utilization_widget) = self.show_utilization {
             widgets.push(utilization_widget);

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -148,7 +148,7 @@ impl Block for Pacman {
 
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.output]
     }
 

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -524,7 +524,7 @@ impl SoundDevice for PulseAudioSoundDevice {
 pub struct Sound {
     text: ButtonWidget,
     id: String,
-    device: Box<SoundDevice>,
+    device: Box<dyn SoundDevice>,
     step_width: u32,
     config: Config,
     on_click: Option<String>,
@@ -613,8 +613,8 @@ impl Sound {
             self.text.set_state(State::Warning);
         } else {
             self.text.set_icon(match volume {
-                0...20 => "volume_empty",
-                21...70 => "volume_half",
+                0..=20 => "volume_empty",
+                21..=70 => "volume_half",
                 _ => "volume_full",
             });
             self.text.set_text(format!("{:02}%", volume));
@@ -653,7 +653,7 @@ impl ConfigBlock for Sound {
         };
 
         // prefere PulseAudio if available and selected, fallback to ALSA
-        let device: Box<SoundDevice> = match pulseaudio_device {
+        let device: Box<dyn SoundDevice> = match pulseaudio_device {
             Ok(dev) => Box::new(dev),
             Err(_) => Box::new(AlsaSoundDevice::new(block_config.name.unwrap_or_else(|| "Master".into()))?)
         };
@@ -683,7 +683,7 @@ impl Block for Sound {
         Ok(None) // The monitor thread will call for updates when needed.
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -169,8 +169,8 @@ impl Block for SpeedTest {
         Ok(())
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
-        let mut new: Vec<&I3BarWidget> = Vec::with_capacity(self.text.len());
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
+        let mut new: Vec<&dyn I3BarWidget> = Vec::with_capacity(self.text.len());
         for w in &self.text {
             new.push(w);
         }

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -195,7 +195,7 @@ impl Block for Temperature {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -57,7 +57,7 @@ impl Block for Template {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -100,7 +100,7 @@ impl Block for Time {
         Ok(())
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.time]
     }
 

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -105,7 +105,7 @@ impl Block for Toggle {
         Ok(self.update_interval)
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -111,7 +111,7 @@ impl Block for Uptime {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -144,13 +144,13 @@ impl Weather {
                 fn convert_wind_direction(direction_opt: Option<f64>) -> String {
                     match direction_opt {
                         Some(direction) => match direction.round() as i64 {
-                            24 ... 68 => "NE".to_string(),
-                            69 ... 113 => "E".to_string(),
-                            114 ... 158 => "SE".to_string(),
-                            159 ... 203 => "S".to_string(),
-                            204 ... 248 => "SW".to_string(),
-                            249 ... 293 => "W".to_string(),
-                            294 ... 338 => "NW".to_string(),
+                            24 ..= 68 => "NE".to_string(),
+                            69 ..= 113 => "E".to_string(),
+                            114 ..= 158 => "SE".to_string(),
+                            159 ..= 203 => "S".to_string(),
+                            204 ..= 248 => "SW".to_string(),
+                            249 ..= 293 => "W".to_string(),
+                            294 ..= 338 => "NW".to_string(),
                             _ => "N".to_string()
                         },
                         None => "-".to_string()
@@ -250,7 +250,7 @@ impl Block for Weather {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.weather]
     }
 

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -248,7 +248,7 @@ impl Block for Xrandr {
         Ok(Some(self.update_interval))
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -113,7 +113,7 @@ impl StdError for Error {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             _ => None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn main() {
                     .takes_value(true)
                     .default_value("10000")
                     .help("How many times to execute update when profiling."),
-            );;
+            );
     });
 
     let matches = builder.get_matches();

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
             .configuration_error("can't parse alternative_tint color code")?;
     }
 
-    let mut blocks: Vec<Box<Block>> = Vec::new();
+    let mut blocks: Vec<Box<dyn Block>> = Vec::new();
 
     let mut alternator = false;
     // Initialize the blocks
@@ -197,7 +197,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
 
     let mut scheduler = UpdateScheduler::new(&blocks);
 
-    let mut block_map: HashMap<String, &mut Block> = HashMap::new();
+    let mut block_map: HashMap<String, &mut dyn Block> = HashMap::new();
 
     for block in &mut blocks {
         block_map.insert(String::from(block.id()), (*block).deref_mut());

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -43,7 +43,7 @@ pub struct UpdateScheduler {
 }
 
 impl UpdateScheduler {
-    pub fn new(blocks: &[Box<Block>]) -> UpdateScheduler {
+    pub fn new(blocks: &[Box<dyn Block>]) -> UpdateScheduler {
         let mut schedule = BinaryHeap::new();
 
         let now = Instant::now();
@@ -72,7 +72,7 @@ impl UpdateScheduler {
         }
     }
 
-    pub fn do_scheduled_updates(&mut self, block_map: &mut HashMap<String, &mut Block>) -> Result<()> {
+    pub fn do_scheduled_updates(&mut self, block_map: &mut HashMap<String, &mut dyn Block>) -> Result<()> {
         let t = self.schedule
             .pop()
             .internal_error("scheduler", "schedule is empty")?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -106,7 +106,7 @@ impl PrintState {
     }
 }
 
-pub fn print_blocks(order: &[String], block_map: &HashMap<String, &mut Block>, config: &Config) -> Result<()> {
+pub fn print_blocks(order: &[String], block_map: &HashMap<String, &mut dyn Block>, config: &Config) -> Result<()> {
     let mut state = PrintState {
         has_predecessor: false,
         last_bg: None,


### PR DESCRIPTION
I cheated and just ran `cargo fix`; turns out the only changes were `dyn` and the range syntax.