### PR TITLE
Escape char to avoid pango_parse_markup error

### DIFF
--- a/src/icons.rs
+++ b/src/icons.rs
@@ -8,7 +8,7 @@ lazy_static! {
         "music_play" => " > ",
         "music_pause" => " || ",
         "music_next" => " > ",
-        "music_prev" => " < ",
+        "music_prev" => " &lt; ",
         "cogs" => " LOAD ",
         "memory_mem" => " MEM ",
         "memory_swap" => " SWAP ",


### PR DESCRIPTION
While investigating #290 I found loads of these errors in my sway log, about 50 a second from the looks of it:

```
2020-01-21 22:21:46 - [common/pango.c:64] pango_parse_markup ' <  ' -> error Error on line 1 char 11: “ ” is not a valid character following a “<” character; it may not begin an element name
```

I checked the output of `i3status-rust` and found the culprit to be the `prev` button for the music block.
```
{"background":"#2196f3","color":"#ffffff","full_text":" <  ","markup":"pango","name":"prev","separator":false,"separator_block_width":0}
```

Checking the [pango markup docs](https://shinmera.github.io/pango-markup/#FUNCTION%20PANGO-MARKUP%3AESCAPE-CHAR), "<" is one of four characters that may need escaping. In our case, it is being interpreted as the start of a tag block in pango markup hence leading to the error. I recently switched my icon theme to `none` so I had never encountered this until now.

This bug has existed since #346 was merged which added pango formatting to the button widget, however, at least in sway, somehow the bar is displayed without issue so I guess you wouldn't really notice unless checking the logs...