### PR TITLE
taskwarrior: Force rc.gc=off

### DIFF
--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -166,7 +166,7 @@ fn get_number_of_pending_tasks(tags: &Vec<String>) -> Result<u32> {
         Command::new("sh")
             .args(&[
                 "-c",
-                &format!("task -COMPLETED {} count", tags_to_filter(tags)),
+                &format!("task rc.gc=off -COMPLETED {} count", tags_to_filter(tags)),
             ])
             .output()
             .block_error(


### PR DESCRIPTION
Garbage Collection is a taskwarrior configuration option that is descibed here: https://taskwarrior.org/docs/ids.html.

It should be always disabled when calling `task` from scripts. Otherwise gc will modify ID numbers of the pending tasks when we complete or delete tasks from the another script.

This will also increase the speed of update for this widget (see "Configuration" section here: https://taskwarrior.org/docs/ids.html).