### PR TITLE
set backlight brightness via DBus when sysfs is inaccessible

### DIFF
--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -134,7 +134,10 @@ impl BacklitDevice {
     }
 
     fn set_brightness_via_dbus(&self, raw_value: u64) -> Result<()> {
-        let device_name = self.device_path.file_name().and_then(|x| x.to_str())
+        let device_name = self
+            .device_path
+            .file_name()
+            .and_then(|x| x.to_str())
             .block_error("backlight", "Malformed device path")?;
 
         let con = dbus::Connection::get_private(dbus::BusType::System)


### PR DESCRIPTION
After not getting sysfs access to work, even with the udev rule mentioned in the documentation, I investigated how other applications/desktops are controlling the backlight brightness.

As it turns out, on systems governed by systemd-logind (or elogind), the correct way [according to the systemd developers](https://github.com/systemd/systemd/issues/14463#issuecomment-570190340) is the DBus interface of logind.

This commit uses this method as a fallback for when we cannot open the sysfs file. This works great on my system, but I'm not particularly attached to this method if you find it too surprising. If you'd rather like a configuration option to switch between two methods, I can implement that as well.