### PR TITLE
backlight: read from actual_brightness as per kernel docs

### DIFF
--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -161,7 +161,7 @@ impl BacklitDevice {
 
     /// The brightness file itself.
     pub fn brightness_file(&self) -> PathBuf {
-        self.device_path.join("brightness")
+        self.device_path.join("actual_brightness")
     }
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/greshake/i3status-rust/issues/447

Other bars do this too: https://github.com/polybar/polybar/commit/627c4ac2af477826e26d799abe790d5c3b0f5aed