### PR TITLE
Allow pacman critical updates config using regex

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -634,6 +634,7 @@ interval = 10
 format = "{count} updates available"
 format_singular = "{count} update available"
 format_up_to_date = "system up to date"
+critical_updates_regex = "(linux |linux-lts|linux-zen)"
 ```
 
 ### Options
@@ -644,6 +645,7 @@ Key | Values | Required | Default
 `format` | Format override | No | `"{count}"`
 `format_singular` | Format override if exactly one update is available | No | `"{count}"`
 `format_up_to_date` | Format override if no updates are available | No | `"{count}"`
+`critical_updates_regex` | Display block as critical if updates matching regex are available | No | `None`
 
 ### Available Format Keys
 


### PR DESCRIPTION
This PR adds `critical_updates_regex` field to pacman block configuration.

Pending updates matching this regular expression are displayed as critical (this a follow up of #595)

The regex showcased in pacman's block documentation has been tested:

```rust
    #[test]
    fn test_kernel_critical_updates_regex() {
        let regex: Regex = Regex::new("(linux |linux-lts|linux-zen|linux-hardened)").unwrap();
        let kernel_update = "linux x.x -> y.y";
        assert!(has_critical_update(kernel_update, &regex));
        let kernel_update = "linux-lts x.x -> y.y";
        assert!(has_critical_update(kernel_update, &regex));
        let kernel_update = "linux-zen x.x -> y.y";
        assert!(has_critical_update(kernel_update, &regex));
        let kernel_update = "linux-hardened x.x -> y.y";
        assert!(has_critical_update(kernel_update, &regex));
        let kernel_update = concat!(
            "not-a-kernel-update x.x -> y.y\n",
            "linux x.x -> y.y\n",
            "another-update x.x -> y.y\n"
        );
        assert!(has_critical_update(kernel_update, &regex));
        let not_kernel_update = "linux-foo x.x -> y.y";
        assert!(!has_critical_update(not_kernel_update, &regex));
    }
```

> IMO this test does not owe to be part of the test suite.

:warning: config file syntax introduced with #595 is no longer supported with this PR (`kernel_updates_are_critical` field has been removed), the feature is still supported  though: use `critical_updates_regex = "(linux |linux-lts|linux-zen|linux-hardened)"` instead.