### PR TITLE
Make sure KDE Connect properly errors when it can't connect to the daemon

### DIFF
--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -134,7 +134,10 @@ impl ConfigBlock for KDEConnect {
             // method call opts: only_reachable=false, only_paired=true
             let (devices,): (Vec<String>,) = p1
                 .method_call("org.kde.kdeconnect.daemon", "devices", (false, true))
-                .unwrap();
+                .block_error(
+                    "kdeconnect",
+                    &"Couldn't connect to KDE Connect daemon".to_string(),
+                )?;
             if devices.is_empty() {
                 return Err(BlockError(
                     "kdeconnect".to_owned(),


### PR DESCRIPTION
This would make i3status-rs crash for me, now it at least gives an error. Although maybe it would be better to wait until it can connect to the daemon? idk