### PR TITLE
Add "one-shot" mode and add some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,5 @@ script:
   - rustup component add rustfmt
   - cargo fmt -- --check
   - cargo build --all-features --all-targets --verbose
+  - cargo build --all-features --all-targets --verbose --release
   - cargo test --all-features --all-targets --verbose

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,13 @@ fn main() {
                 .help("Exit rather than printing errors to i3bar and continuing")
                 .long("exit-on-error")
                 .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("one-shot")
+                .help("Print blocks once and exit")
+                .long("one-shot")
+                .takes_value(false)
+                .hidden(true),
         );
 
     if_debug!({
@@ -207,6 +214,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
     // Fires immediately for first updates
     let mut ttnu = crossbeam_channel::after(Duration::from_millis(0));
 
+    let one_shot = matches.is_present("one-shot");
     loop {
         // We use the message passing concept of channel selection
         // to avoid busy wait
@@ -239,6 +247,9 @@ fn run(matches: &ArgMatches) -> Result<()> {
         match scheduler.time_to_next_update() {
             Some(time) => ttnu = crossbeam_channel::after(time),
             None => ttnu = crossbeam_channel::after(Duration::from_secs(std::u64::MAX)),
+        }
+        if one_shot == true {
+            break Ok(());
         }
     }
 }

--- a/tests/run_binary.rs
+++ b/tests/run_binary.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+mod run_binary {
+    use std::process::Command;
+
+    #[test]
+    fn debug_build() {
+        let output = Command::new("./target/debug/i3status-rs")
+            .args(&["--one-shot", "./tests/testconfig1.toml"])
+            .status()
+            .expect("failed to execute process");
+        assert_eq!(output.success(), true);
+    }
+
+    #[test]
+    fn release_build() {
+        let output = Command::new("./target/release/i3status-rs")
+            .args(&["--one-shot", "./tests/testconfig1.toml"])
+            .status()
+            .expect("failed to execute process");
+        assert_eq!(output.success(), true);
+    }
+}

--- a/tests/testconfig1.toml
+++ b/tests/testconfig1.toml
@@ -1,0 +1,7 @@
+[theme]
+name = "plain"
+
+[[block]]
+block = "time"
+interval = 1
+format = "%a %d/%m %H:%M"


### PR DESCRIPTION
As discussed in #555 

Also added a simple config to be tested with the compiled binary. It can be run locally as well using `cargo test`, and is tested by Travis CI as well.