### PR TITLE
Reduce dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
  "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -551,14 +551,10 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.0.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -571,11 +567,8 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.0"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -828,9 +821,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-"checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
+"checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-"checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
+"checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum serde 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "de4dee3b122edad92d80c66cac8d967ec7f8bf16a3b452247d6eb1dbf83c8f22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,5 @@
 [package]
 name = "i3status-rs"
-description = "A feature-rich and resource-friendly replacement for i3status, written in Rust."
-repository = "https://github.com/greshake/i3status-rust/"
-readme = "README.md"
-license = "GPLv3"
 version = "0.10.0"
 authors = ["Kai Greshake <development@kai-greshake.de>",
            "Contributors on GitHub (https://github.com/greshake/i3status-rust/graphs/contributors)"]
@@ -26,7 +22,6 @@ toml = "0.4"
 clap = "2.31"
 uuid = { version = "0.6", features = ["v4"] }
 dbus = "0.6"
-regex = "1.0"
 nix = "0.14.0"
 i3ipc = "0.8.2"
 num = "0.1.42"
@@ -38,3 +33,8 @@ libpulse-binding = { optional = true, version = "2.2.3", default-features = fals
 # for profiling blocks
 cpuprofiler = { version = "0.0.3", optional = true }
 progress = { version = "0.2", optional = true }
+
+[dependencies.regex]
+version = "1.3.0"
+default-features = false
+features = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "i3status-rs"
+description = "A feature-rich and resource-friendly replacement for i3status, written in Rust."
+repository = "https://github.com/greshake/i3status-rust/"
+readme = "README.md"
+license = "GPLv3"
 version = "0.10.0"
 authors = ["Kai Greshake <development@kai-greshake.de>",
            "Contributors on GitHub (https://github.com/greshake/i3status-rust/graphs/contributors)"]


### PR DESCRIPTION
`regex` 1.3.0 allows for shrinking the dependency tree by disabling crate features. As far as I can tell we are only using the regex crate for some simple ASCII strings so we do not need the Unicode tables, thus we can safely disable those crate features to reduce our dependencies:

Before
![image](https://user-images.githubusercontent.com/24377231/64215984-f38c2900-cef1-11e9-9180-fa00937abd23.png)

After
![image](https://user-images.githubusercontent.com/24377231/64215999-fd159100-cef1-11e9-80a1-8be0a10b092f.png)

(graphs generated with `cargo deps | dot -Tpng > graph.png`)

Due to `parse-zoneinfo` the dependencies have not completely gone away but if `parse-zoneinfo` updates too then the regex 0.2 dependencies should go away too.