### PR TITLE
Remove trailing whitespace from IP address

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -220,9 +220,11 @@ impl NetworkDevice {
             Ok(None)
         } else {
             ip_output.pop(); // Remove trailing newline.
-            String::from_utf8(ip_output)
-                .block_error("net", "Non-UTF8 IP address.")
-                .map(Some)
+            let ip = String::from_utf8(ip_output)
+                .block_error("net", "Non-UTF8 IP address.")?
+                .trim()
+                .to_string();
+            Ok(Some(ip))
         }
     }
 


### PR DESCRIPTION
Should solve #498, or at least one part of the problem.

Before: "■192.168.0.3/24■■"
After: "■192.168.0.3/24■"

where ■ represents a space.