### PR TITLE
Fixes a panic in the iBus block due to the use of Perl regex features

### DIFF
--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -182,7 +182,7 @@ fn get_ibus_address() -> Result<String> {
         // Hence on sway you will need to reload the bar once after login to get the block to work.
         let display_var = env::var("DISPLAY")
             .block_error("ibus", "$DISPLAY not set. Try restarting bar if on sway")?;
-        let re = Regex::new(r"^:(\d{1})$").unwrap(); // Valid regex is safe to unwrap.
+        let re = Regex::new(r"^:([0-9]{1})$").unwrap(); // Valid regex is safe to unwrap.
         let cap = re
             .captures(&display_var)
             .block_error("ibus", "Failed to extract display number from $DISPLAY")?;


### PR DESCRIPTION
After #434 was merged, [this](https://github.com/greshake/i3status-rust/blob/f90bc9874d060a24276c2808275f4068d30ba47b/src/blocks/ibus.rs#L185) line started to cause a panic when using the `ibus` block. 
Adding the `unicode-perl` feature to the crate resolves this issue.

```
> i3status-rs  ~/.config/i3status-rust/config.toml
{"version": 1, "click_events": true}
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Syntax(
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
regex parse error:
    ^:(\d{1})$
       ^^
error: Unicode-aware Perl class not found (make sure the unicode-perl feature is enabled)
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
)', src/libcore/result.rs:999:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
[⏎     
```