### PR TITLE
Read config from XDG_CONFIG_HOME by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,16 +83,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "2.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cpuprofiler"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +161,14 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "i3ipc"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,10 +185,10 @@ version = "0.13.0"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono-tz 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpuprofiler 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "i3ipc 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -466,14 +464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "time"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -561,7 +551,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum charset 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4f426e64df1c3de26cbf44593c6ffff5dbfd43bbf9de0d075058558126b3fc73"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
 "checksum chrono-tz 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e0e430fad0384e4defc3dc6b1223d1b886087a8bf9b7080e5ae027f73851ea15"
-"checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
 "checksum cpuprofiler 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "43f8479dbcfd2bbaa0c0c26779b913052b375981cdf533091f2127ea3d42e52b"
 "checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
@@ -572,6 +561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
+"checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum i3ipc 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a4e0c68a50475f32bf9a728de1198a8acc573ccdb24212db1192c874e37f302"
 "checksum inotify 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ad0bfe014aafc0f4e177fbe66c5f2b59ba59f66f58b022aa1963bbe71ab4118"
 "checksum inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dceb94c43f70baf4c4cd6afbc1e9037d4161dbe68df8a2cd4351a23319ee4fb"
@@ -606,10 +596,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
 "checksum syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "61b8f1b737f929c6516ba46a3133fd6d5215ad8a62f66760f851f7048aebedfb"
 "checksum terminal_size 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4f7fdb2a063032d361d9a72539380900bc3e0cd9ffc9ca8b677f8c855bae0f"
-"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
-"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8630752f979f1b6b87c49830a5e3784082545de63920d59fbaac252474319447"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ pulseaudio = ["libpulse-binding"]
 profiling = ["cpuprofiler", "progress"]
 
 [dependencies]
+getopts = "0.2"
 chrono = "0.4"
 chrono-tz = "0.5"
 lazy_static = "1.0"
@@ -37,10 +38,6 @@ notmuch = { optional = true, version = "0.1.1" }
 # for profiling blocks
 cpuprofiler = { version = "0.0.4", optional = true }
 progress = { version = "0.2", optional = true }
-
-[dependencies.clap]
-version = "2.31"
-default-features = false
 
 [dependencies.regex]
 version = "1.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,53 +38,80 @@ use crate::widgets::text::TextWidget;
 
 use crate::util::deserialize_file;
 
-use clap::{App, Arg, ArgMatches};
 use crossbeam_channel::{select, Receiver, Sender};
