### PR TITLE
weather block: add autolocate option

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -1039,6 +1039,8 @@ Creates a block which displays local weather and temperature information. In ord
 
 Configuring the Weather block requires configuring a weather service, which may require API keys and other parameters.
 
+If using the `autolocate` feature, set the block update interval such that you do not exceed ipapi.co's free daily limit of 1000 hits.
+
 ### Examples
 
 Show detailed weather in San Francisco through the OpenWeatherMap service:
@@ -1057,6 +1059,7 @@ Key | Values | Required | Default
 `format` | The text format of the weather display. | No | `"{weather} {temp}°"`
 `service` | The configuration of a weather service (see below). | Yes | None
 `interval` | Update interval, in seconds. | No | `600`
+`autolocate` | Gets your location using the ipapi.co IP location service (no API key required). If the API call fails then the block will fallback to `city_id` or `place`. | No | false
 
 ### OpenWeatherMap Options
 

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -60,6 +60,7 @@ pub struct Weather {
     weather_keys: HashMap<String, String>,
     service: WeatherService,
     update_interval: Duration,
+    autolocate: bool,
 }
 
 fn malformed_json_error() -> Error {
@@ -75,7 +76,40 @@ impl Weather {
                 ref place,
                 ref units,
             } => {
-                let location_query = if city_id.is_some() {
+                let geoip_city = if self.autolocate {
+                    let geoip_output = match Command::new("sh")
+                        .args(&["-c", "curl --max-time 3 --silent 'https://ipapi.co/json/'"])
+                        .output()
+                    {
+                        Ok(raw_output) => String::from_utf8(raw_output.stdout)
+                            .block_error("weather", "Failed to decode")?,
+                        Err(_) => {
+                            // We don't want the bar to crash if we can't reach the geoip service
+                            String::from("")
+                        }
+                    };
+
+                    if geoip_output.is_empty() {
+                        None
+                    } else {
+                        let geoip_json: serde_json::value::Value =
+                            serde_json::from_str(&geoip_output).block_error(
+                                "weather",
+                                "Failed to parse JSON response from geoip service.",
+                            )?;
+
+                        geoip_json
+                            .pointer("/city")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                    }
+                } else {
+                    None
+                };
+
+                let location_query = if let Some(city) = geoip_city {
+                    format!("q={}", city)
+                } else if city_id.is_some() {
                     format!("id={}", city_id.as_ref().unwrap())
                 } else if place.is_some() {
                     format!("q={}", place.as_ref().unwrap())
@@ -270,6 +304,8 @@ pub struct WeatherConfig {
     #[serde(default = "WeatherConfig::default_format")]
     pub format: String,
     pub service: WeatherService,
+    #[serde(default = "WeatherConfig::default_autolocate")]
+    pub autolocate: bool,
 }
 
 impl WeatherConfig {
@@ -279,6 +315,10 @@ impl WeatherConfig {
 
     fn default_format() -> String {
         "{weather} {temp}\u{00b0}".to_string()
+    }
+
+    fn default_autolocate() -> bool {
+        false
     }
 }
 
@@ -298,6 +338,7 @@ impl ConfigBlock for Weather {
             weather_keys: HashMap::new(),
             service: block_config.service,
             update_interval: block_config.interval,
+            autolocate: block_config.autolocate,
         })
     }
 }

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -76,6 +76,7 @@ impl Weather {
                 ref place,
                 ref units,
             } => {
+                // TODO: might be good to allow for different geolocation services to be used, similar to how we have `service` for the weather API
                 let geoip_city = if self.autolocate {
                     let geoip_output = match Command::new("sh")
                         .args(&["-c", "curl --max-time 3 --silent 'https://ipapi.co/json/'"])


### PR DESCRIPTION
Resolves #367 

This uses the geolocation service mentioned in https://github.com/greshake/i3status-rust/issues/367#issuecomment-489889913 to automatically change the location used for retrieving weather info

@kflak If you have some time could you please test this? It works fine for me but more QA wouldn't hurt.