### PR TITLE
keyboard_layout: Add `format` argument

### DIFF
--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -18,6 +18,7 @@ use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::scheduler::Task;
+use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
@@ -295,6 +296,9 @@ impl dbus::ffidisp::MsgHandler for KbddMessageHandler {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(default, deny_unknown_fields)]
 pub struct KeyboardLayoutConfig {
+    #[serde(default = "KeyboardLayoutConfig::default_format")]
+    pub format: String,
+
     driver: KeyboardLayoutDriver,
     #[serde(
         default = "KeyboardLayoutConfig::default_interval",
@@ -304,6 +308,10 @@ pub struct KeyboardLayoutConfig {
 }
 
 impl KeyboardLayoutConfig {
+    fn default_format() -> String {
+        "{layout}".to_owned()
+    }
+
     fn default_interval() -> Duration {
         Duration::from_secs(60)
     }
@@ -314,6 +322,7 @@ pub struct KeyboardLayout {
     output: TextWidget,
     monitor: Box<dyn KeyboardLayoutMonitor>,
     update_interval: Option<Duration>,
+    format: FormatTemplate,
 }
 
 impl ConfigBlock for KeyboardLayout {
@@ -343,6 +352,10 @@ impl ConfigBlock for KeyboardLayout {
             output: TextWidget::new(config),
             monitor,
             update_interval,
+            format: FormatTemplate::from_string(&block_config.format).block_error(
+                "keyboard_layout",
+                "Invalid format specified for keyboard_layout",
+            )?,
         })
     }
 }
@@ -353,7 +366,11 @@ impl Block for KeyboardLayout {
     }
 
     fn update(&mut self) -> Result<Option<Duration>> {
-        self.output.set_text(self.monitor.keyboard_layout()?);
+        let layout = self.monitor.keyboard_layout()?;
+        let values = map!("{layout}" => layout);
+
+        self.output
+            .set_text(self.format.render_static_str(&values)?);
         Ok(self.update_interval)
     }
 


### PR DESCRIPTION
This PR add `format` argument to `keyboard_layout` block. For now, it only supports `{layout}` placeholder.

The reason for this addition is that I want to add an icon to my keyboard block, something like this:

```toml
[[block]]
block = "keyboard_layout"
driver = "localebus"
interval = 5
format = " {layout}"
```

I could have also added an icon to the keyboard block, however I prefer this approach since it is more flexible, and allow in the future support for more information in `keyboard_layout` block (like keyboard variants).

This is my first code in Rust so if there is any issues, please report it and I will try to fix it :+1: .