### PR TITLE
Chore: Order deps in alphabetical order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,23 +18,23 @@ profiling = ["cpuprofiler", "progress"]
 [dependencies]
 chrono = "0.4"
 chrono-tz = "0.5"
+crossbeam-channel = "0.4"
+dbus = "0.8"
+i3ipc = "0.10.1"
+inotify = "0.8.2"
 lazy_static = "1.0"
+maildir = "0.3"
+nix = "0.16.0"
+num-traits = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 toml = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
-dbus = "0.8"
-nix = "0.16.0"
-i3ipc = "0.10.1"
-num-traits = "0.2"
-crossbeam-channel = "0.4"
-inotify = "0.8.2"
-maildir = "0.3"
+# Optional features/blocks
 libpulse-binding = { optional = true, version = "2.15.0", default-features = false }
 notmuch = { optional = true, version = "0.6.0" }
-# Used only in debug build mode
-# for profiling blocks
+# Used only in debug build for profiling blocks
 cpuprofiler = { version = "0.0.4", optional = true }
 progress = { version = "0.2", optional = true }
 


### PR DESCRIPTION
Since have been working with dependencies a lot lately this had been getting on my mind.

Had a gander at some other crates like `tokio` and they do this there too.