### PR TITLE
toggle block: set block colour if toggle command fails

### DIFF
--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -123,12 +123,12 @@ impl Block for Toggle {
                     &self.command_on
                 };
 
-                let status = Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_owned()))
+                let output = Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_owned()))
                     .args(&["-c", cmd])
-                    .status()
+                    .output()
                     .block_error("toggle", "failed to run toggle command")?;
 
-                if status.success() {
+                if output.status.success() {
                     self.toggled = !self.toggled;
                     self.text.set_icon(if self.toggled {
                         self.icon_on.as_str()

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -10,7 +10,7 @@ use crate::config::Config;
 use crate::de::deserialize_opt_duration;
 use crate::errors::*;
 use crate::input::I3BarEvent;
-use crate::widget::I3BarWidget;
+use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 use uuid::Uuid;
@@ -107,6 +107,8 @@ impl Block for Toggle {
             }
         });
 
+        self.text.set_state(State::Idle);
+
         Ok(self.update_interval)
     }
 
@@ -129,12 +131,15 @@ impl Block for Toggle {
                     .block_error("toggle", "failed to run toggle command")?;
 
                 if output.status.success() {
+                    self.text.set_state(State::Idle);
                     self.toggled = !self.toggled;
                     self.text.set_icon(if self.toggled {
                         self.icon_on.as_str()
                     } else {
                         self.icon_off.as_str()
                     })
+                } else {
+                    self.text.set_state(State::Critical);
                 };
             }
         }


### PR DESCRIPTION
#648 made it so the toggle block only toggles if the respective toggle
command exited successfully. However from a user point of view there was no
feedback, so the user might think their clicks are not registering when in
they are. This PR sets the block state to Critical when a toggle command
fails in order to give visual feedback. The state is reset once clicked again
and the command succeeds, or until the next time the command_state cmd is run.