### PR TITLE
Include use_bits in blocks examples

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -522,7 +522,7 @@ use_bits = false
 
 Key | Values | Required | Default
 ----|--------|----------|--------
-`device` | Network interface to moniter (name from /sys/class/net) | Yes | `lo` (loopback interface)
+`device` | Network interface to monitor (name from /sys/class/net) | Yes | `lo` (loopback interface)
 `ssid` | Display network SSID (wireless only). | No | `false`
 `signal_strength` | Display WiFi signal strength (wireless only). | No | `false`
 `bitrate` | Display connection bitrate. | No | `false`
@@ -531,6 +531,7 @@ Key | Values | Required | Default
 `speed_down` | Display download speed. | No | `true`
 `graph_up` | Display a bar graph for upload speed. | No | `false`
 `graph_down` | Display a bar graph for download speed. | No | `false`
+`use_bits` | Display speeds in bits instead of bytes. | No | `false`
 `interval` | Update interval, in seconds. | No | `1`
 `hide_missing` | Whether to hide networks that are down/inactive completely. | No | `false`
 `hide_inactive` | Whether to hide networks that are missing. | No | `false`

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -350,7 +350,7 @@ pub struct NetConfig {
     pub speed_up: bool,
 
     /// Whether to show speeds in bits or bytes per second.
-    #[serde(default = "NetConfig::use_bits")]
+    #[serde(default = "NetConfig::default_use_bits")]
     pub use_bits: bool,
 
     /// Whether to show the download throughput indicator of active networks.
@@ -414,10 +414,6 @@ impl NetConfig {
         true
     }
 
-    fn use_bits() -> bool {
-        false
-    }
-
     fn default_speed_down() -> bool {
         true
     }
@@ -427,6 +423,10 @@ impl NetConfig {
     }
 
     fn default_graph_down() -> bool {
+        false
+    }
+
+    fn default_use_bits() -> bool {
         false
     }
 


### PR DESCRIPTION
Also fixed up a typo and made a serde default conform to other usages