### PR TITLE
Allow  for natural scrolling.

### DIFF
--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -20,7 +20,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::blocks::{Block, ConfigBlock};
-use crate::config::Config;
+use crate::config::{Config, LogicalDirection};
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
@@ -731,13 +731,14 @@ impl Block for Sound {
                                 .block_error("sound", "could not spawn child")?;
                         }
                     }
-                    MouseButton::WheelUp => {
-                        self.device.set_volume(self.step_width as i32)?;
+                    _ => {
+                        use LogicalDirection::*;
+                        match self.config.scrolling.to_logical_direction(e.button) {
+                            Some(Up) => self.device.set_volume(self.step_width as i32)?,
+                            Some(Down) => self.device.set_volume(-(self.step_width as i32))?,
+                            None => (),
+                        }
                     }
-                    MouseButton::WheelDown => {
-                        self.device.set_volume(-(self.step_width as i32))?;
-                    }
-                    _ => (),
                 }
                 self.display()?;
             }

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use crate::util::FormatTemplate;
 
 use crate::blocks::{Block, ConfigBlock};
-use crate::config::Config;
+use crate::config::{Config, LogicalDirection};
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
@@ -273,21 +273,26 @@ impl Block for Xrandr {
                             self.current_idx = 0;
                         }
                     }
-                    MouseButton::WheelUp => {
-                        if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
-                            if monitor.brightness <= (100 - self.step_width) {
-                                monitor.set_brightness(self.step_width as i32);
+                    mb => {
+                        use LogicalDirection::*;
+                        match self.config.scrolling.to_logical_direction(mb) {
+                            Some(Up) => {
+                                if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
+                                    if monitor.brightness <= (100 - self.step_width) {
+                                        monitor.set_brightness(self.step_width as i32);
+                                    }
+                                }
                             }
+                            Some(Down) => {
+                                if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
+                                    if monitor.brightness >= self.step_width {
+                                        monitor.set_brightness(-(self.step_width as i32));
+                                    }
+                                }
+                            }
+                            None => {}
                         }
                     }
-                    MouseButton::WheelDown => {
-                        if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
-                            if monitor.brightness >= self.step_width {
-                                monitor.set_brightness(-(self.step_width as i32));
-                            }
-                        }
-                    }
-                    _ => {}
                 }
                 self.display()?;
             }

--- a/src/input.rs
+++ b/src/input.rs
@@ -7,7 +7,7 @@ use std::option::Option;
 use std::string::*;
 use std::thread;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MouseButton {
     Left,
     Middle,


### PR DESCRIPTION
Prior to this `NaturalScrolling` option configured on XServer's input devices would lead to inverted behavior. The new functionality is enabled via a top level `scrolling = "natural"` line in the config file. The default is `scrolling = "reverse"`.