### PR TITLE
Kernel updates in the pacman block can be marked as critical

### DIFF
--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -199,7 +199,12 @@ fn has_kernel_update(list_of_packages: &String) -> Result<bool> {
     // check if there are linux kernel updates
     Ok(list_of_packages
         .lines()
-        .filter(|line| line.starts_with("linux "))
+        .filter(|line| {
+            line.starts_with("linux ")
+                || line.starts_with("linux-hardened ")
+                || line.starts_with("linux-lts ")
+                || line.starts_with("linux-zen ")
+        })
         .count()
         > 0)
 }

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -1,6 +1,3 @@
-use crate::scheduler::Task;
-use crossbeam_channel::Sender;
-use serde_derive::Deserialize;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
@@ -9,16 +6,19 @@ use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 
+use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
+use uuid::Uuid;
+
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
+use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-
-use uuid::Uuid;
 
 pub struct Pacman {
     output: ButtonWidget,

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -212,11 +212,6 @@ fn has_kernel_update() -> Result<bool> {
 impl Block for Pacman {
     fn update(&mut self) -> Result<Option<Duration>> {
         let count = get_update_count()?;
-        let has_kernel_update = if count > 0 {
-            has_kernel_update()?
-        } else {
-            false
-        };
         let values = map!("{count}" => count);
         self.output.set_text(match count {
             0 => self.format_up_to_date.render_static_str(&values)?,
@@ -226,7 +221,7 @@ impl Block for Pacman {
         self.output.set_state(match count {
             0 => State::Idle,
             _ => {
-                if self.kernel_updates_are_critical && has_kernel_update {
+                if self.kernel_updates_are_critical && has_kernel_update()? {
                     State::Critical
                 } else {
                     State::Info

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -50,6 +50,11 @@ pub struct PacmanConfig {
     /// Alternative format override for when no updates are available
     #[serde(default = "PacmanConfig::default_format")]
     pub format_up_to_date: String,
+
+    /// Indicate a `critical` state for the block if there are kernel updates available. Default
+    /// behaviour is that kernel updates are treated as any other package update
+    #[serde(default = "PacmanConfig::default_kernel_updates_are_critical")]
+    pub kernel_updates_are_critical: bool,
 }
 
 impl PacmanConfig {
@@ -59,6 +64,10 @@ impl PacmanConfig {
 
     fn default_format() -> String {
         "{count}".to_owned()
+    }
+
+    fn default_kernel_updates_are_critical() -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
I think the `pacman` block is a very useful indicator to remind me if I have to update my system again or not. Nevertheless, sometimes it is useful to know if there are any critical updates which might need a restart of the system (usually the kernel). Therefore, this patch will introduce a new configuration option (`kernel_updates_are_critical` which is by default `false`) to indicate the block as critical as soon as a kernel update is available. Otherwise the block behaves as before.