### PR TITLE
battery: only display remaining time when it is useful

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -513,7 +513,10 @@ impl Block for Battery {
                 Err(_) => "×".into(),
             };
             let time = match self.device.time_remaining() {
-                Ok(time) => format!("{}:{:02}", time / 60, time % 60),
+                Ok(time) => match time {
+                    0 => "".into(),
+                    _ => format!("{}:{:02}", time / 60, time % 60),
+                },
                 Err(_) => "×".into(),
             };
             let power = match self.device.power_consumption() {


### PR DESCRIPTION
Hi, I did not like the battery module displaying `0:00` most of the time. I am not sure about the space left behind, i.e. in `{percentage}% {time}`. It seems unwise to have a formatter that generates a space. which would allow doing `{percentage}%{time}` eliminating that trailing space, but looks weird in configs and leads to double spaces with existing configs.

It might be best to introduce a new formatter, but I'm not sure.