### PR TITLE
blocks/temperature: Only take supported inputs into account

### DIFF
--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -151,6 +151,7 @@ impl Block for Temperature {
 
                 if rest[1].starts_with("input") {
                     match rest[2].parse::<i64>() {
+                        Ok(t) if t == 0 => Ok(()),
                         Ok(t) if t > -101 && t < 151 => {
                             temperatures.push(t);
                             Ok(())


### PR DESCRIPTION
On my machine (ThinkPad X1C 6th Gen, Linux 5.5.13), `sensors` shows 16
`temp*` temperatures for `thinkpad-isa`. All of those temperatures are
taken into account although most of them show 0°C.

It seems as not all sensors are supported. When trying to get the value
of a `temp*` value via `cat` in `/sys/class/hwmon/...`, I get an error
like this:

```
$ cat temp2_input
cat: temp2_input: No such device or address
```

Although those results can't be fetched and are shown as `0°C`,
the temperature block takes those into account when calculating the
average temperature. This patch ignores every input which returns `0` to
get the actual average temperature.