### PR TITLE
Fix #696 - zombie setxkbmap process with kbddbus keyboard layout

### DIFF
--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -1,4 +1,4 @@
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -179,8 +179,7 @@ impl KbdDaemonBus {
     pub fn new() -> Result<Self> {
         Command::new("setxkbmap")
             .arg("-version")
-            .stdout(Stdio::piped())
-            .spawn()
+            .output()
             .block_error("kbddaemonbus", "setxkbmap not found")?;
 
         // also verifies that kbdd daemon is registered in dbus

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -66,7 +66,7 @@ fn setxkbmap_layouts() -> Result<String> {
     let output = Command::new("setxkbmap")
         .args(&["-query"])
         .output()
-        .block_error("keyboard_layout", "Failed to exectute setxkbmap.")
+        .block_error("keyboard_layout", "Failed to execute setxkbmap.")
         .and_then(|raw| {
             String::from_utf8(raw.stdout).block_error("keyboard_layout", "Non-UTF8 input.")
         })?;


### PR DESCRIPTION
The child process was only spawned and its output was not checked/read so its handle was kept through the whole lifetime of i3status-rust.