### PR TITLE
sound block: allow current sink name to be shown

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -920,12 +920,21 @@ block = "sound"
 step_width = 3
 ```
 
+```toml
+[[block]]
+block = "sound"
+format = "{output_name} {volume}"
+[block.mappings]
+"alsa_output.usb-Harman_Multimedia_JBL_Pebbles_1.0.0-00.analog-stereo" = "🔈"
+"alsa_output.pci-0000_00_1b.0.analog-stereo" = "🎧"
+```
+
 ### Options
 
 Key | Values | Required | Default
 ----|--------|----------|--------
 `driver` | `"auto"`, `"pulseaudio"`, `"alsa"` | No | `"auto"` (Pulseaudio with ALSA fallback)
-`format` | Any string to use next to the icon | No | `{volume}%`
+`format` | Any string to use next to the icon. Available qualifiers: `volume`, `output_name` | No | `{volume}%`
 `name` | PulseAudio device name, or the ALSA control name as found in the output of `amixer -D yourdevice scontrols` | No | PulseAudio: `@DEFAULT_SINK@` / ALSA: `Master`
 `device` | ALSA device name, usually in the form "hw:X" or "hw:X,Y" where `X` is the card number and `Y` is the device number as found in the output of `aplay -l` | No | `default`
 `natural_mapping` | Use the mapped volume for evaluating the percentage representation like `alsamixer`/`amixer -M`, to be more natural for human ear | No | `false`

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -20,6 +20,7 @@ use {
 };
 
 use std::cmp::max;
+use std::collections::BTreeMap;
 use std::io::Read;
 use std::process::{Command, Stdio};
 use std::thread;
@@ -45,6 +46,7 @@ use crate::widgets::button::ButtonWidget;
 trait SoundDevice {
     fn volume(&self) -> u32;
     fn muted(&self) -> bool;
+    fn output_name(&self) -> String;
 
     fn get_info(&mut self) -> Result<()>;
     fn set_volume(&mut self, step: i32) -> Result<()>;
@@ -81,6 +83,9 @@ impl SoundDevice for AlsaSoundDevice {
     }
     fn muted(&self) -> bool {
         self.muted
+    }
+    fn output_name(&self) -> String {
+        self.name.clone()
     }
 
     fn get_info(&mut self) -> Result<()> {
@@ -217,6 +222,7 @@ struct PulseAudioSoundDevice {
 struct PulseAudioSinkInfo {
     volume: ChannelVolumes,
     mute: bool,
+    sink_name: String,
 }
 
 #[cfg(feature = "pulseaudio")]
@@ -434,6 +440,7 @@ impl PulseAudioClient {
                     let info = PulseAudioSinkInfo {
                         volume: sink_info.volume,
                         mute: sink_info.mute,
+                        sink_name: name.to_string(),
                     };
                     PULSEAUDIO_SINKS.lock().unwrap().insert(name.into(), info);
                     PulseAudioClient::send_update_event();
@@ -522,6 +529,9 @@ impl SoundDevice for PulseAudioSoundDevice {
     fn muted(&self) -> bool {
         self.muted
     }
+    fn output_name(&self) -> String {
+        self.name()
+    }
 
     fn get_info(&mut self) -> Result<()> {
         match PULSEAUDIO_SINKS.lock().unwrap().get(&self.name()) {
@@ -587,6 +597,7 @@ pub struct Sound {
     on_click: Option<String>,
     show_volume_when_muted: bool,
     bar: bool,
+    mappings: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -627,6 +638,9 @@ pub struct SoundConfig {
     /// Show volume as bar instead of percent
     #[serde(default = "SoundConfig::default_bar")]
     pub bar: bool,
+
+    #[serde(default = "SoundConfig::default_mappings")]
+    pub mappings: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Deserialize, Copy, Clone, Debug)]
@@ -676,6 +690,10 @@ impl SoundConfig {
     fn default_bar() -> bool {
         false
     }
+
+    fn default_mappings() -> Option<BTreeMap<String, String>> {
+        None
+    }
 }
 
 impl Sound {
@@ -683,7 +701,18 @@ impl Sound {
         self.device.get_info()?;
 
         let volume = self.device.volume();
-        let values = map!("{volume}" => format!("{:02}", volume));
+        let output_name = self.device.output_name();
+        let mapped_output_name = if let Some(m) = &self.mappings {
+            match m.get(&output_name) {
+                Some(mapping) => mapping.to_string(),
+                None => output_name,
+            }
+        } else {
+            output_name
+        };
+        let values = map!("{volume}" => format!("{:02}", volume),
+                          "{output_name}" => mapped_output_name
+        );
         let text = self.format.render_static_str(&values)?;
 
         if self.device.muted() {
@@ -766,6 +795,7 @@ impl ConfigBlock for Sound {
             on_click: block_config.on_click,
             show_volume_when_muted: block_config.show_volume_when_muted,
             bar: block_config.bar,
+            mappings: block_config.mappings,
         };
 
         sound.device.monitor(id, tx_update_request)?;


### PR DESCRIPTION
Adds new format qualifier `output_name` which will show the name of the sink whose volume is being reported. This is handy when you have multiple audio outputs that you switch between.

Sink names can be checked via `pactl list short sinks`, and usually look something like "alsa_output.pci-0000_00_1b.0.analog-stereo". Displaying that as-is would be clunky, so this PR also adds a "mapping" config similar to that used in the `ibus` block, where you can assign a display name for each sink.