### PR TITLE
`extern crate` not needed in Rust 2018

### DIFF
--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 
 use crossbeam_channel::Sender;
 use inotify::{EventMask, Inotify, WatchMask};
+use serde_derive::Deserialize;
 use uuid::Uuid;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -12,6 +12,7 @@ use crossbeam_channel::Sender;
 use dbus;
 use dbus::arg::Array;
 use dbus::stdintf::org_freedesktop_dbus::Properties;
+use serde_derive::Deserialize;
 use uuid::Uuid;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -1,3 +1,4 @@
+use serde_derive::Deserialize;
 use std::thread;
 use std::time::{Duration, Instant};
 

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -1,6 +1,7 @@
 use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::time::Duration;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -1,4 +1,5 @@
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::env;
 use std::iter::{Cycle, Peekable};
 use std::process::Command;

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -1,5 +1,6 @@
 use crate::scheduler::Task;
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::path::Path;
 use std::time::Duration;
 
@@ -12,9 +13,7 @@ use crate::widgets::text::TextWidget;
 
 use uuid::Uuid;
 
-extern crate nix;
-
-use self::nix::sys::statvfs::statvfs;
+use nix::sys::statvfs::statvfs;
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
 pub enum Unit {

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -1,4 +1,5 @@
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::process::Command;
 use std::time::Duration;
 

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -1,4 +1,5 @@
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -12,11 +13,10 @@ use crate::widgets::text::TextWidget;
 
 use uuid::Uuid;
 
-extern crate i3ipc;
-use self::i3ipc::event::inner::{WindowChange, WorkspaceChange};
-use self::i3ipc::event::Event;
-use self::i3ipc::I3EventListener;
-use self::i3ipc::Subscription;
+use i3ipc::event::inner::{WindowChange, WorkspaceChange};
+use i3ipc::event::Event;
+use i3ipc::I3EventListener;
+use i3ipc::Subscription;
 
 pub struct FocusedWindow {
     text: TextWidget,

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -9,6 +9,7 @@ use crossbeam_channel::Sender;
 use dbus::stdintf::org_freedesktop_dbus::Properties;
 use dbus::{arg, Connection, ConnectionItem};
 use regex::Regex;
+use serde_derive::Deserialize;
 use uuid::Uuid;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -7,6 +7,7 @@ use crossbeam_channel::Sender;
 use dbus;
 use dbus::stdintf::org_freedesktop_dbus::Properties;
 use dbus::{Message, MsgHandlerResult, MsgHandlerType};
+use serde_derive::Deserialize;
 use uuid::Uuid;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -1,3 +1,4 @@
+use serde_derive::Deserialize;
 use std::time::Duration;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -1,4 +1,5 @@
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::time::Duration;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -2,6 +2,7 @@ use crate::blocks::{Block, ConfigBlock};
 use crate::input::{I3BarEvent, MouseButton};
 use crate::util::*;
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::collections::HashMap;
 use std::fmt;
 use std::fs::File;

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -1,4 +1,5 @@
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::boxed::Box;
 use std::ffi::OsStr;
 use std::process::Command;

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -1,4 +1,5 @@
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::ffi::OsStr;
 use std::fs::read_to_string;
 use std::fs::OpenOptions;

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use crossbeam_channel::Sender;
 use dbus::arg::Variant;
 use dbus::{BusType, Connection, Message, MessageItem};
+use serde_derive::Deserialize;
 use uuid::Uuid;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use crossbeam_channel::Sender;
 use notmuch;
+use serde_derive::Deserialize;
 use uuid::Uuid;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -1,4 +1,5 @@
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::process::Command;
 use std::time::Duration;
 

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -1,5 +1,6 @@
 use crate::scheduler::Task;
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::env;
 use std::ffi::OsString;
 use std::fs;

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -1,4 +1,5 @@
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -44,6 +44,8 @@ use crate::pulse::proplist::{properties, Proplist};
 #[cfg(feature = "pulseaudio")]
 use crate::pulse::volume::{ChannelVolumes, VOLUME_MAX, VOLUME_NORM};
 
+use lazy_static::lazy_static;
+use serde_derive::Deserialize;
 use uuid::Uuid;
 
 trait SoundDevice {

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -1,5 +1,6 @@
 use crate::scheduler::Task;
 use crossbeam_channel::{unbounded, Receiver, Sender};
+use serde_derive::Deserialize;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread::spawn;

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -8,6 +8,7 @@ use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::process::Command;
 use std::time::Duration;
 

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -1,4 +1,5 @@
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::time::Duration;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -1,3 +1,4 @@
+use serde_derive::Deserialize;
 use std::time::Duration;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -1,5 +1,6 @@
 use crate::scheduler::Task;
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use std::env;
 use std::process::Command;
 use std::time::Duration;

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use uuid::Uuid;
 
 use crate::blocks::{Block, ConfigBlock};

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -1,4 +1,5 @@
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use serde_json;
 use std::collections::HashMap;
 use std::env;

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -14,6 +14,7 @@ use crate::input::{I3BarEvent, MouseButton};
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 
+use serde_derive::Deserialize;
 use uuid::Uuid;
 
 struct Monitor {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use crate::icons;
 use crate::input::MouseButton;
 use crate::themes::{self, Theme};
 use serde::de::{self, Deserialize, Deserializer};
+use serde_derive::Deserialize;
 use std::collections::HashMap as Map;
 use std::marker::PhantomData;
 use std::ops::Deref;

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use std::collections::HashMap as Map;
 
 lazy_static! {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,6 @@
 use crossbeam_channel::Sender;
 use serde::{de, Deserializer};
+use serde_derive::Deserialize;
 use serde_json;
 use std::fmt;
 use std::io;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,6 @@
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde;
-#[macro_use]
 extern crate serde_json;
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate chrono;
-extern crate chrono_tz;
-extern crate clap;
-extern crate dbus;
-extern crate inotify;
-#[cfg(feature = "pulseaudio")]
-extern crate libpulse_binding as pulse;
-extern crate maildir;
-#[cfg(feature = "notmuch")]
-extern crate notmuch;
-extern crate num_traits;
-extern crate regex;
-extern crate toml;
-extern crate uuid;
+use libpulse_binding as pulse;
 
 #[macro_use]
 mod de;
@@ -38,11 +18,9 @@ mod widget;
 mod widgets;
 
 #[cfg(feature = "profiling")]
-extern crate cpuprofiler;
-#[cfg(feature = "profiling")]
 use cpuprofiler::PROFILER;
 #[cfg(feature = "profiling")]
-extern crate progress;
+use progress;
 
 use std::collections::HashMap;
 use std::ops::DerefMut;
@@ -60,8 +38,8 @@ use crate::widgets::text::TextWidget;
 
 use crate::util::deserialize_file;
 
-use self::clap::{App, Arg, ArgMatches};
-use crossbeam_channel::{Receiver, Sender};
+use clap::{App, Arg, ArgMatches};
+use crossbeam_channel::{select, Receiver, Sender};
 
 fn main() {
     let mut builder = App::new("i3status-rs")

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,3 +1,5 @@
+use lazy_static::lazy_static;
+use serde_derive::Deserialize;
 use std::str::FromStr;
 
 lazy_static! {


### PR DESCRIPTION
- `extern crate` declarations are no longer needed
- Also if I understand correctly, `#[cfg(feature = ...")` is also [no longer necessary](https://github.com/rust-lang/edition-guide/issues/96)

Reference:
https://doc.rust-lang.org/stable/edition-guide/rust-2018/macros/macro-changes.html
https://doc.rust-lang.org/stable/edition-guide/rust-2018/module-system/path-clarity.html