### PR TITLE
Fix pango escaping

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -16,7 +16,7 @@ use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
-use crate::util::format_percent_bar;
+use crate::util::{escape_pango_text, format_percent_bar};
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::graph::GraphWidget;
@@ -689,7 +689,8 @@ impl Net {
             if let Some(s) = ssid {
                 let mut truncated = s;
                 truncated.truncate(self.max_ssid_width);
-                ssid_widget.set_text(truncated);
+                // SSID names can contain chars that need escaping
+                ssid_widget.set_text(escape_pango_text(truncated));
             }
         }
         Ok(())

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -2,7 +2,6 @@ use serde_json::value::Value;
 
 use super::super::widget::I3BarWidget;
 use crate::config::Config;
-use crate::util::escape_pango_text;
 use crate::widget::State;
 
 #[derive(Clone, Debug)]
@@ -81,7 +80,7 @@ impl ButtonWidget {
         self.rendered = json!({
             "full_text": format!("{}{} ",
                                 self.icon.clone().unwrap_or_else(|| String::from(" ")),
-                                escape_pango_text(self.content.clone().unwrap_or_else(|| String::from("")))),
+                                self.content.clone().unwrap_or_else(|| String::from(""))),
             "separator": false,
             "name": self.id.clone(),
             "separator_block_width": 0,


### PR DESCRIPTION
Reverts part of #650 as the escaping was being done in the wrong place.
Unilaterally escaping everything means pango formatting set by users in their config will be broken.
Instead, we need to escape on a per-block, per-item basis.
For now, the net block's SSID display has been identified a source of unintended pango formatting, so that has been escaped. There may be others, they will have to be done as discovered.