### PR TITLE
Add short_text management + example for time and net block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -326,6 +326,7 @@ Note that `command` and `cycle` are mutually exclusive.
 Key | Values | Required | Default
 ----|--------|----------|--------
 `command` | Shell command to execute & display. Shell command output may need to be escaped, refer to [Escaping Text](#escaping-text). | No | None
+`short_command` | Shell command to execute & display for short with widget. Shell command output may need to be escaped, refer to [Escaping Text](#escaping-text).| No | None
 `on_click` | Command to execute when the button is clicked. | No | None
 `cycle` | Commands to execute and change when the button is clicked. | No | None
 `interval` | Update interval, in seconds (or `"once"` to update only once). | No | `10`
@@ -333,6 +334,11 @@ Key | Values | Required | Default
 `signal` | Signal value that causes an update for this block with 0 corresponding to `-SIGRTMIN+0` and the largest value being `-SIGRTMAX`. | No | None
 `hide_when_empty` | Hides the block when the command output (or json text field) is empty. | No | false
 `shell` | Specify the shell to use when running commands. | No | `$SHELL` if set, otherwise fallback to `sh`
+`width` | `Default`, `Full`, `Short` | No | `Default`
+
+With `Default` width, `i3bar` selects the full text obtained via `command` if 
+there is enough room on the bar or else the short text obtained via  
+`short_command`.  
 
 ###### [↥ back to top](#list-of-available-blocks)
 
@@ -935,6 +941,10 @@ Key | Values | Required | Default
 `hide_inactive` | Whether to hide interfaces that are not connected (or missing). | No | `false`
 `width` | Whether to force the widget to display `Full` or `Short` text (default is to let i3bar choose) | No | `Default`
 
+With `Default` width, `i3bar` selects the full text representation if there is
+enough room on the bar else the short text representation where bitrate, ip
+addresses and speeds are hidden.
+
 #### Available Format Keys
 
 Placeholder | Description
@@ -1415,10 +1425,16 @@ locale = "fr_BE"
 Key | Values | Required | Default
 ----|--------|----------|--------
 `format` | A string to customise the output of this block. See the [chrono docs](https://docs.rs/chrono/0.3.0/chrono/format/strftime/index.html#specifiers) for all options. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"%a %d/%m %R"`
+`format` | A string to customise the *short* output of this block. See the [chrono docs](https://docs.rs/chrono/0.3.0/chrono/format/strftime/index.html#specifiers) for all options. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"%a %d/%m %R"`
 `on_click` | Shell command to run when the time block is clicked. | No | None
 `interval` | Update interval, in seconds. | No | `5`
 `timezone` | A timezone specifier (e.g. "Europe/Lisbon"). | No | Local timezone
 `locale` | Locale to apply when formatting the time. | No | System locale
+`width` | `Default`, `Full`, `Short` | No | `Default`
+
+With `Default` width, `i3bar` select the full text obtained via `format` if 
+there is enough room on the bar or else the short text obtained via  
+`format_short`.  
 
 ###### [↥ back to top](#list-of-available-blocks)
 

--- a/blocks.md
+++ b/blocks.md
@@ -915,6 +915,7 @@ but the 'use_bits' flag can be set to `true` to convert the units to bps (little
 block = "net"
 device = "wlp2s0"
 format = "{ssid} {signal_strength} {ip} {speed_down} {graph_down}"
+short_format = "{ssid}"
 interval = 5
 use_bits = false
 ```
@@ -925,12 +926,14 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `device` | Network interface to monitor (name from /sys/class/net). | No | Automatically chosen from the output of `ip route show default`
 `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | "{speed_up} {speed_down}" 
+`short_format` | A string to customise the short output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | "{ssid}" 
 `speed_digits` | Number of digits to use when displaying speeds. | No | `3`
 `speed_min_unit` | Smallest unit to use when displaying speeds. Possible choices: `"B"`, `"K"`, `"M"`, `"G"`, `"T"`. | No | `"K"`
 `use_bits` | Display speeds in bits instead of bytes. | No | `false`
 `interval` | Update interval, in seconds. Note: the update interval for SSID and IP address is fixed at 30 seconds, and bitrate fixed at 10 seconds. | No | `1`
 `hide_missing` | Whether to hide interfaces that don't exist on the system. | No | `false`
 `hide_inactive` | Whether to hide interfaces that are not connected (or missing). | No | `false`
+`width` | Whether to force the widget to display `Full` or `Short` text (default is to let i3bar choose) | No | `Default`
 
 #### Available Format Keys
 

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -220,14 +220,13 @@ impl Block for Custom {
             self.output
                 .set_text_with_width(&self.width, output.text, short_text);
         } else {
-            let short_raw_output ;
+            let short_raw_output;
             if let Some(ref short_command) = self.short_command {
-                short_raw_output =
-                    Command::new(&self.shell)
-                        .args(&["-c", short_command])
-                        .output()
-                        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
-                        .unwrap_or_else(|e| e.to_string());
+                short_raw_output = Command::new(&self.shell)
+                    .args(&["-c", short_command])
+                    .output()
+                    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+                    .unwrap_or_else(|e| e.to_string());
             } else {
                 short_raw_output = raw_output.clone();
             }

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -643,7 +643,7 @@ impl ConfigBlock for Net {
             block_config.short_format
         } else {
             // Default format
-            block_config.short_format
+            format.clone()
         };
 
         Ok(Net {

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -773,7 +773,7 @@ fn read_file(path: &Path) -> Result<String> {
 }
 
 
-#[derive(PartialEq,Debug)]
+#[derive(PartialEq, Debug)]
 enum WidthChanged {
     Yes,
     No,
@@ -943,7 +943,7 @@ impl Net {
 
         self.network.set_text("".to_string());
 
-        // Update SSID and IP address every 30s and the bitrate every 10s
+        // Update SSID and IP address every 30s and the bitrate every 10s or when width change
         let now = Instant::now();
         if changed == WidthChanged::Yes || now.duration_since(self.last_update).as_secs() % 10 == 0
         {

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -677,12 +677,18 @@ impl ConfigBlock for Net {
                 None
             },
             max_ssid_width: block_config.max_ssid_width,
-            signal_strength: if wireless && (format.contains("{signal_strength}") || short_format.contains("{signal_strength}")) {
+            signal_strength: if wireless
+                && (format.contains("{signal_strength}")
+                    || short_format.contains("{signal_strength}"))
+            {
                 Some(0.to_string())
             } else {
                 None
             },
-            signal_strength_bar: if wireless && (format.contains("{signal_strength_bar}") || short_format.contains("{signal_strength_bar}")) {
+            signal_strength_bar: if wireless
+                && (format.contains("{signal_strength_bar}")
+                    || short_format.contains("{signal_strength_bar}"))
+            {
                 Some("".to_string())
             } else {
                 None
@@ -771,7 +777,6 @@ fn read_file(path: &Path) -> Result<String> {
     content.pop();
     Ok(content)
 }
-
 
 #[derive(PartialEq, Debug)]
 enum WidthChanged {
@@ -1008,8 +1013,11 @@ impl Net {
             "{graph_down}" =>  self.graph_rx.as_ref().unwrap_or(&empty_string)
         );
 
-        self.output
-            .set_text_with_width(&self.width, self.format.render_static_str(&values)?, self.short_format.render_static_str(&values)?);
+        self.output.set_text_with_width(
+            &self.width,
+            self.format.render_static_str(&values)?,
+            self.short_format.render_static_str(&values)?,
+        );
         Ok(())
     }
 }

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -1041,7 +1041,7 @@ impl Block for Net {
                                 .block_error("net", "could not spawn child")?;
                         }
                     }
-                    MouseButton::Right | MouseButton::Middle => {
+                    MouseButton::Middle => {
                         self.width = self.width.next();
                         let _ = self.update_widget(WidthChanged::Yes);
                     }

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -3,8 +3,8 @@ use std::convert::TryInto;
 use std::time::Duration;
 
 use chrono::{
+    format::{strftime::StrftimeItems, DelayedFormat},
     offset::{Local, TimeZone, Utc},
-    format::{DelayedFormat, strftime::StrftimeItems},
     Locale,
 };
 use chrono_tz::Tz;
@@ -104,7 +104,11 @@ impl TimeConfig {
 }
 
 impl Time {
-    fn format<'a>(& self, time: &chrono::DateTime<Local>, format: &'a str) -> Result<DelayedFormat<StrftimeItems<'a>>> {
+    fn format<'a>(
+        &self,
+        time: &chrono::DateTime<Local>,
+        format: &'a str,
+    ) -> Result<DelayedFormat<StrftimeItems<'a>>> {
         let formatted_time = match &self.locale {
             Some(l) => {
                 let locale: Locale = l
@@ -112,16 +116,14 @@ impl Time {
                     .try_into()
                     .block_error("time", "invalid locale")?;
                 match self.timezone {
-                    Some(tz) => time
-                        .with_timezone(&tz)
-                        .format_localized(format, locale),
+                    Some(tz) => time.with_timezone(&tz).format_localized(format, locale),
                     None => time.format_localized(format, locale),
                 }
             }
             None => match self.timezone {
                 Some(tz) => time.with_timezone(&tz).format(format),
                 None => time.format(format),
-            }
+            },
         };
         Ok(formatted_time)
     }
@@ -165,7 +167,6 @@ impl Block for Time {
         );
         Ok(Some(self.update_interval.into()))
     }
-
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
         if let Some(ref name) = e.name {

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -177,7 +177,7 @@ impl Block for Time {
                                 .block_error("time", "could not spawn child")?;
                         }
                     }
-                    MouseButton::Right | MouseButton::Middle => {
+                    MouseButton::Middle => {
                         self.width = self.width.next();
                         let _ = self.update();
                     }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -52,3 +52,29 @@ pub trait I3BarWidget {
     fn to_string(&self) -> String;
     fn get_rendered(&self) -> &Value;
 }
+
+#[derive(Deserialize, Debug, Clone)]
+pub enum WidgetWidth {
+    /// the widget width is choosen by i3bar
+    Default = 0,
+    /// the short_text is enforced
+    Short,
+    /// the full_text is enforced
+    Full,
+}
+
+impl std::default::Default for WidgetWidth {
+    fn default() -> WidgetWidth {
+        WidgetWidth::Default
+    }
+}
+
+impl WidgetWidth {
+    pub fn next(&self) -> WidgetWidth {
+        match self {
+            WidgetWidth::Default => WidgetWidth::Short,
+            WidgetWidth::Short => WidgetWidth::Full,
+            WidgetWidth::Full => WidgetWidth::Default,
+        }
+    }
+}

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -62,15 +62,16 @@ impl ButtonWidget {
         self
     }
 
+    /// Set the `full_text` adn `short_text` representation of the widget
     pub fn with_text(mut self, content: &str) -> Self {
         self.content = Some(String::from(content));
-        if self.short_content == None {
-            self.short_content = self.content.clone();
-        }
+        self.short_content = self.content.clone();
         self.update();
         self
     }
 
+    /// Set the `short_text` representation of the widget. Shall be call after `with_text`
+    /// to have any effect.
     pub fn with_short_text(mut self, content: &str) -> Self {
         self.short_content = Some(String::from(content));
         self.update();
@@ -91,9 +92,7 @@ impl ButtonWidget {
 
     pub fn set_text<S: Into<String>>(&mut self, content: S) {
         let content = Some(content.into());
-        if self.short_content == None {
-            self.short_content = content.clone();
-        }
+        self.short_content = content.clone();
         self.content = content;
         self.update();
     }

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -55,6 +55,7 @@ impl ButtonWidget {
         self
     }
 
+    #[allow(dead_code)]
     pub fn with_short_content(mut self, content: Option<String>) -> Self {
         self.short_content = content;
         self.update();

--- a/src/widgets/graph.rs
+++ b/src/widgets/graph.rs
@@ -1,7 +1,7 @@
 use num_traits::{clamp, ToPrimitive};
 use serde_json::value::Value;
 
-use super::super::widget::{I3BarWidget};
+use super::super::widget::I3BarWidget;
 use crate::config::Config;
 use crate::widget::Spacing;
 use crate::widget::State;

--- a/src/widgets/graph.rs
+++ b/src/widgets/graph.rs
@@ -1,7 +1,7 @@
 use num_traits::{clamp, ToPrimitive};
 use serde_json::value::Value;
 
-use super::super::widget::{I3BarWidget, WidgetWidth};
+use super::super::widget::{I3BarWidget};
 use crate::config::Config;
 use crate::widget::Spacing;
 use crate::widget::State;
@@ -9,7 +9,6 @@ use crate::widget::State;
 #[derive(Clone, Debug)]
 pub struct GraphWidget {
     content: Option<String>,
-    short_content: Option<String>,
     icon: Option<String>,
     state: State,
     spacing: Spacing,
@@ -22,7 +21,6 @@ impl GraphWidget {
     pub fn new(config: Config) -> Self {
         GraphWidget {
             content: None,
-            short_content: None,
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
@@ -56,27 +54,6 @@ impl GraphWidget {
         self
     }
 
-    pub fn set_values_with_width<T>(
-        &mut self,
-        width: &WidgetWidth,
-        content: &[T],
-        min: Option<T>,
-        max: Option<T>,
-    ) where
-        T: Ord + ToPrimitive,
-    {
-        self.set_values(content, min, max);
-        match width {
-            WidgetWidth::Short => {
-                self.content = self.short_content.clone();
-            }
-            WidgetWidth::Full => {
-                self.short_content = self.content.clone();
-            }
-            WidgetWidth::Default => (),
-        }
-    }
-
     pub fn set_values<T>(&mut self, content: &[T], min: Option<T>, max: Option<T>)
     where
         T: Ord + ToPrimitive,
@@ -101,15 +78,12 @@ impl GraphWidget {
                 .collect::<Vec<&'static str>>()
                 .concat();
             self.content = Some(bar.clone());
-            // short_content is set to the last bar value
-            self.short_content = Some(bar.chars().last().unwrap().to_string());
         } else {
             let bar = (0..content.len() - 1)
                 .map(|_| bars[0])
                 .collect::<Vec<&'static str>>()
                 .concat();
             self.content = Some(bar.clone());
-            self.short_content = Some(bar.chars().last().unwrap().to_string());
         }
         self.update();
     }

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -8,6 +8,7 @@ use crate::widget::State;
 #[derive(Clone, Debug)]
 pub struct TextWidget {
     content: Option<String>,
+    short_content: Option<String>,
     icon: Option<String>,
     state: State,
     spacing: Spacing,
@@ -20,6 +21,7 @@ impl TextWidget {
     pub fn new(config: Config) -> Self {
         TextWidget {
             content: None,
+            short_content: None,
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
@@ -43,6 +45,14 @@ impl TextWidget {
 
     pub fn with_text(mut self, content: &str) -> Self {
         self.content = Some(String::from(content));
+        self.short_content = self.content.clone();
+        self.update();
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn with_short_text(mut self, content: &str) -> Self {
+        self.short_content = Some(String::from(content));
         self.update();
         self
     }
@@ -61,6 +71,13 @@ impl TextWidget {
 
     pub fn set_text(&mut self, content: String) {
         self.content = Some(content);
+        self.short_content = self.content.clone();
+        self.update();
+    }
+
+    #[allow(dead_code)]
+    pub fn set_short_text(&mut self, content: String) {
+        self.short_content = Some(content);
         self.update();
     }
 
@@ -91,6 +108,19 @@ impl TextWidget {
                                     }
                                 }),
                                 self.content.clone().unwrap_or_else(|| String::from("")),
+                                match self.spacing {
+                                    Spacing::Hidden => String::from(""),
+                                    _ => String::from(" ")
+                                }
+                            ),
+            "short_text": format!("{}{}{}",
+                                self.icon.clone().unwrap_or_else(|| {
+                                    match self.spacing {
+                                        Spacing::Normal => String::from(" "),
+                                        _ => String::from("")
+                                    }
+                                }),
+                                self.short_content.clone().unwrap_or_else(|| String::from("")),
                                 match self.spacing {
                                     Spacing::Hidden => String::from(""),
                                     _ => String::from(" ")


### PR DESCRIPTION
This PR propose to add short_text management as a response to #676. 

The features are:
- a widget may set full_text and short_text which are then automatically used by i3bar depending upon the available space in the bar (this is the default behavior) — this is similar to PR #693 ,
- the user may right or middle click on the block to switch from the default behavior to a widget where both full_text and shot_text are set to either the wide text or the narrow text.

This allow the user to enforce a widget view (full, short or default) by clicking or by configuration.

Does this behavior suites you ?

NB. I'm a rust and i3 beginner, so, do not hesitate to review and suggest improvement.
