### PR TITLE
battery: Add configurable thresholds

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -376,6 +376,8 @@ pub struct Battery {
     device: Box<dyn BatteryDevice>,
     format: FormatTemplate,
     driver: BatteryDriver,
+    critical: u64,
+    warning: u64,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -422,6 +424,14 @@ pub struct BatteryConfig {
 
     /// The "driver" to use for powering the block. One of "sysfs" or "upower".
     pub driver: Option<BatteryDriver>,
+
+    /// The threshold below which the remaining capacity is shown as critical
+    #[serde(default = "BatteryConfig::default_critical")]
+    pub critical: u64,
+
+    /// The threshold below which the remaining capacity is shown as warning
+    #[serde(default = "BatteryConfig::default_warning")]
+    pub warning: u64,
 }
 
 impl BatteryConfig {
@@ -439,6 +449,14 @@ impl BatteryConfig {
 
     fn default_upower() -> bool {
         false
+    }
+
+    fn default_critical() -> u64 {
+        10
+    }
+
+    fn default_warning() -> u64 {
+        30
     }
 }
 
@@ -487,6 +505,8 @@ impl ConfigBlock for Battery {
             device,
             format: FormatTemplate::from_string(&format)?,
             driver,
+            critical: block_config.critical,
+            warning: block_config.warning,
         })
     }
 }
@@ -529,11 +549,16 @@ impl Block for Battery {
                 }
                 _ => {
                     self.output.set_state(match capacity {
-                        Ok(0..=15) => State::Critical,
-                        Ok(16..=30) => State::Warning,
-                        Ok(31..=60) => State::Info,
-                        Ok(61..=100) => State::Good,
-                        _ => State::Warning,
+                        Ok(capacity) => {
+                            if capacity <= self.critical {
+                                State::Critical
+                            } else if capacity <= self.warning {
+                                State::Warning
+                            } else {
+                                State::Idle
+                            }
+                        }
+                        Err(_) => State::Warning,
                     });
                 }
             }


### PR DESCRIPTION
Add critical and warning thresholds to the block configuration. Use
State::Idle when above the warning threshold.

The battery block is unlike most other blocks, in that it doesn't use the Idle state when it has nothing interesting to say, meaning it stands out when it shouldn't. The way I see it, the current battery capacity is uninteresting for most of the discharge cycle, and the block should only draw attention when it is starting to get low (warning) or close to empty (critical). I have chosen 30% and 10% as the default thresholds, but I am open to suggestions. The option names, `warning` and `critical` are inspired by the CPU and similar blocks.

I'm somewhat new to rust, so let me know if my proposed changes are unidiomatic or simply incorrect.