### PR TITLE
Remove depecrated configuration option

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
 max_width = 200
-write_mode = "Overwrite"


### PR DESCRIPTION
Running `cargo fmt` or `rustfmt` gives :

> Warning: Unknown configuration option `write_mode`.

It is not listed as an option in the (Rust 2018 Edition) [rustfmt docs](https://rust-lang.github.io/rustfmt/ ) and it looks like it has been deprecated according to issues such as rust-lang/cargo#5545.

My env: rustc 1.37.0