### PR TITLE
Fix CPU format when per_core is true

### DIFF
--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -105,6 +105,8 @@ impl ConfigBlock for Cpu {
     ) -> Result<Self> {
         let format = if block_config.frequency {
             "{utilization}% {frequency}GHz".into()
+        } else if block_config.per_core {
+            "{utilization}".to_owned()
         } else {
             block_config.format
         };


### PR DESCRIPTION
When the option "per_core" was true the last core
had two percent signs because one was added for each core
and another was added after the "utilization" placeholder.

When "per_core" is true the last percent sign after "utilization"
is no longer added.