### PR TITLE
Add connection check before starting thread to prevent panic

### DIFF
--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -61,6 +61,9 @@ impl ConfigBlock for FocusedWindow {
         let title_original = Arc::new(Mutex::new(String::from("")));
         let title = title_original.clone();
 
+        let _test_conn = I3EventListener::connect()
+            .block_error("focused_window", "failed to acquire connect to IPC")?;
+
         thread::spawn(move || {
             // establish connection.
             let mut listener = I3EventListener::connect().unwrap();


### PR DESCRIPTION
Closes #536 

It's unlikely that the IPC will go down between checking and starting the thread, so this should be fine for most cases.

A better solution would be #538 but the solution does not look trivial, so I think we should make this fix for now.