### PR TITLE
Use /sys/class/net/<device>/carrier instead of operstate in is_up()

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -72,8 +72,8 @@ impl NetworkDevice {
     /// Check whether this network device is in the `up` state. Note that a
     /// device that is not `up` is not necessarily `down`.
     pub fn is_up(&self) -> Result<bool> {
-        let carrier_file = self.device_path.join("carrier");
-        if !carrier_file.exists() {
+        let operstate_file = self.device_path.join("operstate");
+        if !operstate_file.exists() {
             // It seems more reasonable to treat these as inactive networks as
             // opposed to erroring out the entire block.
             Ok(false)
@@ -84,8 +84,18 @@ impl NetworkDevice {
         } else if self.ppp {
             Ok(true)
         } else {
-            let carrier = read_file(&carrier_file)?;
-            Ok(carrier == "1")
+            let operstate = read_file(&operstate_file)?;
+            let carrier_file = self.device_path.join("carrier");
+            if !carrier_file.exists() {
+                Ok(operstate == "up")
+            } else {
+                if operstate == "up" {
+                    Ok(true)
+                } else {
+                    let carrier = read_file(&carrier_file)?;
+                    Ok(carrier == "1")
+                }
+            }
         }
     }
 

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -72,8 +72,8 @@ impl NetworkDevice {
     /// Check whether this network device is in the `up` state. Note that a
     /// device that is not `up` is not necessarily `down`.
     pub fn is_up(&self) -> Result<bool> {
-        let operstate_file = self.device_path.join("operstate");
-        if !operstate_file.exists() {
+        let carrier_file = self.device_path.join("carrier");
+        if !carrier_file.exists() {
             // It seems more reasonable to treat these as inactive networks as
             // opposed to erroring out the entire block.
             Ok(false)
@@ -84,8 +84,8 @@ impl NetworkDevice {
         } else if self.ppp {
             Ok(true)
         } else {
-            let operstate = read_file(&operstate_file)?;
-            Ok(operstate == "up")
+            let carrier = read_file(&carrier_file)?;
+            Ok(carrier == "1")
         }
     }
 


### PR DESCRIPTION
When using android usb tethering in Arch Linux (kernel: Linux 5.6.5-zen4-1-zen),
`operstate` file shows `unknown`. But the `carrier` file correctly shows `1`.
  `ethtool` also correctly says `Link detected: yes`.