### PR TITLE
Clear cache for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,14 @@ addons:
       - libnotmuch-dev
       - pandoc
 cache: cargo
+before_cache:
+  - rm -rfv target/debug/incremental/i3status_rs-*
+  - rm -rfv target/debug/.fingerprint/i3status-rs-*
+  - rm -rfv target/debug/build/i3status_rs-*
+  - rm -rfv target/debug/deps/libi3status_rs-*
+  - rm -rfv target/debug/deps/i3status_rs-*
+  - rm -rfv target/debug/i3status-rs.d
+  - cargo clean --package i3status-rs
 os:
   - linux
 matrix:


### PR DESCRIPTION
This fixes #545, where the nightly builds are timing out at the cache step.
It is likely that our caches are too large and they cannot be expanded within the allowed time frame.

See:
https://travis-ci.community/t/builds-timeout-during-or-shortly-after-creating-directory-home-travis-cache-sccache/5001/2
https://gist.github.com/jkcclemens/000456ca646bd502cac0dbddcb8fa307
https://www.reddit.com/r/rust/comments/dbgril/caching_on_travis_when_building_rust_projects/