### PR TITLE
Simplify volume_muted icons

### DIFF
--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -627,22 +627,15 @@ impl Sound {
 
         let volume = self.device.volume();
         if self.device.muted() {
-            self.text.set_icon("volume_empty");
-            let icon = self
-                .config
-                .icons
-                .get("volume_muted")
-                .block_error("sound", "cannot find icon")?
-                .to_owned();
+            self.text.set_icon("volume_muted");
             if self.show_volume_when_muted {
                 if self.bar {
-                    self.text
-                        .set_text(format!("{} {}", icon, format_percent_bar(volume as f32)));
+                    self.text.set_text(format_percent_bar(volume as f32));
                 } else {
-                    self.text.set_text(format!("{} {:02}%", icon, volume));
+                    self.text.set_text(format!("{:02}%", volume));
                 }
             } else {
-                self.text.set_text(icon);
+                self.text.set_text("");
             }
             self.text.set_state(State::Warning);
         } else {

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -26,8 +26,7 @@ lazy_static! {
         "volume_full" => " VOL ",
         "volume_half" => " VOL ",
         "volume_empty" => " VOL ",
-        // This icon has no spaces around it because it is manually set as text. (sound.rs)
-        "volume_muted" => "MUTED",
+        "volume_muted" => " VOL MUTED ",
         "thermometer" => " TEMP ",
         "xrandr" => " SCREEN ",
         "net_up" => " UP ",
@@ -83,8 +82,7 @@ lazy_static! {
         "volume_full" => " \u{f028} ",
         "volume_half" => " \u{f027} ",
         "volume_empty" => " \u{f026} ",
-        // This icon has no spaces around it because it is manually set as text. (sound.rs)
-        "volume_muted" => "\u{f00d}",
+        "volume_muted" => " \u{f6a9} ",
         "thermometer" => " \u{f2c8} ",
         "xrandr" => " \u{f26c} ",
         "net_up" => " \u{2b06} ",
@@ -142,8 +140,7 @@ lazy_static! {
         "volume_full" => " \u{e050} ",
         "volume_half" => " \u{e04d} ",
         "volume_empty" => " \u{e04e} ",
-        // This icon has no spaces around it because it is manually set as text. (sound.rs)
-        "volume_muted" => "\u{e04f}",
+        "volume_muted" => " \u{e04e} \u{e04f} ",
         "thermometer" => " \u{f2c8} ", // TODO
         "xrandr" => " \u{e31e} ",
         // Same as time symbol.


### PR DESCRIPTION
Maybe I'm missing something, but font awesome includes a volume mute icon so we should just use that instead of attempting to build it out of multiple icons. It is also possible to simplify the code around creating custom mute icons. Not sure if there is a default volume mute icon for material icons, but would be happy to amend.