### PR TITLE
Add JSON parsing to Custom block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -145,6 +145,7 @@ Key | Values | Required | Default
 `mac` | MAC address of the Bluetooth device. | Yes | None
 `label` | Text label to display next to the icon. | No | None
 
+
 ## CPU Utilization
 
 Creates a block which displays the overall CPU utilization, calculated from `/proc/stat`.
@@ -176,10 +177,10 @@ Key | Values | Required | Default
 
 Creates a block that display the output of custom shell commands.
 
-For further customisation, have the shell command output valid JSON in the schema below:
+For further customisation, use the `json` option and have the shell command output valid JSON in the schema below:
 `{"icon": "ICON", state": "STATE", "text": "YOURTEXT"}`
-`icon` is optional, it may be an icon name from `icons.rs`
-`state` is optonal, it may be Info, Good, Warning, Critical
+`icon` is optional, it may be an icon name from `icons.rs` (default "")
+`state` is optional, it may be Idle, Info, Good, Warning, Critical (default Idle)
 
 ### Examples
 
@@ -198,6 +199,13 @@ on_click = "<command>"
 interval = 1
 ```
 
+```toml
+[[block]]
+block = "custom"
+command = "echo '{\"icon\":\"weather_thunder\",\"state\":\"Critical\", \"text\": \"Danger!\"}'"
+json = true
+```
+
 ### Options
 
 Note that `command` and `cycle` are mutually exclusive.
@@ -208,6 +216,7 @@ Key | Values | Required | Default
 `on_click` | Command to execute when the button is clicked. The command will be passed to whatever is specified in your `$SHELL` variable and - if not set - fallback to `sh`. | No | None
 `cycle` | Commands to execute and change when the button is clicked. | No | None
 `interval` | Update interval, in seconds. | No | `10`
+`json` | Use JSON from command output to format the block. If the JSON is not valid, the block will error out. | No | `false`
 
 ## Disk Space
 

--- a/blocks.md
+++ b/blocks.md
@@ -176,6 +176,11 @@ Key | Values | Required | Default
 
 Creates a block that display the output of custom shell commands.
 
+For further customisation, have the shell command output valid JSON in the schema below:
+`{"icon": "ICON", state": "STATE", "text": "YOURTEXT"}`
+`icon` is optional, it may be an icon name from `icons.rs`
+`state` is optonal, it may be Info, Good, Warning, Critical
+
 ### Examples
 
 ```toml

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,7 +1,8 @@
 use crate::themes::Theme;
+use serde_derive::Deserialize;
 use serde_json::value::Value;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Deserialize)]
 pub enum State {
     Idle,
     Info,


### PR DESCRIPTION
This builds on the work in #165:
- support for setting the icon has been added
- non-JSON output is passed through as-is which allows us to not break users' configs (block behaves the same as now).

This allows for a more versatile `custom` block and should solve the following issues such as #331, #414 and #454 as long as the user writes a wrapper script for their commands that outputs JSON. 