### PR TITLE
toggle block: only toggle if command exited successfully

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -897,7 +897,7 @@ Key | Values | Required | Default
 
 ## Toggle
 
-Creates a toggle block. You can add commands to be executed to disable the toggle (`command_off`), and to enable it (`command_on`).
+Creates a toggle block. You can add commands to be executed to disable the toggle (`command_off`), and to enable it (`command_on`). If these command exit with a non-zero status, the block will not be toggled.
 You also need to specify a command to determine the (initial) state of the toggle (`command_state`). When the command outputs nothing, the toggle is disabled, otherwise enabled.
 By specifying the `interval` property you can let the `command_state` be executed continuously.
 

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -118,19 +118,24 @@ impl Block for Toggle {
         if let Some(ref name) = e.name {
             if name.as_str() == self.id {
                 let cmd = if self.toggled {
-                    self.toggled = false;
-                    self.text.set_icon(self.icon_off.as_str());
                     &self.command_off
                 } else {
-                    self.toggled = true;
-                    self.text.set_icon(self.icon_on.as_str());
                     &self.command_on
                 };
 
-                Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_owned()))
+                let status = Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_owned()))
                     .args(&["-c", cmd])
-                    .output()
+                    .status()
                     .block_error("toggle", "failed to run toggle command")?;
+
+                if status.success() {
+                    self.toggled = !self.toggled;
+                    self.text.set_icon(if self.toggled {
+                        self.icon_on.as_str()
+                    } else {
+                        self.icon_off.as_str()
+                    })
+                };
             }
         }
 


### PR DESCRIPTION
Resolves #167

Old behaviour: block would toggle state regardless of whether `command_on`/`command_off` exited successfully.

New behaviour: block only toggle states if `command_on`/`command_off` exited successfully (non-zero exit status).

I left `command_state` alone for now.

Future work could make change the colour of the block when command_on/off didn't run successfully, otherwise a user might think the bar is just being unresponsive.