### PR TITLE
battery block: fallback for determining power consumption

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -182,6 +182,10 @@ impl BatteryDevice for PowerSupplyDevice {
             ));
         };
 
+        // If the device driver uses the combination of energy_full, energy_now and power_now,
+        // all values (full, fill, and usage) are in Watts, while if it uses charge_full, charge_now
+        // and current_now, they're in Amps. In all 3 equations below the units cancel out and
+        // we're left with a time value.
         let status = self.status()?;
         match status.as_str() {
             "Full" => Ok(((full as f64 / usage) * 60.0) as u64),
@@ -573,6 +577,7 @@ impl Block for Battery {
                 Ok(time) => format!("{}:{:02}", time / 60, time % 60),
                 Err(_) => "×".into(),
             };
+            // convert µW to W for display
             let power = match self.device.power_consumption() {
                 Ok(power) => format!("{:.2}", power as f64 / 1000.0 / 1000.0),
                 Err(_) => "×".into(),

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -64,7 +64,7 @@ impl PowerSupplyDevice {
             ));
         }
 
-        // Read charge_full exactly once, if it exists.
+        // Read charge_full exactly once, if it exists, units are µAh
         let charge_full = if device_path.join("charge_full").exists() {
             Some(
                 read_file("battery", &device_path.join("charge_full"))?
@@ -75,7 +75,7 @@ impl PowerSupplyDevice {
             None
         };
 
-        // Read energy_full exactly once, if it exists.
+        // Read energy_full exactly once, if it exists. Units are µWh.
         let energy_full = if device_path.join("energy_full").exists() {
             Some(
                 read_file("battery", &device_path.join("energy_full"))?
@@ -135,6 +135,7 @@ impl BatteryDevice for PowerSupplyDevice {
     }
 
     fn time_remaining(&self) -> Result<u64> {
+        // Units are µWh
         let full = if self.energy_full.is_some() {
             self.energy_full.unwrap()
         } else if self.charge_full.is_some() {
@@ -146,6 +147,7 @@ impl BatteryDevice for PowerSupplyDevice {
             ));
         };
 
+        // Units are µWh/µAh
         let energy_path = self.device_path.join("energy_now");
         let charge_path = self.device_path.join("charge_now");
         let fill = if energy_path.exists() {

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -216,7 +216,7 @@ impl BatteryDevice for PowerSupplyDevice {
             let voltage = read_file("battery", &voltage_path)?
                 .parse::<u64>()
                 .block_error("battery", "failed to parse voltage_now")?;
-            Ok(current * voltage)
+            Ok((current * voltage) / 1_000_000)
         } else {
             Err(BlockError(
                 "battery".to_string(),


### PR DESCRIPTION
Resolves #429 by implementing the simple approach mentioned here: https://github.com/greshake/i3status-rust/issues/429#issuecomment-626132440. This could be worked on in the future for better hysteresis.

I don't have a battery operated device to test with at the moment so would appreciate if @travankor, @GladOSkar could check this out if they have time.