+use getopts::Options;
+use std::env;
+use std::path::PathBuf;
+
+const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
+const AUTHORS: Option<&'static str> = option_env!("CARGO_PKG_AUTHORS");
+const DESCRIPTION: Option<&'static str> = option_env!("CARGO_PKG_DESCRIPTION");
+
+fn print_version(program: &str) {
+    print!("{} {}", program, VERSION.unwrap_or("unknown"));
+}
+
+fn print_help(program: &str, opts: Options) {
+    print_version(program);
+    let header_msg = format!(
+        "\n{}\n{}\n",
+        AUTHORS.unwrap_or(""),
+        DESCRIPTION.unwrap_or("")
+    );
+    println!("{}", header_msg);
+    let usage_msg = format!("USAGE: {} [FLAGS] [OPTIONS] [CONFIG FILE]", program);
+    print!("{}", opts.usage(&usage_msg));
+}
 
 fn main() {
-    let mut builder = App::new("i3status-rs")
-        .version("0.13.0")
-        .author(
-            "Kai Greshake <development@kai-greshake.de>, Contributors on GitHub: \\
-             https://github.com/greshake/i3status-rust/graphs/contributors",
-        )
-        .about("Replacement for i3status for Linux, written in Rust")
-        .arg(
-            Arg::with_name("config")
-                .value_name("CONFIG_FILE")
-                .help("sets a toml config file")
-                .required(true)
-                .index(1),
-        )
-        .arg(
-            Arg::with_name("exit-on-error")
-                .help("exit on error rather than printing the error to i3bar and keep running")
-                .long("exit-on-error")
-                .takes_value(false),
-        );
+    let args: Vec<String> = env::args().collect();
+    let program_name = args[0].clone();
+
+    let mut opts = Options::new();
+    opts.optflag(
+        "",
+        "exit-on-error",
+        "Exit rather than printing errors to i3bar and continuing",
+    );
+    opts.optflag("h", "help", "Prints help information");
+    opts.optflag("V", "version", "Prints version information");
 
     if_debug!({
-        builder = builder
-            .arg(
-                Arg::with_name("profile")
-                    .long("profile")
-                    .takes_value(true)
-                    .help("A block to be profiled. Analyze block.profile with pprof"),
-            )
-            .arg(
-                Arg::with_name("profile-runs")
-                    .long("profile-runs")
-                    .takes_value(true)
-                    .default_value("10000")
-                    .help("How many times to execute update when profiling."),
-            );
+        opts.optopt("", "profile", "A block to be profiled. Creates a `block.profile` file that can be analyzed with `pprof`", "BLOCK NAME");
+        opts.optopt(
+            "",
+            "profile-runs",
+            "Number of times to execute update when profiling",
+            "POSITIVE NUMBER",
+        );
     });
 
-    let matches = builder.get_matches();
-    let exit_on_error = matches.is_present("exit-on-error");
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => panic!(f.to_string()),
+    };
+    if matches.opt_present("h") {
+        print_help(&program_name, opts);
+        return;
+    }
+    if matches.opt_present("V") {
+        print_version(&program_name);
+        return;
+    }
+    let exit_on_error = matches.opt_present("exit-on-error");
+    let profile_target = matches.opt_str("profile");
+    let profile_runs = matches
+        .opt_get_default("profile-runs", "1000".to_owned())
+        .unwrap();
+
+    let config_path = if !matches.free.is_empty() {
+        std::path::PathBuf::from(matches.free[0].clone())
+    } else {
+        util::xdg_config_home().join("i3status-rust/config.toml")
+    };
 
     // Run and match for potential error
-    if let Err(error) = run(&matches) {
+    if let Err(error) = run(&config_path, profile_target, &profile_runs) {
         if exit_on_error {
             eprintln!("{:?}", error);
             ::std::process::exit(1);
@@ -108,25 +135,19 @@ fn main() {
 }
 
 #[allow(unused_mut)] // TODO: Remove when fixed in chan_select
-fn run(matches: &ArgMatches) -> Result<()> {
+fn run(config_path: &PathBuf, profile_target: Option<String>, profile_runs: &str) -> Result<()> {
     // Now we can start to run the i3bar protocol
     print!("{{\"version\": 1, \"click_events\": true}}\n[");
 
-    // Read & parse the config file
-    let config: Config = deserialize_file(matches.value_of("config").unwrap())?;
+    let config: Config = deserialize_file(config_path.to_str().unwrap())?;
 
     // Update request channel
     let (tx_update_requests, rx_update_requests): (Sender<Task>, Receiver<Task>) =
         crossbeam_channel::unbounded();
 
     // In dev build, we might diverge into profiling blocks here
-    if let Some(name) = matches.value_of("profile") {
-        profile_config(
-            name,
-            matches.value_of("profile-runs").unwrap(),
-            &config,
-            tx_update_requests,
-        )?;
+    if let Some(name) = profile_target {
+        profile_config(&name, profile_runs, &config, tx_update_requests)?;
         return Ok(());
     }
 


### PR DESCRIPTION
Closes #465 by adding a `--config` option flag.

If the flag is omitted then we default to reading from:

1. $XDG_CONFIG_HOME/i3status-rust/config.toml
2. $HOME/.config/i3status-rust/config.toml if XDG_CONFIG_HOME is not set.

NOTE: This is a breaking change.
For users who happen to be using a different path to the above for their config files, they will have to update their invocation of i3status-rs to use the `--config` option. 
For other users they will need to remove the argument from their i3status-rs command.