### PR TITLE
Fix #89 support running a block only once

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -191,11 +191,15 @@ For further customisation, use the `json` option and have the shell command outp
 
 ### Examples
 
+Display temperature, update every 10 seconds:
+
 ```toml
 [[block]]
 block = "custom"
 command = ''' cat /sys/class/thermal/thermal_zone0/temp | awk '{printf("%.1f\n",$1/1000)}' '''
 ```
+
+Display temperature, update every 1 second, run `<command` when block is clicked:
 
 ```toml
 [[block]]
@@ -205,11 +209,22 @@ on_click = "<command>"
 interval = 1
 ```
 
+Use JSON output:
+
 ```toml
 [[block]]
 block = "custom"
 command = "echo '{\"icon\":\"weather_thunder\",\"state\":\"Critical\", \"text\": \"Danger!\"}'"
 json = true
+```
+
+Display kernel, update the block only once:
+
+```toml
+[[block]]
+block = "custom"
+command = "uname -r"
+interval = "once"
 ```
 
 ### Options
@@ -221,7 +236,7 @@ Key | Values | Required | Default
 `command` | Shell command to execute & display. | No | None
 `on_click` | Command to execute when the button is clicked. The command will be passed to whatever is specified in your `$SHELL` variable and - if not set - fallback to `sh`. | No | None
 `cycle` | Commands to execute and change when the button is clicked. | No | None
-`interval` | Update interval, in seconds. | No | `10`
+`interval` | Update interval, in seconds (or `"once"` or `"Once"` to update only once). | No | `10`
 `json` | Use JSON from command output to format the block. If the JSON is not valid, the block will error out. | No | `false`
 
 

--- a/blocks.md
+++ b/blocks.md
@@ -199,7 +199,7 @@ block = "custom"
 command = ''' cat /sys/class/thermal/thermal_zone0/temp | awk '{printf("%.1f\n",$1/1000)}' '''
 ```
 
-Display temperature, update every 1 second, run `<command` when block is clicked:
+Cycle between "ON" and "OFF", update every 1 second, run `<command>` when block is clicked:
 
 ```toml
 [[block]]

--- a/blocks.md
+++ b/blocks.md
@@ -236,7 +236,7 @@ Key | Values | Required | Default
 `command` | Shell command to execute & display. | No | None
 `on_click` | Command to execute when the button is clicked. The command will be passed to whatever is specified in your `$SHELL` variable and - if not set - fallback to `sh`. | No | None
 `cycle` | Commands to execute and change when the button is clicked. | No | None
