### PR TITLE
Name threads for easier debugging

### DIFF
--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -223,31 +223,34 @@ impl ConfigBlock for Backlight {
 
         // Spin up a thread to watch for changes to the brightness file for the
         // device, and schedule an update if needed.
-        thread::spawn(move || {
-            let mut notify = Inotify::init().expect("Failed to start inotify");
-            notify
-                .add_watch(brightness_file, WatchMask::MODIFY)
-                .expect("Failed to watch brightness file");
+        thread::Builder::new()
+            .name("backlight".into())
+            .spawn(move || {
+                let mut notify = Inotify::init().expect("Failed to start inotify");
+                notify
+                    .add_watch(brightness_file, WatchMask::MODIFY)
+                    .expect("Failed to watch brightness file");
 
-            let mut buffer = [0; 1024];
-            loop {
-                let mut events = notify
-                    .read_events_blocking(&mut buffer)
-                    .expect("Error while reading inotify events");
+                let mut buffer = [0; 1024];
+                loop {
+                    let mut events = notify
+                        .read_events_blocking(&mut buffer)
+                        .expect("Error while reading inotify events");
 
-                if events.any(|event| event.mask.contains(EventMask::MODIFY)) {
-                    tx_update_request
-                        .send(Task {
-                            id: id.clone(),
-                            update_time: Instant::now(),
-                        })
-                        .unwrap();
+                    if events.any(|event| event.mask.contains(EventMask::MODIFY)) {
+                        tx_update_request
+                            .send(Task {
+                                id: id.clone(),
+                                update_time: Instant::now(),
+                            })
+                            .unwrap();
+                    }
+
+                    // Avoid update spam.
+                    thread::sleep(Duration::from_millis(250))
                 }
-
-                // Avoid update spam.
-                thread::sleep(Duration::from_millis(250))
-            }
-        });
+            })
+            .unwrap();
 
         Ok(backlight)
     }

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -119,34 +119,37 @@ impl BluetoothDevice {
     /// via the `update_request` channel.
     pub fn monitor(&self, id: String, update_request: Sender<Task>) {
         let path = self.path.clone();
-        thread::spawn(move || {
-            let con = dbus::ffidisp::Connection::get_private(dbus::ffidisp::BusType::System)
-                .expect("Failed to establish D-Bus connection.");
-            let rule = format!(
-                "type='signal',\
+        thread::Builder::new()
+            .name("bluetooth".into())
+            .spawn(move || {
+                let con = dbus::ffidisp::Connection::get_private(dbus::ffidisp::BusType::System)
+                    .expect("Failed to establish D-Bus connection.");
+                let rule = format!(
+                    "type='signal',\
                  path='{}',\
                  interface='org.freedesktop.DBus.Properties',\
                  member='PropertiesChanged'",
-                path
-            );
+                    path
+                );
 
-            // Skip the NameAcquired event.
-            con.incoming(10_000).next();
+                // Skip the NameAcquired event.
+                con.incoming(10_000).next();
 
-            con.add_match(&rule)
-                .expect("Failed to add D-Bus match rule.");
+                con.add_match(&rule)
+                    .expect("Failed to add D-Bus match rule.");
 
-            loop {
-                if con.incoming(10_000).next().is_some() {
-                    update_request
-                        .send(Task {
-                            id: id.clone(),
-                            update_time: Instant::now(),
-                        })
-                        .unwrap();
+                loop {
+                    if con.incoming(10_000).next().is_some() {
+                        update_request
+                            .send(Task {
+                                id: id.clone(),
+                                update_time: Instant::now(),
+                            })
+                            .unwrap();
+                    }
                 }
-            }
-        });
+            })
+            .unwrap();
     }
 }
 

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -110,7 +110,7 @@ impl ConfigBlock for Music {
         let id: String = Uuid::new_v4().to_simple().to_string();
         let id_copy = id.clone();
 
-        thread::spawn(move || {
+        thread::Builder::new().name("music".into()).spawn(move || {
             let c = Connection::get_private(BusType::Session).unwrap();
             c.add_match("interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',path='/org/mpris/MediaPlayer2'")
                 .unwrap();
@@ -125,7 +125,7 @@ impl ConfigBlock for Music {
                     }
                 }
             }
-        });
+        }).unwrap();
 
         let mut play: Option<ButtonWidget> = None;
         let mut prev: Option<ButtonWidget> = None;

--- a/src/input.rs
+++ b/src/input.rs
@@ -41,19 +41,22 @@ impl I3BarEvent {
 }
 
 pub fn process_events(sender: Sender<I3BarEvent>) {
-    thread::spawn(move || loop {
-        let mut input = String::new();
-        io::stdin().read_line(&mut input).unwrap();
+    thread::Builder::new()
+        .name("input".into())
+        .spawn(move || loop {
+            let mut input = String::new();
+            io::stdin().read_line(&mut input).unwrap();
 
-        // Take only the valid JSON object betweem curly braces (cut off leading bracket, commas and whitespace)
-        let slice = input.trim_start_matches(|c| c != '{');
-        let slice = slice.trim_end_matches(|c| c != '}');
+            // Take only the valid JSON object betweem curly braces (cut off leading bracket, commas and whitespace)
+            let slice = input.trim_start_matches(|c| c != '{');
+            let slice = slice.trim_end_matches(|c| c != '}');
 
-        if !slice.is_empty() {
-            let e: I3BarEvent = serde_json::from_str(slice).unwrap();
-            sender.send(e).unwrap();
-        }
-    });
+            if !slice.is_empty() {
+                let e: I3BarEvent = serde_json::from_str(slice).unwrap();
+                sender.send(e).unwrap();
+            }
+        })
+        .unwrap();
 }
 
 fn deserialize_mousebutton<'de, D>(deserializer: D) -> Result<MouseButton, D::Error>

--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -18,6 +18,9 @@ pub fn spawn_child_async(name: &str, args: &[&str]) -> io::Result<()> {
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .spawn()?;
-    thread::spawn(move || child.wait());
+    thread::Builder::new()
+        .name("subprocess".into())
+        .spawn(move || child.wait())
+        .unwrap();
     Ok(())
 }


### PR DESCRIPTION
This should make debugging at least a little easier/faster.
(Have been investigating a couple of different panics and this has come in handy,)

The unwraps are necessary because thread::Builder::spawn returns a Result, however the behaviour should be the same as before because thread::spawn panics on failure anyway.