### PR TITLE
focused_window: fix freeze on closing window

### DIFF
--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -136,8 +136,6 @@ impl ConfigBlock for FocusedWindow {
                                         let mut title = title_original.lock().unwrap();
                                         if name == *title {
                                             *title = String::from("");
-                                            let mut marks = title_original.lock().unwrap();
-                                            *marks = String::from("");
                                             tx.send(Task {
                                                 id: id_clone.clone(),
                                                 update_time: Instant::now(),


### PR DESCRIPTION
One small fix for the new marks-related changed. Otherwise, the bar freezes when closing windows.