### PR TITLE
Add instructions on how to install with cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Stable releases are packaged on some distributions:
 Otherwise, you can install from source:
 
 ```shell
+$ cargo install --git https://github.com/greshake/i3status-rust i3status-rs
+```
+
+(will be installed to ~/.cargo/bin/i3status-rs)
+
+or manually:
+
+```shell
 $ git clone https://github.com/greshake/i3status-rust
 $ cd i3status-rust && cargo build --release
 # Optional:


### PR DESCRIPTION
Until this is published to crates.io, a cargo install --git command can be used as well.