### PR TITLE
load: delegate counting cpus to cpuinfo crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpuinfo"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db68970c27ea78b9345e2d0e8e0e4d60e8b9d36779a8f554e77f6d992c22c80"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cpuprofiler"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +312,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "cpuinfo",
  "cpuprofiler",
  "crossbeam-channel",
  "dbus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0"
 swayipc = "2.6.0"
 toml = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
+cpuinfo = "0.1"
 # Optional features/blocks
 libpulse-binding = { optional = true, version = "2.15.0", default-features = false }
 notmuch = { optional = true, version = "0.6.0" }


### PR DESCRIPTION
/proc/cpuinfo is meant to be human readable, and its format is subject to change. On my system (linux kernel 5.7.0), it does not contain the lines which load.rs attempts to read. This PR simplifies things by getting another crate to do the hard work. Works correctly on my system.