### PR TITLE
Solve Error::description() deprecated errors on Rust 1.41

### DIFF
--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -97,7 +97,7 @@ impl Block for Custom {
             .args(&["-c", &command_str])
             .output()
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
-            .unwrap_or_else(|e| e.description().to_owned());
+            .unwrap_or_else(|e| e.to_string());
 
         self.output.set_text(output);
 

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -101,12 +101,7 @@ fn run_query(db_path: &String, query_string: &String) -> Result<u32> {
     notmuch::Database::open(db_path, notmuch::DatabaseMode::ReadOnly)
         .and_then(|db| db.create_query(query_string))
         .and_then(|q| q.count_messages())
-        .or_else(|e| {
-            Err(BlockError(
-                "notmuch".to_string(),
-                e.description().to_owned(),
-            ))
-        })
+        .or_else(|e| Err(BlockError("notmuch".to_string(), e.to_string())))
 }
 
 impl ConfigBlock for Notmuch {

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -136,7 +136,7 @@ impl Block for Temperature {
             .args(&args)
             .output()
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
-            .unwrap_or_else(|e| e.description().to_owned());
+            .unwrap_or_else(|e| e.to_string());
 
         let mut temperatures: Vec<i64> = Vec::new();
 

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -93,7 +93,7 @@ impl Block for Toggle {
             .args(&["-c", &self.command_state])
             .output()
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
-            .unwrap_or_else(|e| e.description().to_owned());
+            .unwrap_or_else(|e| e.to_string());
 
         self.text.set_icon(match output.trim_start() {
             "" => {

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,7 +1,6 @@
 use chrono_tz::Tz;
 use serde::de::{self, Deserialize, DeserializeSeed, Deserializer};
 use std::collections::{BTreeMap, HashMap as Map};
-use std::error::Error;
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -174,12 +173,12 @@ where
             combined.extend(
                 raw_names
                     .deserialize_any(MapType::<T, V>(PhantomData, PhantomData))
-                    .map_err(|e: toml::de::Error| de::Error::custom(e.description()))?,
+                    .map_err(|e: toml::de::Error| de::Error::custom(e.to_string()))?,
             );
         }
         if let Some(raw_overrides) = map.remove("overrides") {
             let overrides: Map<String, V> = Map::<String, V>::deserialize(raw_overrides)
-                .map_err(|e: toml::de::Error| de::Error::custom(e.description()))?;
+                .map_err(|e: toml::de::Error| de::Error::custom(e.to_string()))?;
             combined.extend(overrides);
         }
 


### PR DESCRIPTION
Error::description() is [deprecated](https://github.com/rust-lang/rust/blob/e0bbe7915e2b663ac84244918d6d06e0747ed33e/src/libstd/error.rs#L138) since Rust 1.41.0.

Will solve current/future build errors on 1.41+