-`interval` | Update interval, in seconds (or `"once"` or `"Once"` to update only once). | No | `10`
+`interval` | Update interval, in seconds (or `"once"` to update only once). | No | `10`
 `json` | Use JSON from command output to format the block. If the JSON is not valid, the block will error out. | No | `false`
 
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -78,10 +78,16 @@ use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::widget::I3BarWidget;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Refresh {
     Every(Duration),
     Once,
+}
+
+impl Default for Refresh {
+    fn default() -> Self {
+        Refresh::Once
+    }
 }
 
 impl Into<Refresh> for Duration {

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -79,20 +79,20 @@ use crate::scheduler::Task;
 use crate::widget::I3BarWidget;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum Refresh {
+pub enum Update {
     Every(Duration),
     Once,
 }
 
-impl Default for Refresh {
+impl Default for Update {
     fn default() -> Self {
-        Refresh::Once
+        Update::Once
     }
 }
 
-impl Into<Refresh> for Duration {
-    fn into(self) -> Refresh {
-        Refresh::Every(self)
+impl Into<Update> for Duration {
+    fn into(self) -> Update {
+        Update::Every(self)
     }
 }
 
@@ -104,7 +104,7 @@ pub trait Block {
     fn view(&self) -> Vec<&dyn I3BarWidget>;
 
     /// Forces an update of the internal state of the block.
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         Ok(None)
     }
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -78,6 +78,18 @@ use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::widget::I3BarWidget;
 
+#[derive(Clone)]
+pub enum Refresh {
+    Every(Duration),
+    Once,
+}
+
+impl Into<Refresh> for Duration {
+    fn into(self) -> Refresh {
+        Refresh::Every(self)
+    }
+}
+
 pub trait Block {
     /// A unique id for the block.
     fn id(&self) -> &str;
@@ -86,7 +98,7 @@ pub trait Block {
     fn view(&self) -> Vec<&dyn I3BarWidget>;
 
     /// Forces an update of the internal state of the block.
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         Ok(None)
     }
 

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -25,6 +25,7 @@ use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 /// Read a brightness value from the given path.
 fn read_brightness(device_file: &Path) -> Result<u64> {
@@ -263,7 +264,7 @@ impl ConfigBlock for Backlight {
 }
 
 impl Block for Backlight {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let brightness = self.device.brightness()?;
         self.output.set_text(format!("{}%", brightness));
         match brightness {

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -18,7 +18,7 @@ use inotify::{EventMask, Inotify, WatchMask};
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::{Config, LogicalDirection, Scrolling};
 use crate::errors::*;
@@ -264,7 +264,7 @@ impl ConfigBlock for Backlight {
 }
 
 impl Block for Backlight {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let brightness = self.device.brightness()?;
         self.output.set_text(format!("{}%", brightness));
         match brightness {

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -18,6 +18,7 @@ use inotify::{EventMask, Inotify, WatchMask};
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::{Config, LogicalDirection, Scrolling};
 use crate::errors::*;
@@ -25,7 +26,6 @@ use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 /// Read a brightness value from the given path.
 fn read_brightness(device_file: &Path) -> Result<u64> {

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -22,6 +22,7 @@ use crate::scheduler::Task;
 use crate::util::{format_percent_bar, read_file, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 /// A battery device can be queried for a few properties relevant to the user.
 pub trait BatteryDevice {
@@ -554,7 +555,7 @@ impl ConfigBlock for Battery {
 }
 
 impl Block for Battery {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         // TODO: Maybe use dbus to immediately signal when the battery state changes.
 
         let status = self.device.status()?;
@@ -626,7 +627,7 @@ impl Block for Battery {
         }
 
         match self.driver {
-            BatteryDriver::Sysfs => Ok(Some(self.update_interval)),
+            BatteryDriver::Sysfs => Ok(Some(self.update_interval.into())),
             BatteryDriver::Upower => Ok(None),
         }
     }

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -14,6 +14,7 @@ use dbus::ffidisp::stdintf::org_freedesktop_dbus::Properties;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -22,7 +23,6 @@ use crate::scheduler::Task;
 use crate::util::{format_percent_bar, read_file, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 /// A battery device can be queried for a few properties relevant to the user.
 pub trait BatteryDevice {

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -14,7 +14,7 @@ use dbus::ffidisp::stdintf::org_freedesktop_dbus::Properties;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -555,7 +555,7 @@ impl ConfigBlock for Battery {
 }
 
 impl Block for Battery {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         // TODO: Maybe use dbus to immediately signal when the battery state changes.
 
         let status = self.device.status()?;

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -1,6 +1,6 @@
 use serde_derive::Deserialize;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Instant};
 
 use crossbeam_channel::Sender;
 use dbus::ffidisp::stdintf::org_freedesktop_dbus::{ObjectManager, Properties};
@@ -13,6 +13,7 @@ use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 pub struct BluetoothDevice {
     pub path: String,
@@ -193,7 +194,7 @@ impl Block for Bluetooth {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let connected = self.device.connected();
         self.output.set_text(self.device.label.to_string());
         self.output

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -1,11 +1,12 @@
 use serde_derive::Deserialize;
 use std::thread;
-use std::time::{Instant};
+use std::time::Instant;
 
 use crossbeam_channel::Sender;
 use dbus::ffidisp::stdintf::org_freedesktop_dbus::{ObjectManager, Properties};
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::errors::*;
@@ -13,7 +14,6 @@ use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 pub struct BluetoothDevice {
     pub path: String,

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -6,7 +6,7 @@ use crossbeam_channel::Sender;
 use dbus::ffidisp::stdintf::org_freedesktop_dbus::{ObjectManager, Properties};
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::errors::*;
@@ -194,7 +194,7 @@ impl Block for Bluetooth {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let connected = self.device.connected();
         self.output.set_text(self.device.label.to_string());
         self.output

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -15,6 +15,7 @@ use crate::scheduler::Task;
 use crate::util::{format_percent_bar, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 /// Maximum number of CPUs we support.
 const MAX_CPUS: usize = 32;
@@ -130,7 +131,7 @@ impl ConfigBlock for Cpu {
 }
 
 impl Block for Cpu {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let f = File::open("/proc/stat")
             .block_error("cpu", "Your system doesn't support /proc/stat")?;
         let f = BufReader::new(f);
@@ -236,7 +237,7 @@ impl Block for Cpu {
         self.output
             .set_text(self.format.render_static_str(&values)?);
 
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -7,7 +7,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -131,7 +131,7 @@ impl ConfigBlock for Cpu {
 }
 
 impl Block for Cpu {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let f = File::open("/proc/stat")
             .block_error("cpu", "Your system doesn't support /proc/stat")?;
         let f = BufReader::new(f);

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -7,6 +7,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -15,7 +16,6 @@ use crate::scheduler::Task;
 use crate::util::{format_percent_bar, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 /// Maximum number of CPUs we support.
 const MAX_CPUS: usize = 32;

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -8,6 +8,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_opt_duration;
@@ -17,7 +18,6 @@ use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 pub struct Custom {
     id: String,
@@ -35,8 +35,8 @@ pub struct Custom {
 pub struct CustomConfig {
     /// Update interval in seconds
     #[serde(
-    default = "CustomConfig::default_interval",
-    deserialize_with = "deserialize_opt_duration"
+        default = "CustomConfig::default_interval",
+        deserialize_with = "deserialize_opt_duration"
     )]
     pub interval: Option<Duration>,
 
@@ -70,12 +70,10 @@ impl ConfigBlock for Custom {
     fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
         let mut custom = Custom {
             id: Uuid::new_v4().to_simple().to_string(),
-            update_interval:
-            match block_config.interval {
+            update_interval: match block_config.interval {
                 None => Refresh::Once,
                 Some(d) => Refresh::Every(d),
-            }
-            ,
+            },
             output: ButtonWidget::new(config.clone(), ""),
             command: None,
             on_click: None,

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -149,7 +149,7 @@ impl Block for Custom {
             self.output.set_text(raw_output);
         }
 
-        Ok(Some(self.update_interval.clone().into()))
+        Ok(Some(self.update_interval.clone()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -8,10 +8,10 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
-use crate::de::deserialize_refresh;
+use crate::de::deserialize_update;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
@@ -21,7 +21,7 @@ use crate::widgets::button::ButtonWidget;
 
 pub struct Custom {
     id: String,
-    update_interval: Refresh,
+    update_interval: Update,
     output: ButtonWidget,
     command: Option<String>,
     on_click: Option<String>,
@@ -36,9 +36,9 @@ pub struct CustomConfig {
     /// Update interval in seconds
     #[serde(
         default = "CustomConfig::default_interval",
-        deserialize_with = "deserialize_refresh"
+        deserialize_with = "deserialize_update"
     )]
-    pub interval: Refresh,
+    pub interval: Update,
 
     /// Shell Command to execute & display
     pub command: Option<String>,
@@ -55,8 +55,8 @@ pub struct CustomConfig {
 }
 
 impl CustomConfig {
-    fn default_interval() -> Refresh {
-        Refresh::Every(Duration::new(10, 0))
+    fn default_interval() -> Update {
+        Update::Every(Duration::new(10, 0))
     }
 
     fn default_json() -> bool {
@@ -115,7 +115,7 @@ struct Output {
 }
 
 impl Block for Custom {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let command_str = self
             .cycle
             .as_mut()

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -8,7 +8,7 @@ use dbus::tree::Factory;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::{Block, ConfigBlock};
+use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::Config;
 use crate::errors::*;
 use crate::input::I3BarEvent;
@@ -102,7 +102,7 @@ impl Block for CustomDBus {
     }
 
     // Updates the internal state of the block.
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let status = (*self
             .status
             .lock()

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -14,6 +14,7 @@ use crate::scheduler::Task;
 use crate::util::format_percent_bar;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
 pub enum Unit {
@@ -203,7 +204,7 @@ impl ConfigBlock for DiskSpace {
 }
 
 impl Block for DiskSpace {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let statvfs = statvfs(Path::new(self.path.as_str()))
             .block_error("disk_space", "failed to retrieve statvfs")?;
         let mut result;
@@ -267,7 +268,7 @@ impl Block for DiskSpace {
         let state = self.compute_state(result, self.warning, self.alert);
         self.disk_space.set_state(state);
 
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -6,7 +6,7 @@ use nix::sys::statvfs::statvfs;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -204,7 +204,7 @@ impl ConfigBlock for DiskSpace {
 }
 
 impl Block for DiskSpace {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let statvfs = statvfs(Path::new(self.path.as_str()))
             .block_error("disk_space", "failed to retrieve statvfs")?;
         let mut result;

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -6,6 +6,7 @@ use nix::sys::statvfs::statvfs;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -14,7 +15,6 @@ use crate::scheduler::Task;
 use crate::util::format_percent_bar;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
 pub enum Unit {

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -5,7 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -80,7 +80,7 @@ impl ConfigBlock for Docker {
 }
 
 impl Block for Docker {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let output = match Command::new("sh")
             .args(&[
                 "-c",

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -14,6 +14,7 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 pub struct Docker {
     text: TextWidget,
@@ -79,7 +80,7 @@ impl ConfigBlock for Docker {
 }
 
 impl Block for Docker {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let output = match Command::new("sh")
             .args(&[
                 "-c",
@@ -93,13 +94,13 @@ impl Block for Docker {
             Err(_) => {
                 // We don't want the bar to crash if we can't reach the docker daemon.
                 self.text.set_text("N/A".to_string());
-                return Ok(Some(self.update_interval));
+                return Ok(Some(self.update_interval.into()));
             }
         };
 
         if output.is_empty() {
             self.text.set_text("N/A".to_string());
-            return Ok(Some(self.update_interval));
+            return Ok(Some(self.update_interval.into()));
         }
 
         let status: Status = serde_json::from_str(&output)
@@ -115,7 +116,7 @@ impl Block for Docker {
 
         self.text.set_text(self.format.render_static_str(&values)?);
 
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -5,6 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -14,7 +15,6 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 pub struct Docker {
     text: TextWidget,

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -9,13 +9,13 @@ use swayipc::reply::{WindowChange, WorkspaceChange};
 use swayipc::{Connection, EventType};
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::errors::*;
 use crate::scheduler::Task;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 #[derive(Copy, Clone, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -9,7 +9,7 @@ use swayipc::reply::{WindowChange, WorkspaceChange};
 use swayipc::{Connection, EventType};
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::errors::*;
@@ -194,7 +194,7 @@ impl ConfigBlock for FocusedWindow {
 }
 
 impl Block for FocusedWindow {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let mut marks_string = (*self
             .marks
             .lock()

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -15,6 +15,7 @@ use crate::errors::*;
 use crate::scheduler::Task;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 #[derive(Copy, Clone, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -193,7 +194,7 @@ impl ConfigBlock for FocusedWindow {
 }
 
 impl Block for FocusedWindow {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let mut marks_string = (*self
             .marks
             .lock()

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use crossbeam_channel::Sender;
 use serde_derive::Deserialize;

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -16,6 +16,7 @@ use regex::Regex;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::errors::*;
@@ -24,7 +25,6 @@ use crate::scheduler::Task;
 use crate::util;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 pub struct IBus {
     id: String,

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -16,7 +16,7 @@ use regex::Regex;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::errors::*;
@@ -119,7 +119,7 @@ impl Block for IBus {
     }
 
     // Updates the internal state of the block.
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let engine = (*self
             .engine
             .lock()

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -4,7 +4,7 @@ use std::fs::{read_dir, File};
 use std::io::prelude::*;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use crossbeam_channel::Sender;
 use dbus::ffidisp::stdintf::org_freedesktop_dbus::Properties;

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -24,6 +24,7 @@ use crate::scheduler::Task;
 use crate::util;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 pub struct IBus {
     id: String,
@@ -118,7 +119,7 @@ impl Block for IBus {
     }
 
     // Updates the internal state of the block.
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let engine = (*self
             .engine
             .lock()

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -15,6 +15,7 @@ use swayipc::reply::InputChange;
 use swayipc::{Connection, EventType};
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -23,7 +24,6 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -23,6 +23,7 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -461,13 +462,13 @@ impl Block for KeyboardLayout {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let layout = self.monitor.keyboard_layout()?;
         let values = map!("{layout}" => layout);
 
         self.output
             .set_text(self.format.render_static_str(&values)?);
-        Ok(self.update_interval)
+        Ok(self.update_interval.map(|d| d.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -15,7 +15,7 @@ use swayipc::reply::InputChange;
 use swayipc::{Connection, EventType};
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -462,7 +462,7 @@ impl Block for KeyboardLayout {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let layout = self.monitor.keyboard_layout()?;
         let values = map!("{layout}" => layout);
 

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use crossbeam_channel::Sender;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -118,7 +118,7 @@ impl ConfigBlock for Load {
 }
 
 impl Block for Load {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let mut f = OpenOptions::new()
             .read(true)
             .open("/proc/loadavg")

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -15,6 +15,7 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 pub struct Load {
     text: TextWidget,
@@ -117,7 +118,7 @@ impl ConfigBlock for Load {
 }
 
 impl Block for Load {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let mut f = OpenOptions::new()
             .read(true)
             .open("/proc/loadavg")
@@ -149,7 +150,7 @@ impl Block for Load {
 
         self.text.set_text(self.format.render_static_str(&values)?);
 
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use crossbeam_channel::Sender;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -15,7 +16,6 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 pub struct Load {
     text: TextWidget,

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -5,7 +5,7 @@ use maildir::Maildir as ExtMaildir;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -110,7 +110,7 @@ impl ConfigBlock for Maildir {
 }
 
 impl Block for Maildir {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let mut newmails = 0;
         for inbox in &self.inboxes {
             let isl: &str = &inbox[..];

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -5,6 +5,7 @@ use maildir::Maildir as ExtMaildir;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -13,7 +14,6 @@ use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -13,6 +13,7 @@ use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -109,7 +110,7 @@ impl ConfigBlock for Maildir {
 }
 
 impl Block for Maildir {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let mut newmails = 0;
         for inbox in &self.inboxes {
             let isl: &str = &inbox[..];
@@ -124,7 +125,7 @@ impl Block for Maildir {
         }
         self.text.set_state(state);
         self.text.set_text(format!("{}", newmails));
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -16,6 +16,7 @@ use crate::scheduler::Task;
 use crate::util::*;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
@@ -389,7 +390,7 @@ impl Block for Memory {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let f =
             File::open("/proc/meminfo").block_error("memory", "/proc/meminfo does not exist")?;
         let f = BufReader::new(f);
@@ -502,7 +503,7 @@ impl Block for Memory {
             writeln!(f, "Updated: {:?}", self)
                 .block_error("memory", "failed to write to /tmp/i3log")?;
         });
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -16,7 +17,6 @@ use crate::scheduler::Task;
 use crate::util::*;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -390,7 +390,7 @@ impl Block for Memory {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let f =
             File::open("/proc/meminfo").block_error("memory", "/proc/meminfo does not exist")?;
         let f = BufReader::new(f);

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -23,6 +23,7 @@ use crate::subprocess::spawn_child_async;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::rotatingtext::RotatingTextWidget;
+use crate::blocks::Refresh;
 
 pub struct Music {
     id: String,
@@ -222,7 +223,7 @@ impl Block for Music {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let (rotated, next) = if self.marquee {
             self.current_song.next()?
         } else {
@@ -364,8 +365,8 @@ impl Block for Music {
             }
         }
         Ok(match (next, self.marquee) {
-            (Some(_), _) => next,
-            (None, _) => Some(Duration::new(2, 0)),
+            (Some(_), _) => next.map(|d| d.into()),
+            (None, _) => Some(Duration::new(2, 0).into()),
         })
     }
 

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -13,6 +13,7 @@ use dbus::{
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -23,7 +24,6 @@ use crate::subprocess::spawn_child_async;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::rotatingtext::RotatingTextWidget;
-use crate::blocks::Refresh;
 
 pub struct Music {
     id: String,

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -13,7 +13,7 @@ use dbus::{
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -223,7 +223,7 @@ impl Block for Music {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let (rotated, next) = if self.marquee {
             self.current_song.next()?
         } else {

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -20,6 +20,7 @@ use crate::util::{escape_pango_text, format_percent_bar};
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::graph::GraphWidget;
+use crate::blocks::Refresh;
 
 pub struct NetworkDevice {
     device: String,
@@ -771,7 +772,7 @@ impl Net {
 }
 
 impl Block for Net {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         self.update_device();
 
         // skip updating if device is not up.
@@ -787,7 +788,7 @@ impl Block for Net {
                 rx_widget.set_text("×".to_string());
             };
 
-            return Ok(Some(self.update_interval));
+            return Ok(Some(self.update_interval.into()));
         }
 
         self.active = true;
@@ -807,7 +808,7 @@ impl Block for Net {
 
         self.update_tx_rx()?;
 
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -9,6 +9,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -20,7 +21,6 @@ use crate::util::{escape_pango_text, format_percent_bar};
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::graph::GraphWidget;
-use crate::blocks::Refresh;
 
 pub struct NetworkDevice {
     device: String,

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -9,7 +9,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -772,7 +772,7 @@ impl Net {
 }
 
 impl Block for Net {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         self.update_device();
 
         // skip updating if device is not up.

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -15,7 +15,7 @@ use dbus::{
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::errors::*;
@@ -556,7 +556,7 @@ impl Block for NetworkManager {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let state = self.manager.state(&self.dbus_conn);
 
         self.indicator.set_state(match state {

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::net::Ipv4Addr;
 use std::process::Command;
 use std::thread;
-use std::time::{Instant};
+use std::time::Instant;
 
 use crossbeam_channel::Sender;
 use dbus::arg::{Array, Iter, Variant};
@@ -15,6 +15,7 @@ use dbus::{
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::errors::*;
@@ -23,7 +24,6 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 enum NetworkState {
     Unknown,

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::net::Ipv4Addr;
 use std::process::Command;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Instant};
 
 use crossbeam_channel::Sender;
 use dbus::arg::{Array, Iter, Variant};
@@ -23,6 +23,7 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 enum NetworkState {
     Unknown,
@@ -555,7 +556,7 @@ impl Block for NetworkManager {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let state = self.manager.state(&self.dbus_conn);
 
         self.indicator.set_state(match state {

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -5,6 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -13,7 +14,6 @@ use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 pub struct Notmuch {
     text: TextWidget,

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -13,6 +13,7 @@ use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 pub struct Notmuch {
     text: TextWidget,
@@ -156,12 +157,12 @@ impl Notmuch {
 }
 
 impl Block for Notmuch {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         match run_query(&self.db, &self.query) {
             Ok(count) => {
                 self.update_text(count);
                 self.update_state(count);
-                Ok(Some(self.update_interval))
+                Ok(Some(self.update_interval.into()))
             }
             Err(e) => Err(BlockError("notmuch".to_string(), e.to_string())),
         }

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -5,7 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -157,7 +157,7 @@ impl Notmuch {
 }
 
 impl Block for Notmuch {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         match run_query(&self.db, &self.query) {
             Ok(count) => {
                 self.update_text(count);

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -5,7 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::{Config, LogicalDirection, Scrolling};
 use crate::de::deserialize_duration;
@@ -225,7 +225,7 @@ impl ConfigBlock for NvidiaGpu {
 }
 
 impl Block for NvidiaGpu {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let mut params = String::new();
         if self.show_utilization.is_some() {
             params += "utilization.gpu,";

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -5,6 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::{Config, LogicalDirection, Scrolling};
 use crate::de::deserialize_duration;
@@ -14,7 +15,6 @@ use crate::scheduler::Task;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 pub struct NvidiaGpu {
     gpu_widget: ButtonWidget,

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -14,6 +14,7 @@ use crate::scheduler::Task;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 pub struct NvidiaGpu {
     gpu_widget: ButtonWidget,
@@ -224,7 +225,7 @@ impl ConfigBlock for NvidiaGpu {
 }
 
 impl Block for NvidiaGpu {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let mut params = String::new();
         if self.show_utilization.is_some() {
             params += "utilization.gpu,";
@@ -298,7 +299,7 @@ impl Block for NvidiaGpu {
             self.gpu_widget.set_text(self.label.to_string());
         }
 
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -20,6 +20,7 @@ use crate::scheduler::Task;
 use crate::util::{has_command, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 pub struct Pacman {
     output: ButtonWidget,
@@ -297,7 +298,7 @@ impl Block for Pacman {
         vec![&self.output]
     }
 
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let (formatting_map, critical, cum_count) = match &self.watched {
             Watched::Pacman => {
                 check_fakeroot_command_exists()?;
@@ -347,7 +348,7 @@ impl Block for Pacman {
                 }
             }
         });
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -298,7 +298,7 @@ impl Block for Pacman {
         vec![&self.output]
     }
 
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let (formatting_map, critical, cum_count) = match &self.watched {
             Watched::Pacman => {
                 check_fakeroot_command_exists()?;

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -11,6 +11,7 @@ use regex::Regex;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -20,7 +21,6 @@ use crate::scheduler::Task;
 use crate::util::{has_command, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 pub struct Pacman {
     output: ButtonWidget,

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -12,6 +12,7 @@ use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 enum State {
     Started,
@@ -127,7 +128,7 @@ impl Block for Pomodoro {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         self.tick();
         self.set_text();
 
@@ -154,7 +155,7 @@ impl Block for Pomodoro {
             _ => {}
         }
 
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -4,6 +4,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::errors::*;
@@ -12,7 +13,6 @@ use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 enum State {
     Started,

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -4,7 +4,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::errors::*;
@@ -128,7 +128,7 @@ impl Block for Pomodoro {
         &self.id
     }
 
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         self.tick();
         self.set_text();
 

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -29,6 +29,7 @@ use crate::util::format_percent_bar;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 #[cfg(feature = "pulseaudio")]
 use crate::pulse::callbacks::ListResult;
@@ -783,7 +784,7 @@ impl ConfigBlock for Sound {
 const FILTER: &[char] = &['[', ']', '%'];
 
 impl Block for Sound {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         self.display()?;
         Ok(None)
     }

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -19,7 +19,7 @@ use std::sync::Mutex;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::{Config, LogicalDirection};
 use crate::errors::*;
@@ -784,7 +784,7 @@ impl ConfigBlock for Sound {
 const FILTER: &[char] = &['[', ']', '%'];
 
 impl Block for Sound {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         self.display()?;
         Ok(None)
     }

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -19,6 +19,7 @@ use std::sync::Mutex;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::{Config, LogicalDirection};
 use crate::errors::*;
@@ -29,7 +30,6 @@ use crate::util::format_percent_bar;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 #[cfg(feature = "pulseaudio")]
 use crate::pulse::callbacks::ListResult;

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -7,6 +7,7 @@ use crossbeam_channel::{unbounded, Receiver, Sender};
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -15,7 +16,6 @@ use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 pub struct SpeedTest {
     vals: Arc<Mutex<(bool, Vec<f32>)>>,

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -7,7 +7,7 @@ use crossbeam_channel::{unbounded, Receiver, Sender};
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -149,7 +149,7 @@ impl ConfigBlock for SpeedTest {
 }
 
 impl Block for SpeedTest {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let (ref mut updated, ref vals) = *self
             .vals
             .lock()

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -15,6 +15,7 @@ use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 pub struct SpeedTest {
     vals: Arc<Mutex<(bool, Vec<f32>)>>,
@@ -148,7 +149,7 @@ impl ConfigBlock for SpeedTest {
 }
 
 impl Block for SpeedTest {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let (ref mut updated, ref vals) = *self
             .vals
             .lock()
@@ -177,7 +178,7 @@ impl Block for SpeedTest {
             Ok(None)
         } else {
             self.send.send(())?;
-            Ok(Some(self.config.interval))
+            Ok(Some(self.config.interval.into()))
         }
     }
 

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -5,7 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -186,7 +186,7 @@ fn get_number_of_pending_tasks(tags: &[String]) -> Result<u32> {
 }
 
 impl Block for Taskwarrior {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         if !has_taskwarrior()? {
             self.output.set_text("?")
         } else {

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -5,6 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -14,7 +15,6 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 pub struct Taskwarrior {
     output: ButtonWidget,

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -14,6 +14,7 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 pub struct Taskwarrior {
     output: ButtonWidget,
@@ -185,7 +186,7 @@ fn get_number_of_pending_tasks(tags: &[String]) -> Result<u32> {
 }
 
 impl Block for Taskwarrior {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         if !has_taskwarrior()? {
             self.output.set_text("?")
         } else {
@@ -210,7 +211,7 @@ impl Block for Taskwarrior {
         }
 
         // continue updating the block in the configured interval
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -5,7 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -130,7 +130,7 @@ impl ConfigBlock for Temperature {
 }
 
 impl Block for Temperature {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let mut args = vec!["-u"];
         if let Some(ref chip) = &self.chip {
             args.push(chip);

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -5,6 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -14,7 +15,6 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 pub struct Temperature {
     text: ButtonWidget,

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -14,6 +14,7 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 pub struct Temperature {
     text: ButtonWidget,
@@ -129,7 +130,7 @@ impl ConfigBlock for Temperature {
 }
 
 impl Block for Temperature {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let mut args = vec!["-u"];
         if let Some(ref chip) = &self.chip {
             args.push(chip);
@@ -203,7 +204,7 @@ impl Block for Temperature {
             self.text.set_state(state);
         }
 
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -4,7 +4,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::{Block, ConfigBlock};
+use crate::blocks::{Block, ConfigBlock, Refresh};
 use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
@@ -61,8 +61,8 @@ impl ConfigBlock for Template {
 }
 
 impl Block for Template {
-    fn update(&mut self) -> Result<Option<Duration>> {
-        Ok(Some(self.update_interval))
+    fn update(&mut self) -> Result<Option<Refresh>> {
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -4,7 +4,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::{Block, ConfigBlock, Refresh};
+use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
@@ -61,7 +61,7 @@ impl ConfigBlock for Template {
 }
 
 impl Block for Template {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         Ok(Some(self.update_interval.into()))
     }
 

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -6,6 +6,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::{deserialize_duration, deserialize_timezone};
@@ -15,7 +16,6 @@ use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 pub struct Time {
     time: ButtonWidget,

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -6,7 +6,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::{deserialize_duration, deserialize_timezone};
@@ -91,7 +91,7 @@ impl ConfigBlock for Time {
 }
 
 impl Block for Time {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let time = match self.timezone {
             Some(tz) => Utc::now().with_timezone(&tz).format(&self.format),
             None => Local::now().format(&self.format),

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -15,6 +15,7 @@ use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 pub struct Time {
     time: ButtonWidget,
@@ -90,13 +91,13 @@ impl ConfigBlock for Time {
 }
 
 impl Block for Time {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let time = match self.timezone {
             Some(tz) => Utc::now().with_timezone(&tz).format(&self.format),
             None => Local::now().format(&self.format),
         };
         self.time.set_text(format!("{}", time));
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::process::Command;
 use std::time::Duration;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_opt_duration;
@@ -90,7 +90,7 @@ impl ConfigBlock for Toggle {
 }
 
 impl Block for Toggle {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let output = Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_owned()))
             .args(&["-c", &self.command_state])
             .output()

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -12,6 +12,7 @@ use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 use uuid::Uuid;
 
@@ -89,7 +90,7 @@ impl ConfigBlock for Toggle {
 }
 
 impl Block for Toggle {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let output = Command::new(env::var("SHELL").unwrap_or_else(|_| "sh".to_owned()))
             .args(&["-c", &self.command_state])
             .output()
@@ -109,7 +110,7 @@ impl Block for Toggle {
 
         self.text.set_state(State::Idle);
 
-        Ok(self.update_interval)
+        Ok(self.update_interval.map(|d| d.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -5,6 +5,7 @@ use std::env;
 use std::process::Command;
 use std::time::Duration;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_opt_duration;
@@ -12,7 +13,6 @@ use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 use uuid::Uuid;
 

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -5,6 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -13,7 +14,6 @@ use crate::scheduler::Task;
 use crate::util::read_file;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
-use crate::blocks::Refresh;
 
 pub struct Uptime {
     text: TextWidget,

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -5,7 +5,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -63,7 +63,7 @@ impl ConfigBlock for Uptime {
 }
 
 impl Block for Uptime {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let uptime_raw = match read_file("uptime", Path::new("/proc/uptime")) {
             Ok(file) => file,
             Err(e) => {

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -13,6 +13,7 @@ use crate::scheduler::Task;
 use crate::util::read_file;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
+use crate::blocks::Refresh;
 
 pub struct Uptime {
     text: TextWidget,
@@ -62,7 +63,7 @@ impl ConfigBlock for Uptime {
 }
 
 impl Block for Uptime {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let uptime_raw = match read_file("uptime", Path::new("/proc/uptime")) {
             Ok(file) => file,
             Err(e) => {
@@ -118,7 +119,7 @@ impl Block for Uptime {
             unreachable!()
         };
         self.text.set_text(text);
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_local_timestamp;
@@ -19,7 +20,6 @@ use crossbeam_channel::Sender;
 use inotify::{EventMask, Inotify, WatchMask};
 use serde_derive::Deserialize;
 use uuid::Uuid;
-use crate::blocks::Refresh;
 
 pub struct Watson {
     id: String,

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -19,6 +19,7 @@ use crossbeam_channel::Sender;
 use inotify::{EventMask, Inotify, WatchMask};
 use serde_derive::Deserialize;
 use uuid::Uuid;
+use crate::blocks::Refresh;
 
 pub struct Watson {
     id: String,
@@ -114,7 +115,7 @@ impl ConfigBlock for Watson {
 }
 
 impl Block for Watson {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         let state = {
             let file = BufReader::new(
                 File::open(&self.state_path).block_error("watson", "unable to open state file")?,
@@ -131,7 +132,7 @@ impl Block for Watson {
                 self.prev_state = Some(state);
                 Ok(if self.show_time {
                     // regular updates if time is enabled
-                    Some(Duration::from_secs(60))
+                    Some(Duration::from_secs(60).into())
                 } else {
                     None
                 })
@@ -150,7 +151,7 @@ impl Block for Watson {
                     self.prev_state = Some(state);
 
                     // Show stopped status for some seconds before returning to idle
-                    Ok(Some(Duration::from_secs(5)))
+                    Ok(Some(Duration::from_secs(5).into()))
                 } else {
                     // File is empty which means that there is currently no active time tracking,
                     // and the previous state wasn't time tracking neither so we reset the
@@ -162,7 +163,7 @@ impl Block for Watson {
                     self.prev_state = Some(state);
                     Ok(if self.show_time {
                         // regular updates if time is enabled
-                        Some(Duration::from_secs(60))
+                        Some(Duration::from_secs(60).into())
                     } else {
                         None
                     })

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_local_timestamp;
@@ -115,7 +115,7 @@ impl ConfigBlock for Watson {
 }
 
 impl Block for Watson {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         let state = {
             let file = BufReader::new(
                 File::open(&self.state_path).block_error("watson", "unable to open state file")?,

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -15,6 +15,7 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 const OPENWEATHERMAP_API_KEY_ENV: &str = "OPENWEATHERMAP_API_KEY";
 const OPENWEATHERMAP_CITY_ID_ENV: &str = "OPENWEATHERMAP_CITY_ID";
@@ -303,7 +304,7 @@ impl ConfigBlock for Weather {
 }
 
 impl Block for Weather {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         self.update_weather()?;
         // Display an error/disabled-looking widget when we don't have any
         // weather information, which is likely due to internet connectivity.
@@ -313,7 +314,7 @@ impl Block for Weather {
             let fmt = FormatTemplate::from_string(&self.format)?;
             self.weather.set_text(fmt.render(&self.weather_keys));
         }
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use std::time::Duration;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -15,7 +16,6 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 const OPENWEATHERMAP_API_KEY_ENV: &str = "OPENWEATHERMAP_API_KEY";
 const OPENWEATHERMAP_CITY_ID_ENV: &str = "OPENWEATHERMAP_CITY_ID";

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::time::Duration;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
 use crate::de::deserialize_duration;
@@ -304,7 +304,7 @@ impl ConfigBlock for Weather {
 }
 
 impl Block for Weather {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         self.update_weather()?;
         // Display an error/disabled-looking widget when we don't have any
         // weather information, which is likely due to internet connectivity.

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -6,6 +6,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
+use crate::blocks::Refresh;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::{Config, LogicalDirection};
 use crate::de::deserialize_duration;
@@ -15,7 +16,6 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
-use crate::blocks::Refresh;
 
 struct Monitor {
     name: String,

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -15,6 +15,7 @@ use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
+use crate::blocks::Refresh;
 
 struct Monitor {
     name: String,
@@ -247,7 +248,7 @@ impl ConfigBlock for Xrandr {
 }
 
 impl Block for Xrandr {
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Refresh>> {
         if let Some(am) = Xrandr::get_active_monitors()? {
             if let Some(mm) = Xrandr::get_monitor_metrics(&am)? {
                 self.monitors = mm;
@@ -255,7 +256,7 @@ impl Block for Xrandr {
             }
         }
 
-        Ok(Some(self.update_interval))
+        Ok(Some(self.update_interval.into()))
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -6,7 +6,7 @@ use crossbeam_channel::Sender;
 use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::{Config, LogicalDirection};
 use crate::de::deserialize_duration;
@@ -248,7 +248,7 @@ impl ConfigBlock for Xrandr {
 }
 
 impl Block for Xrandr {
-    fn update(&mut self) -> Result<Option<Refresh>> {
+    fn update(&mut self) -> Result<Option<Update>> {
         if let Some(am) = Xrandr::get_active_monitors()? {
             if let Some(mm) = Xrandr::get_monitor_metrics(&am)? {
                 self.monitors = mm;

--- a/src/de.rs
+++ b/src/de.rs
@@ -42,7 +42,11 @@ where
         where
             E: de::Error,
         {
-            Ok(Refresh::Once)
+            if value.to_lowercase() == "once" {
+                Ok(Refresh::Once)
+            } else {
+                Err(de::Error::custom(r#"expected "[Oo]nce""#))
+            }
         }
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -209,3 +209,28 @@ where
     use chrono::TimeZone;
     i64::deserialize(deserializer).map(|seconds| Local.timestamp(seconds, 0))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::de::deserialize_duration;
+    use serde_derive::Deserialize;
+    use std::time::Duration;
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(deny_unknown_fields)]
+    pub struct Config {
+        /// Update interval in seconds
+        #[serde(deserialize_with = "deserialize_duration")]
+        pub interval: Duration,
+    }
+
+    #[test]
+    fn test_deserialize_duration() {
+        let duration_toml = r#""interval"= 5"#;
+        let deserialized: Config = toml::from_str(duration_toml).unwrap();
+        assert_eq!(Duration::new(5, 0), deserialized.interval);
+        let duration_toml = r#""interval"= 0.5"#;
+        let deserialized: Config = toml::from_str(duration_toml).unwrap();
+        assert_eq!(Duration::new(0, 500_000_000), deserialized.interval);
+    }
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -21,7 +21,7 @@ where
         type Value = Update;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str(r#"i64, f64 or "[Oo]nce" "#)
+            formatter.write_str(r#"i64, f64 or "once" "#)
         }
 
         fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
@@ -42,10 +42,10 @@ where
         where
             E: de::Error,
         {
-            if value.to_lowercase() == "once" {
+            if value == "once" {
                 Ok(Update::Once)
             } else {
-                Err(de::Error::custom(r#"expected "[Oo]nce""#))
+                Err(de::Error::custom(r#"expected "once""#))
             }
         }
     }
@@ -295,7 +295,7 @@ mod tests {
         let duration_toml = r#""interval"= 0.5"#;
         let deserialized: UpdateConfig = toml::from_str(duration_toml).unwrap();
         assert_eq!(Every(Duration::new(0, 500_000_000)), deserialized.interval);
-        let duration_toml = r#""interval"= "Once""#;
+        let duration_toml = r#""interval"= "once""#;
         let deserialized: UpdateConfig = toml::from_str(duration_toml).unwrap();
         assert_eq!(Once, deserialized.interval);
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,4 +1,4 @@
-use crate::blocks::Refresh;
+use crate::blocks::Update;
 use std::cmp;
 use std::collections::{BinaryHeap, HashMap};
 use std::fmt;
@@ -113,11 +113,11 @@ impl UpdateScheduler {
                 .update()?
             {
                 match dur {
-                    Refresh::Every(d) => self.schedule.push(Task {
+                    Update::Every(d) => self.schedule.push(Task {
                         id: task.id,
                         update_time: now + d,
                     }),
-                    Refresh::Once => {} // do not schedule this task again
+                    Update::Once => {} // do not schedule this task again
                 }
             }
         }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -3,6 +3,7 @@ use std::collections::{BinaryHeap, HashMap};
 use std::fmt;
 use std::thread;
 use std::time::{Duration, Instant};
+use crate::blocks::Refresh;
 
 use crate::blocks::Block;
 use crate::errors::*;
@@ -111,10 +112,16 @@ impl UpdateScheduler {
                 .internal_error("scheduler", "could not get required block")?
                 .update()?
             {
-                self.schedule.push(Task {
-                    id: task.id,
-                    update_time: now + dur,
-                })
+                match dur {
+                    Refresh::Every(d) => {
+                        self.schedule.push(Task {
+                            id: task.id,
+                            update_time: now + d,
+                        })
+                    },
+                    Refresh::Once => {
+                    }, // do not schedule this task again
+                }
             }
         }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,9 +1,9 @@
+use crate::blocks::Refresh;
 use std::cmp;
 use std::collections::{BinaryHeap, HashMap};
 use std::fmt;
 use std::thread;
 use std::time::{Duration, Instant};
-use crate::blocks::Refresh;
 
 use crate::blocks::Block;
 use crate::errors::*;
@@ -113,14 +113,11 @@ impl UpdateScheduler {
                 .update()?
             {
                 match dur {
-                    Refresh::Every(d) => {
-                        self.schedule.push(Task {
-                            id: task.id,
-                            update_time: now + d,
-                        })
-                    },
-                    Refresh::Once => {
-                    }, // do not schedule this task again
+                    Refresh::Every(d) => self.schedule.push(Task {
+                        id: task.id,
+                        update_time: now + d,
+                    }),
+                    Refresh::Once => {} // do not schedule this task again
                 }
             }
         }


### PR DESCRIPTION
Fix #89 

```toml
interval = 2  # every 2 seconds
```
```toml
interval = "once" # only update once
```
```toml
# interval not provided, use default value
```

This PR modifies the `Block` trait and adds an `Update` enum:

```diff
    /// Forces an update of the internal state of the block.
-    fn update(&mut self) -> Result<Option<Duration>> {
+    fn update(&mut self) -> Result<Option<Update>> {
```

```rust
pub enum Update {
    Every(Duration), // update every <duration> seconds
    Once, // only update once
}
```

What do you think?

## How to try this PR

status.toml:

```toml
[[block]]
block = "custom"
command = "date"
interval = 2 # updated every 2 seconds

[[block]]
block = "custom"
command = "date"
interval = "once" # only updated once

[[block]]
block = "custom"
command = "date"
# no interval provided, updated every 10 seconds
```

`./target/debug/i3status-rs test.toml`

Then check the first block is updated every 2 seconds, the 2nd block only once and 3rd block every 10 seconds.

## TODO before merge

- [x] rebase
- [x] rename `Refresh` to `Update` ?
- [x] add doc
- [x] does it make sense to support running once for other blocks?