### PR TITLE
Ignore stdin and stdout for `spawn_child_async`

### DIFF
--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::thread;
 
 /// Splits a string into command name and arguments.
@@ -10,9 +10,14 @@ pub fn parse_command(command: &str) -> (&str, Vec<&str>) {
     (name, args.to_vec())
 }
 
-// Spawns a new child process. This returns to the caller after the child has been started. A new thread waits for the child to exit.
+/// Spawns a new child process. This closes stdin and stdout, and returns to the caller after the
+/// child has been started, while a background thread waits for the child to exit.
 pub fn spawn_child_async(name: &str, args: &[&str]) -> io::Result<()> {
-    let mut child = Command::new(name).args(args).spawn()?;
+    let mut child = Command::new(name)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .spawn()?;
     thread::spawn(move || child.wait());
     Ok(())
 }


### PR DESCRIPTION
If stdout from child processes is not deliberately ignored and/or
quieted via external means, it can interfere with the i3bar protocol
stream. Stdin is less dangerous, but gets closed almost immediately by
`wait()`ing.

Connect both of them to `Stdio::null()` to avoid any problems. Stderr
is safe and can remain as-is for debugging purposes.