### PR TITLE
fix builds on armv7 and i686

### DIFF
--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -189,16 +189,16 @@ impl Block for DiskSpace {
         let mut result;
         let mut converted = 0.0f64;
         let mut converted_str = String::new();
-        let total = (statvfs.blocks() * (statvfs.fragment_size() as u64)) as u64;
-        let used = ((statvfs.blocks() - statvfs.blocks_free()) * (statvfs.fragment_size() as u64)) as u64;
+        let total = (statvfs.blocks() as u64) * (statvfs.fragment_size() as u64);
+        let used = ((statvfs.blocks() as u64) - (statvfs.blocks_free() as u64)) * (statvfs.fragment_size() as u64);
 
         match self.info_type {
             InfoType::Available => {
-                result = (statvfs.blocks_available() * (statvfs.block_size() as u64)) as u64;
+                result = (statvfs.blocks_available() as u64) * (statvfs.block_size() as u64);
                 converted = Unit::bytes_in_unit(self.unit, result);
             }
             InfoType::Free => {
-                result = (statvfs.blocks_free() * (statvfs.block_size() as u64)) as u64;
+                result = (statvfs.blocks_free() as u64) * (statvfs.block_size() as u64);
                 converted = Unit::bytes_in_unit(self.unit, result);
             }
             InfoType::Total => {


### PR DESCRIPTION
These were broken by #449, which naively fixed armv6 builds.
This commit should now work on all platforms.
It wraps all return values of statvfs from the nix crate in
`as u64`, which means that the platform specific data type
(which might be u32 instead) is always converted to u64 when
necessary. Before this, only values which were known to cause
an issue were converted.