### PR TITLE
Allow to display per-core CPU metrics

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -173,6 +173,7 @@ Key | Values | Required | Default
 `interval` | Update interval, in seconds. | No | `1`
 `format` | A format string. Possible placeholders: `{barchart}` (barchart of each CPU's core utilization), `{utilization}` (average CPU utilization in percent) and `{frequency}` (CPU frequency). | No | `"{utilization}%"`
 `frequency` | Deprecated in favour of `format`. Sets format to `{utilization}% {frequency}GHz` | No | `false`
+`per_core` | Display CPU frequencies and utilization per core. | No | `false`
 
 
 ## Custom

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -17,10 +17,13 @@ use std::io::BufReader;
 
 use uuid::Uuid;
 
+/// Maximum number of CPUs we support.
+const MAX_CPUS: usize = 32;
+
 pub struct Cpu {
     output: TextWidget,
-    prev_idles: [u64; 32],
-    prev_non_idles: [u64; 32],
+    prev_idles: [u64; MAX_CPUS],
+    prev_non_idles: [u64; MAX_CPUS],
     id: String,
     update_interval: Duration,
     minimum_info: u64,
@@ -110,8 +113,8 @@ impl ConfigBlock for Cpu {
             id: Uuid::new_v4().to_simple().to_string(),
             update_interval: block_config.interval,
             output: TextWidget::new(config).with_icon("cpu"),
-            prev_idles: [0; 32],
-            prev_non_idles: [0; 32],
+            prev_idles: [0; MAX_CPUS],
+            prev_non_idles: [0; MAX_CPUS],
             minimum_info: block_config.info,
             minimum_warning: block_config.warning,
             minimum_critical: block_config.critical,
@@ -154,8 +157,8 @@ impl Block for Cpu {
             freq = (freq / (n_cpu as f32) / 1000.0) as f32;
         }
 
-        // Read data from a maximum of 32 CPU cores, if a barchart is displayed
-        let max_cpus = if self.has_barchart { 32 } else { 1 };
+        // Read data from a maximum of `MAX_CPUS` CPU cores, if a barchart is displayed
+        let max_cpus = if self.has_barchart { MAX_CPUS } else { 1 };
         let mut cpu_utilizations = vec![0.0; max_cpus];
 
         let mut cpu_i = 0;
@@ -196,7 +199,7 @@ impl Block for Cpu {
                 self.prev_idles[cpu_i] = idle;
                 self.prev_non_idles[cpu_i] = non_idle;
                 cpu_i += 1;
-                if cpu_i >= max_cpus {
+                if cpu_i >= MAX_CPUS {
                     break;
                 };
             }

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -29,6 +29,7 @@ pub struct Cpu {
     format: FormatTemplate,
     has_barchart: bool,
     has_frequency: bool,
+    per_core: bool,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -60,6 +61,10 @@ pub struct CpuConfig {
     /// Format override
     #[serde(default = "CpuConfig::default_format")]
     pub format: String,
+
+    /// Compute the metrics (utilization and frequency) per core.
+    #[serde(default)]
+    pub per_core: bool,
 }
 
 impl CpuConfig {
@@ -114,6 +119,7 @@ impl ConfigBlock for Cpu {
                 .block_error("cpu", "Invalid format specified for cpu")?,
             has_frequency: format.contains("{frequency}"),
             has_barchart: format.contains("{barchart}"),
+            per_core: block_config.per_core,
         })
     }
 }


### PR DESCRIPTION
This PR introduce a new config parameter for the block `cpu`: `per_core`.

When set, the block will display the metrics for each core instead of computing an average.
This work for both frequency and utilization percentage.

Closes: #603 