### PR TITLE
music block: add smart_trim config option

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -515,6 +515,7 @@ Key | Values | Required | Default
 `marquee` | Bool to specify if a marquee style rotation should be used if the title + artist is longer than max-width | No | `true`
 `marquee_interval` | Marquee interval in seconds. This is the delay between each rotation. | No | `10`
 `marquee_speed` | Marquee speed in seconds. This is the scrolling time used per character. | No | `0.5`
+`smart_trim` | When marquee rotation is disabled and the title + artist is longer than max-width, trim from both the artist and the title in proportion to their lengths, to try and show the most information possible. | No | `false`
 `buttons` | Array of control buttons to be displayed. Options are prev (previous title), play (play/pause) and next (next title) | No | `[]`
 `on_collapsed_click` | Shell command to run when the music block is clicked while collapsed. | No | None
 


### PR DESCRIPTION
This allows the block to be a little smarter in how it trims text to fit within
a max width. More precisely - it will trim from both the artist and the title
in proportion to their lengths, to try and show the most information possible.

Based on work done by https://github.com/jgbyrne mentioned here:
https://github.com/greshake/i3status-rust/issues/189

Resolves #189