### PR TITLE
Allow sound block to have a format string

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -647,6 +647,7 @@ step_width = 3
 Key | Values | Required | Default
 ----|--------|----------|--------
 `driver` | `"auto"`, `"pulseaudio"`, `"alsa"` | No | `"auto"` (Pulseaudio with ALSA fallback)
+`format` | Any string to use next to the icon | No | `{volume}%`
 `name` | PulseAudio / ALSA device name | No | Default Device (`@DEFAULT_SINK@` / `Master`)
 `step_width` | The percent volume level is increased/decreased for the selected audio device when scrolling. Capped automatically at 50. | No | `5`
 `on_click` | Shell command to run when the sound block is clicked. | No | None


### PR DESCRIPTION
Right now it just supports {volume}. Defaults to {volume}%.