### PR TITLE
[WAIT] Bump `uuid` crate to reduce dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,23 +152,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "futures"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "getrandom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "i3ipc"
@@ -205,7 +200,7 @@ dependencies = [
  "serde_derive 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (git+https://github.com/uuid-rs/uuid)",
 ]
 
 [[package]]
@@ -245,6 +240,9 @@ dependencies = [
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
@@ -388,16 +386,6 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rand"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +432,11 @@ dependencies = [
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
@@ -503,11 +496,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uuid"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.8.1"
+source = "git+https://github.com/uuid-rs/uuid#f177d20151f23a8beb9a75df40c736b27dead0d1"
 dependencies = [
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -569,9 +561,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
+"checksum getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
 "checksum i3ipc 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a4e0c68a50475f32bf9a728de1198a8acc573ccdb24212db1192c874e37f302"
 "checksum inotify 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ad0bfe014aafc0f4e177fbe66c5f2b59ba59f66f58b022aa1963bbe71ab4118"
 "checksum inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dceb94c43f70baf4c4cd6afbc1e9037d4161dbe68df8a2cd4351a23319ee4fb"
@@ -596,7 +587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b820305721858696053a7fd0215cfeeee16ecaaf96b7a209945428e02f1c44"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quoted_printable 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86cedf331228892e747bb85beb130b6bb23fc628c40dde9ea01eb6becea3c798"
-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
@@ -604,6 +594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "de4dee3b122edad92d80c66cac8d967ec7f8bf16a3b452247d6eb1dbf83c8f22"
 "checksum serde_derive 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "7149ef7af607b09e0e7df38b1fd74264f08a29a67f604d5cb09d3fbdb1e256bc"
 "checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
+"checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "61b8f1b737f929c6516ba46a3133fd6d5215ad8a62f66760f851f7048aebedfb"
 "checksum terminal_size 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4f7fdb2a063032d361d9a72539380900bc3e0cd9ffc9ca8b677f8c855bae0f"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
@@ -611,7 +602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8630752f979f1b6b87c49830a5e3784082545de63920d59fbaac252474319447"
+"checksum uuid 0.8.1 (git+https://github.com/uuid-rs/uuid)" = "<none>"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 toml = "0.4"
-uuid = { version = "0.6", features = ["v4"] }
+uuid = { git = "https://github.com/uuid-rs/uuid", version = "0.8", features = ["v4"] }
 dbus = "0.6"
 nix = "0.14.0"
 i3ipc = "0.8.2"

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -209,7 +209,7 @@ impl ConfigBlock for Backlight {
             None => BacklitDevice::default(),
         }?;
 
-        let id = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
         let brightness_file = device.brightness_file();
 
         let scrolling = config.scrolling;

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -471,7 +471,7 @@ impl ConfigBlock for Battery {
             _ => BatteryDriver::Sysfs,
         };
 
-        let id = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
         let device: Box<dyn BatteryDevice> = match driver {
             BatteryDriver::Upower => {
                 let out = UpowerDevice::from_device(&block_config.device)?;

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -164,7 +164,7 @@ impl ConfigBlock for Bluetooth {
     type Config = BluetoothConfig;
 
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id: String = Uuid::new_v4().simple().to_string();
+        let id: String = Uuid::new_v4().unwrap().to_string();
         let device = BluetoothDevice::from_mac(block_config.mac)?;
         device.monitor(id.clone(), send);
 

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -102,7 +102,7 @@ impl ConfigBlock for Cpu {
         }
 
         Ok(Cpu {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             update_interval: block_config.interval,
             output: TextWidget::new(config).with_icon("cpu"),
             prev_idles: [0; 32],

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -58,7 +58,7 @@ impl ConfigBlock for Custom {
 
     fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
         let mut custom = Custom {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             update_interval: block_config.interval,
             output: ButtonWidget::new(config.clone(), ""),
             command: None,

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -178,7 +178,7 @@ impl ConfigBlock for DiskSpace {
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         Ok(DiskSpace {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             update_interval: block_config.interval,
             disk_space: TextWidget::new(config).with_text("DiskSpace"),
             alias: block_config.alias,

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -69,7 +69,7 @@ impl ConfigBlock for Docker {
 
     fn new(block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
         Ok(Docker {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             text: TextWidget::new(config.clone())
                 .with_text("N/A")
                 .with_icon("docker"),

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -43,7 +43,7 @@ impl ConfigBlock for FocusedWindow {
     type Config = FocusedWindowConfig;
 
     fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
-        let id = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
         let id_clone = id.clone();
 
         let title_original = Arc::new(Mutex::new(String::from("")));

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -35,7 +35,7 @@ impl ConfigBlock for IBus {
     type Config = IBusConfig;
 
     fn new(_block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id: String = Uuid::new_v4().simple().to_string();
+        let id: String = Uuid::new_v4().unwrap().to_string();
         let id_copy = id.clone();
 
         let ibus_address = get_ibus_address()?;

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -316,7 +316,7 @@ impl ConfigBlock for KeyboardLayout {
     type Config = KeyboardLayoutConfig;
 
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id: String = Uuid::new_v4().simple().to_string();
+        let id: String = Uuid::new_v4().unwrap().to_string();
         let monitor: Box<dyn KeyboardLayoutMonitor> = match block_config.driver {
             KeyboardLayoutDriver::SetXkbMap => Box::new(SetXkbMap::new()?),
             KeyboardLayoutDriver::LocaleBus => {

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -77,7 +77,7 @@ impl ConfigBlock for Load {
         }
 
         Ok(Load {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             logical_cores,
             update_interval: block_config.interval,
             format: FormatTemplate::from_string(&block_config.format)

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -93,7 +93,7 @@ impl ConfigBlock for Maildir {
     ) -> Result<Self> {
         let widget = TextWidget::new(config.clone()).with_text("");
         Ok(Maildir {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             update_interval: block_config.interval,
             text: if block_config.icon {
                 widget.with_icon("mail")

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -425,7 +425,7 @@ impl ConfigBlock for Memory {
         let icons: bool = block_config.icons;
         let widget = ButtonWidget::new(config, "memory").with_text("");
         Ok(Memory {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             memtype: block_config.display_type,
             output: if icons {
                 (

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -103,7 +103,7 @@ impl ConfigBlock for Music {
     type Config = MusicConfig;
 
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id: String = Uuid::new_v4().simple().to_string();
+        let id: String = Uuid::new_v4().unwrap().to_string();
         let id_copy = id.clone();
 
         thread::spawn(move || {

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -428,7 +428,7 @@ impl ConfigBlock for Net {
         let init_tx_bytes = device.tx_bytes().unwrap_or(0);
         let wireless = device.is_wireless();
         let vpn = device.is_vpn();
-        let id = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
         Ok(Net {
             id: id.clone(),
             update_interval: block_config.interval,

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -156,7 +156,7 @@ impl ConfigBlock for NetworkManager {
     type Config = NetworkManagerConfig;
 
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id: String = Uuid::new_v4().simple().to_string();
+        let id: String = Uuid::new_v4().unwrap().to_string();
         let id_copy = id.clone();
         let dbus_conn = Connection::get_private(BusType::System)
             .block_error("networkmanager", "failed to establish D-Bus connection")?;

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -118,7 +118,7 @@ impl ConfigBlock for Notmuch {
             widget.set_icon("mail");
         }
         Ok(Notmuch {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             update_interval: block_config.interval,
             db: block_config.maildir,
             query: block_config.query,

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -118,9 +118,9 @@ impl ConfigBlock for NvidiaGpu {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = Uuid::new_v4().simple().to_string();
-        let id_memory = Uuid::new_v4().simple().to_string();
-        let id_fans = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
+        let id_memory = Uuid::new_v4().unwrap().to_string();
+        let id_fans = Uuid::new_v4().unwrap().to_string();
         let mut output = Command::new("nvidia-smi")
             .args(&[
                 "-i",

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -71,7 +71,7 @@ impl ConfigBlock for Pacman {
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         Ok(Pacman {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             update_interval: block_config.interval,
             format: FormatTemplate::from_string(&block_config.format)
                 .block_error("pacman", "Invalid format specified for pacman::format")?,

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -104,7 +104,7 @@ impl ConfigBlock for Pomodoro {
     type Config = PomodoroConfig;
 
     fn new(block_config: Self::Config, config: Config, _send: Sender<Task>) -> Result<Self> {
-        let id: String = Uuid::new_v4().simple().to_string();
+        let id: String = Uuid::new_v4().unwrap().to_string();
 
         Ok(Pomodoro {
             id: id.clone(),

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -660,7 +660,7 @@ impl ConfigBlock for Sound {
         config: Config,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
         let mut step_width = block_config.step_width;
         if step_width > 50 {
             step_width = 50;

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -118,7 +118,7 @@ impl ConfigBlock for SpeedTest {
         // Create all the things we are going to send and take for ourselves.
         let (send, recv): (Sender<()>, Receiver<()>) = unbounded();
         let vals = Arc::new(Mutex::new((false, vec![])));
-        let id = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
 
         // Make the update thread
         make_thread(recv, done, vals.clone(), block_config.clone(), id.clone());

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -109,7 +109,7 @@ impl ConfigBlock for Temperature {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
         Ok(Temperature {
             update_interval: block_config.interval,
             text: ButtonWidget::new(config, &id).with_icon("thermometer"),

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -51,7 +51,7 @@ impl ConfigBlock for Template {
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         Ok(Template {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             update_interval: block_config.interval,
             text: TextWidget::new(config.clone()).with_text("Template"),
             tx_update_request,

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -74,7 +74,7 @@ impl ConfigBlock for Time {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let i = Uuid::new_v4().simple().to_string();
+        let i = Uuid::new_v4().unwrap().to_string();
         Ok(Time {
             id: i.clone(),
             format: block_config.format,

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -73,7 +73,7 @@ impl ConfigBlock for Toggle {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
         Ok(Toggle {
             text: ButtonWidget::new(config, &id).with_content(block_config.text),
             command_on: block_config.command_on,

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -52,7 +52,7 @@ impl ConfigBlock for Uptime {
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         Ok(Uptime {
-            id: Uuid::new_v4().simple().to_string(),
+            id: Uuid::new_v4().unwrap().to_string(),
             update_interval: block_config.interval,
             text: TextWidget::new(config.clone()).with_icon("uptime"),
             tx_update_request,

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -231,7 +231,7 @@ impl ConfigBlock for Weather {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
         Ok(Weather {
             id: id.clone(),
             weather: ButtonWidget::new(config, &id),

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -228,7 +228,7 @@ impl ConfigBlock for Xrandr {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().unwrap().to_string();
         let mut step_width = block_config.step_width;
         if step_width > 50 {
             step_width = 50;


### PR DESCRIPTION
Merge this once the next release of `uuid` that contains [this](https://github.com/uuid-rs/uuid/pull/447) is out. (Make sure to update Cargo.* files first.)

Before (10): 
c2-chacha, cfg-if, getrandom, libc, ppv-lite86, rand, rand_chacha, rand_core, rand_hc, wasi

After (4):
 cfg-if, getrandom, libc, wasi
