### PR TITLE
Better fix for #535 and #582

### DIFF
--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -20,7 +20,6 @@ use uuid::Uuid;
 
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::{Config, LogicalDirection, Scrolling};
-use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
@@ -178,7 +177,6 @@ pub struct Backlight {
     device: BacklitDevice,
     step_width: u64,
     scrolling: Scrolling,
-    update_interval: Duration,
 }
 
 /// Configuration for the [`Backlight`](./struct.Backlight.html) block.
@@ -192,12 +190,6 @@ pub struct BacklightConfig {
     /// The steps brightness is in/decreased for the selected screen (When greater than 50 it gets limited to 50)
     #[serde(default = "BacklightConfig::default_step_width")]
     pub step_width: u64,
-
-    #[serde(
-        default = "BacklightConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
-    pub interval: Duration,
 }
 
 impl BacklightConfig {
@@ -207,10 +199,6 @@ impl BacklightConfig {
 
     fn default_step_width() -> u64 {
         5
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(30)
     }
 }
 
@@ -237,7 +225,6 @@ impl ConfigBlock for Backlight {
             device,
             step_width: block_config.step_width,
             scrolling,
-            update_interval: block_config.interval,
         };
 
         // Spin up a thread to watch for changes to the brightness file for the
@@ -286,7 +273,7 @@ impl Block for Backlight {
             60..=79 => self.output.set_icon("backlight_partial3"),
             _ => self.output.set_icon("backlight_full"),
         }
-        Ok(Some(self.update_interval))
+        Ok(None)
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -11,7 +11,6 @@ use uuid::Uuid;
 
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
-use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::scheduler::Task;
 use crate::widget::I3BarWidget;
@@ -32,7 +31,6 @@ pub struct FocusedWindow {
     show_marks: MarksType,
     max_width: usize,
     id: String,
-    update_interval: Duration,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -42,12 +40,6 @@ pub struct FocusedWindowConfig {
     #[serde(default = "FocusedWindowConfig::default_max_width")]
     pub max_width: usize,
 
-    #[serde(
-        default = "FocusedWindowConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
-    pub interval: Duration,
-
     /// Show marks in place of title (if exist)
     #[serde(default = "FocusedWindowConfig::default_show_marks")]
     pub show_marks: MarksType,
@@ -56,10 +48,6 @@ pub struct FocusedWindowConfig {
 impl FocusedWindowConfig {
     fn default_max_width() -> usize {
         21
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(30)
     }
 
     fn default_show_marks() -> MarksType {
@@ -200,7 +188,6 @@ impl ConfigBlock for FocusedWindow {
             show_marks: block_config.show_marks,
             title,
             marks,
-            update_interval: block_config.interval,
         })
     }
 }
@@ -231,7 +218,7 @@ impl Block for FocusedWindow {
         };
         self.text.set_text(out_str);
 
-        Ok(Some(self.update_interval))
+        Ok(None)
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -18,7 +18,6 @@ use uuid::Uuid;
 
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::Config;
-use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
@@ -31,7 +30,6 @@ pub struct IBus {
     text: TextWidget,
     engine: Arc<Mutex<String>>,
     mappings: Option<BTreeMap<String, String>>,
-    update_interval: Duration,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -39,21 +37,11 @@ pub struct IBus {
 pub struct IBusConfig {
     #[serde(default = "IBusConfig::default_mappings")]
     pub mappings: Option<BTreeMap<String, String>>,
-
-    #[serde(
-        default = "IBusConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
-    pub interval: Duration,
 }
 
 impl IBusConfig {
     fn default_mappings() -> Option<BTreeMap<String, String>> {
         None
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(30)
     }
 }
 
@@ -120,7 +108,6 @@ impl ConfigBlock for IBus {
             text: TextWidget::new(config).with_text("IBus"),
             engine,
             mappings: block_config.mappings,
-            update_interval: block_config.interval,
         })
     }
 }
@@ -147,7 +134,7 @@ impl Block for IBus {
         };
 
         self.text.set_text(display_engine);
-        Ok(Some(self.update_interval))
+        Ok(None)
     }
 
     // Returns the view of the block, comprised of widgets.

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -21,7 +21,6 @@ use std::time::{Duration, Instant};
 
 use crate::blocks::{Block, ConfigBlock};
 use crate::config::{Config, LogicalDirection};
-use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
@@ -593,7 +592,6 @@ pub struct Sound {
     on_click: Option<String>,
     show_volume_when_muted: bool,
     bar: bool,
-    update_interval: Duration,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -634,12 +632,6 @@ pub struct SoundConfig {
     /// Show volume as bar instead of percent
     #[serde(default = "SoundConfig::default_bar")]
     pub bar: bool,
-
-    #[serde(
-        default = "SoundConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
-    pub interval: Duration,
 }
 
 #[derive(Deserialize, Copy, Clone, Debug)]
@@ -688,10 +680,6 @@ impl SoundConfig {
 
     fn default_bar() -> bool {
         false
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(30)
     }
 }
 
@@ -783,7 +771,6 @@ impl ConfigBlock for Sound {
             on_click: block_config.on_click,
             show_volume_when_muted: block_config.show_volume_when_muted,
             bar: block_config.bar,
-            update_interval: block_config.interval,
         };
 
         sound.device.monitor(id, tx_update_request)?;
@@ -798,7 +785,7 @@ const FILTER: &[char] = &['[', ']', '%'];
 impl Block for Sound {
     fn update(&mut self) -> Result<Option<Duration>> {
         self.display()?;
-        Ok(Some(self.update_interval))
+        Ok(None)
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,9 +244,8 @@ fn run(matches: &ArgMatches) -> Result<()> {
         }
 
         // Set the time-to-next-update timer
-        match scheduler.time_to_next_update() {
-            Some(time) => ttnu = crossbeam_channel::after(time),
-            None => ttnu = crossbeam_channel::after(Duration::from_secs(std::u64::MAX)),
+        if let Some(time) = scheduler.time_to_next_update() {
+            ttnu = crossbeam_channel::after(time)
         }
         if one_shot {
             break Ok(());


### PR DESCRIPTION
This undoes the bandaid fixes that were implemented to deal with the panics that
occur when only using blocks that have no update interval (ones that use DBus etc).

Instead of kludging a dummy update interval to those blocks, the scheduler
logic is changed so that no updates are scheduled if the block has no
update_interval value set.