### PR TITLE
Update bare trait objects

### DIFF
--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -173,7 +173,7 @@ impl Block for Notmuch {
         }
     }
 
-    fn view(&self) -> Vec<&I3BarWidget> {
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
 }
 
 #[cfg(feature = "profiling")]
-fn profile(iterations: i32, name: &str, block: &mut Block) {
+fn profile(iterations: i32, name: &str, block: &mut dyn Block) {
     let mut bar = progress::Bar::new();
     println!(
         "Now profiling the {0} block by executing {1} updates.\n \


### PR DESCRIPTION
A couple that were missed in 6b602784f8758631c274c1f7013189695ad5bcb7.

Is it trivial to get our Travis CI to test our optional features as well? It doesn't seem to be doing that at the moment, just the standard build with no options.