### PR TITLE
separate command to get state for custom block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -197,6 +197,7 @@ Note that `command` and `cycle` are mutually exclusive.
 Key | Values | Required | Default
 ----|--------|----------|--------
 `command` | Shell command to execute & display. | No | None
+`state_command` | Shell command to get the block state | No | None
 `on_click` | Command to execute when the button is clicked. The command will be passed to whatever is specified in your `$SHELL` variable and - if not set - fallback to `sh`. | No | None
 `cycle` | Commands to execute and change when the button is clicked. | No | None
 `interval` | Update interval, in seconds. | No | `10`

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -113,8 +113,7 @@ impl Block for Custom {
                 .args(&["-c", &state_command.clone()])
                 .output()
                 .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
-                .unwrap_or_else(|e| e.description().to_owned())
-                .try_into()
+                .map(|o| o.try_into().unwrap_or(State::Critical))
                 .unwrap_or(State::Critical);
 
             self.output.set_state(state);

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,5 +1,6 @@
 use crate::themes::Theme;
 use serde_json::value::Value;
+use std::convert::TryFrom;
 
 #[derive(Debug, Copy, Clone)]
 pub enum State {
@@ -19,6 +20,21 @@ impl State {
             Good => (&theme.good_bg, &theme.good_fg),
             Warning => (&theme.warning_bg, &theme.warning_fg),
             Critical => (&theme.critical_bg, &theme.critical_fg),
+        }
+    }
+}
+
+impl TryFrom<String> for State {
+    type Error = &'static str;
+
+    fn try_from(state: String) -> Result<Self, Self::Error> {
+        match state.to_lowercase().as_ref() {
+            "idle" => Ok(Self::Idle),
+            "info" => Ok(Self::Info),
+            "good" => Ok(Self::Good),
+            "warning" => Ok(Self::Warning),
+            "critical" => Ok(Self::Critical),
+            _ => Err("Not a valid state.")
         }
     }
 }


### PR DESCRIPTION
This is an alternative to \#414. I implemented it without knowing \#414
existed. But since it already existed and it's not merged yet,
I'm pushing this as a simpler alternative.