### PR TITLE
Enable clippy for all features and targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
 script:
   - man/generate.sh man/test.1 && diff man/test.1 man/i3status-rs.1 || true
   - cargo fmt -- --check
-  - cargo clippy -- -D warnings
+  - cargo clippy --all-features --all-targets
   - cargo build --all-features --all-targets --verbose
   - cargo build --all-features --all-targets --verbose --release
   - cargo test --all-features --all-targets --verbose

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::time::Duration;
 
 use crossbeam_channel::Sender;
-use notmuch;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
@@ -98,8 +97,8 @@ impl NotmuchConfig {
     }
 }
 
-fn run_query(db_path: &String, query_string: &String) -> std::result::Result<u32, notmuch::Error> {
-    let db = notmuch::Database::open(db_path, notmuch::DatabaseMode::ReadOnly)?;
+fn run_query(db_path: &str, query_string: &str) -> std::result::Result<u32, notmuch::Error> {
+    let db = notmuch::Database::open(&db_path, notmuch::DatabaseMode::ReadOnly)?;
     let query = db.create_query(query_string)?;
     Ok(query.count_messages()?)
 }
@@ -112,7 +111,7 @@ impl ConfigBlock for Notmuch {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let mut widget = TextWidget::new(config.clone());
+        let mut widget = TextWidget::new(config);
         if !block_config.no_icon {
             widget.set_icon("mail");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,6 @@ mod widgets;
 
 #[cfg(feature = "profiling")]
 use cpuprofiler::PROFILER;
-#[cfg(feature = "profiling")]
-use progress;
 
 use std::collections::HashMap;
 use std::ops::DerefMut;
@@ -286,12 +284,8 @@ fn profile_config(name: &str, runs: &str, config: &Config, update: Sender<Task>)
         .configuration_error("failed to parse --profile-runs as an integer")?;
     for &(ref block_name, ref block_config) in &config.blocks {
         if block_name == name {
-            let mut block = create_block(
-                &block_name,
-                block_config.clone(),
-                config.clone(),
-                update.clone(),
-            )?;
+            let mut block =
+                create_block(&block_name, block_config.clone(), config.clone(), update)?;
             profile(profile_runs, &block_name, block.deref_mut());
             break;
         }


### PR DESCRIPTION
This fixes up a few more clippy lints necessary to enable clippy for all features and targets and enables the check in travis.