### PR TITLE
Travis CI: Adjust to check all code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ env:
 script:
   - rustup component add rustfmt
   - cargo fmt -- --check
-  - cargo build --verbose
-  - cargo test --verbose
+  - cargo build --all-features --all-targets --verbose
+  - cargo test --all-features --all-targets --verbose

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
             name,
             matches.value_of("profile-runs").unwrap(),
             &config,
-            &tx_update_requests,
+            tx_update_requests,
         )?;
         return Ok(());
     }
@@ -291,12 +291,7 @@ fn profile_config(name: &str, runs: &str, config: &Config, update: Sender<Task>)
 }
 
 #[cfg(not(feature = "profiling"))]
-fn profile_config(
-    _name: &str,
-    _runs: &str,
-    _config: &Config,
-    _update: &Sender<Task>,
-) -> Result<()> {
+fn profile_config(_name: &str, _runs: &str, _config: &Config, _update: Sender<Task>) -> Result<()> {
     // TODO: Maybe we should just panic! here.
     Err(InternalError(
         "profile".to_string(),


### PR DESCRIPTION
Add `--all-features` and `--all-targets` to make sure all code gets
compiled. This uncovered a type mismatch with the `profiling` feature
enabled, which this commit fixes as well.