### PR TITLE
Add Custom DBus block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -5,6 +5,7 @@
 - [Bluetooth](#bluetooth)
 - [CPU Utilization](#cpu-utilization)
 - [Custom](#custom)
+- [Custom DBus](#custom-dbus)
 - [Disk Space](#disk-space)
 - [Focused Window](#focused-window)
 - [IBus](#ibus)
@@ -220,6 +221,27 @@ Key | Values | Required | Default
 `cycle` | Commands to execute and change when the button is clicked. | No | None
 `interval` | Update interval, in seconds. | No | `10`
 `json` | Use JSON from command output to format the block. If the JSON is not valid, the block will error out. | No | `false`
+
+
+## Custom DBus
+
+Creates a block that can be updated asynchronously using DBus.
+
+For example, updating the block using the command line tool `qdbus`: `qdbus i3.status.rs /CurrentSoundDevice i3.status.rs.SetStatus headphones`
+
+### Examples
+
+```toml
+[[block]]
+block = "custom_dbus"
+name = "CurrentSoundDevice"
+```
+
+### Options
+
+Key | Values | Required | Default
+----|--------|----------|--------
+`name` | Name of the DBus object. Must be unique. | Yes | None
 
 ## Disk Space
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -3,6 +3,7 @@ pub mod battery;
 pub mod bluetooth;
 pub mod cpu;
 pub mod custom;
+pub mod custom_dbus;
 pub mod disk_space;
 pub mod docker;
 pub mod focused_window;
@@ -36,6 +37,7 @@ use self::battery::*;
 use self::bluetooth::*;
 use self::cpu::*;
 use self::custom::*;
+use self::custom_dbus::*;
 use self::disk_space::*;
 use self::docker::*;
 use self::focused_window::*;
@@ -130,6 +132,7 @@ pub fn create_block(
         "bluetooth" => block!(Bluetooth, block_config, config, update_request),
         "cpu" => block!(Cpu, block_config, config, update_request),
         "custom" => block!(Custom, block_config, config, update_request),
+        "custom_dbus" => block!(CustomDBus, block_config, config, update_request),
         "disk_space" => block!(DiskSpace, block_config, config, update_request),
         "docker" => block!(Docker, block_config, config, update_request),
         "focused_window" => block!(FocusedWindow, block_config, config, update_request),

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -1,0 +1,126 @@
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crossbeam_channel::Sender;
+use dbus::blocking::LocalConnection;
+use dbus::tree::Factory;
+use serde_derive::Deserialize;
+use uuid::Uuid;
+
+use crate::blocks::{Block, ConfigBlock};
+use crate::config::Config;
+use crate::errors::*;
+use crate::input::I3BarEvent;
+use crate::scheduler::Task;
+use crate::widget::I3BarWidget;
+use crate::widgets::text::TextWidget;
+
+pub struct CustomDBus {
+    id: String,
+    text: TextWidget,
+    status: Arc<Mutex<String>>,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct CustomDBusConfig {
+    pub name: String,
+}
+
+impl ConfigBlock for CustomDBus {
+    type Config = CustomDBusConfig;
+
+    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
+        let id: String = Uuid::new_v4().to_simple().to_string();
+        let id_copy = id.clone();
+
+        let status_original = Arc::new(Mutex::new(String::from("??")));
+        let status = status_original.clone();
+        thread::Builder::new()
+            .name("custom_dbus".into())
+            .spawn(move || {
+                let mut c = LocalConnection::new_session()
+                    .expect("Failed to establish DBus connection in thread");
+                c.request_name("i3.status.rs", false, true, false)
+                    .expect("Failed to request bus name");
+
+                // TODO: better to rewrite this to use a property?
+                let f = Factory::new_fn::<()>();
+                let tree = f
+                    .tree(())
+                    .add(
+                        f.object_path(format!("/{}", block_config.name), ())
+                            .introspectable()
+                            .add(
+                                f.interface("i3.status.rs", ()).add_m(
+                                    f.method("SetStatus", (), move |m| {
+                                        // This is the callback that will be called when another peer on the bus calls our method.
+                                        // the callback receives "MethodInfo" struct and can return either an error, or a list of
+                                        // messages to send back.
+
+                                        let new_status: &str = m.msg.read1()?;
+                                        let mut status = status_original.lock().unwrap();
+                                        *status = new_status.to_string();
+
+                                        // Tell block to update now.
+                                        send.send(Task {
+                                            id: id.clone(),
+                                            update_time: Instant::now(),
+                                        })
+                                        .unwrap();
+
+                                        Ok(vec![m.msg.method_return()])
+                                    })
+                                    .inarg::<&str, _>("name"), // We also add the signal to the interface. This is mainly for introspection.
+                                ),
+                            ),
+                    )
+                    .add(f.object_path("/", ()).introspectable());
+
+                // We add the tree to the connection so that incoming method calls will be handled.
+                tree.start_receive(&c);
+
+                // Serve clients forever.
+                loop {
+                    c.process(Duration::from_millis(1000)).unwrap();
+                }
+            })
+            .unwrap();
+
+        Ok(CustomDBus {
+            id: id_copy,
+            text: TextWidget::new(config).with_text("CustomDBus"),
+            status,
+        })
+    }
+}
+
+impl Block for CustomDBus {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    // Updates the internal state of the block.
+    fn update(&mut self) -> Result<Option<Duration>> {
+        let status = (*self
+            .status
+            .lock()
+            .block_error("custom_dbus", "failed to acquire lock")?)
+        .clone();
+        self.text.set_text(status);
+        Ok(None)
+    }
+
+    // Returns the view of the block, comprised of widgets.
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
+        vec![&self.text]
+    }
+
+    // This function is called on every block for every click.
+    // TODO: Filter events by using the event.name property,
+    // and use to switch between input engines?
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Supersede #426 

This allows you to have a custom block that updates instantly over DBus. 

For example, you might have a script that changes your sound output device.
With the standard `custom` block, you would setup the block like this:
```toml
[[block]]
block = "custom"
command = "check_current_sound_output_device"
interval = 1
```
where the command is a separate script that checks the current sound output device, and the block can only be updated up to once per second. 

However with this new block, you can add a line at the end of your script that changes your sound output device to send a message over DBus to instantly update the block:
```toml
[[block]]
block = "custom_dbus"
name = "CurrentSoundOutput"
```
and add this inside your sound output change script: `qdbus i3.status.rs /CurrentSoundOutput i3.status.rs.SetStatus headphones`. This will update the block instantly to show "headphones". 
