### PR TITLE
Document the optional `notmuch` block

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,7 +43,7 @@
 
 * Adds a new Notmuch block for querying information from a Notmuch mail
   database. This block is currently an optional feature and must be enabled with
-  `cargo build --feature notmuch`. (#215 by @bobthemighty and @atheriel)
+  `cargo build --features notmuch`. (#215 by @bobthemighty and @atheriel)
 
 * The Weather block will now obey the `OPENWEATHERMAP_API_KEY` and
   `OPENWEATHERMAP_CITY_ID` environment variables. (#410 by @nicholasfagan)

--- a/blocks.md
+++ b/blocks.md
@@ -14,6 +14,7 @@
 - [Memory](#memory)
 - [Music](#music)
 - [Net](#net)
+- [Notmuch](#notmuch)
 - [Nvidia Gpu](#nvidia-gpu)
 - [Pacman](#pacman)
 - [Pomodoro](#pomodoro)
@@ -518,6 +519,38 @@ Key | Values | Required | Default
 `interval` | Update interval, in seconds. | No | `1`
 `hide_missing` | Whether to hide networks that are down/inactive completely. | No | `false`
 `hide_inactive` | Whether to hide networks that are missing. | No | `false`
+
+## Notmuch
+
+Creates a block which queries a notmuch database and displays the count of messages.
+
+The simplest configuration will return the total count of messages in the notmuch database stored at $HOME/.mail
+
+NOTE: This block can only be used if you build with `cargo build --features=notmuch`
+
+### Examples
+
+```toml
+[[block]]
+block = "notmuch"
+query = "tag:alert and not tag:trash"
+threshold_warning = 1
+threshold_critical = 10
+name = "A"
+```
+
+### Options
+
+Key | Values | Required | Default
+----|--------|----------|--------
+`maildir` | Path to the directory containing the notmuch database | No | `$HOME/.mail`
+`query` | Query to run on the database | No | `""`
+`threshold_critical` | Mail count that triggers `critical` state | No | `99999`
+`threshold_warning` | Mail count that triggers `warning` state | No | `99999`
+`threshold_good` | Mail count that triggers `good` state | No | `99999`
+`threshold_info` | Mail count that triggers `info` state | No | `99999`
+`name` | Label to show before the mail count | No | `""`
+`no_icon` | Disable the mail icon | No | `false`
 
 ## Nvidia Gpu
 


### PR DESCRIPTION
As per the title.

Wasn't sure how to communicate the default thresholds which are set to `<u32>::max_value()` so I just put an arbitrarily large enough number which, when given this block deals with mails, should get the point across.