### PR TITLE
Allow setting the icon and state in custom_dbus

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -251,7 +251,7 @@ Key | Values | Required | Default
 
 Creates a block that can be updated asynchronously using DBus.
 
-For example, updating the block using the command line tool `qdbus`: `qdbus i3.status.rs /CurrentSoundDevice i3.status.rs.SetStatus headphones`
+For example, updating the block using the command line tool `qdbus`: `qdbus i3.status.rs /CurrentSoundDevice i3.status.rs.SetStatus Headphones music Good`. The first argument is the text content of the block, the second (optional) argument is the icon to use (as found in `icons.rs`; default ""), and the third (optional) argument is the state (one of Idle, Info, Good, Warning, or Critical; default Idle).
 
 ### Examples
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,3 +1,7 @@
+use std::str::FromStr;
+
+use serde::de::value::{Error, StrDeserializer};
+use serde::de::{Deserialize, IntoDeserializer};
 use serde_derive::Deserialize;
 use serde_json::value::Value;
 
@@ -22,6 +26,15 @@ impl State {
             Warning => (&theme.warning_bg, &theme.warning_fg),
             Critical => (&theme.critical_bg, &theme.critical_fg),
         }
+    }
+}
+
+impl FromStr for State {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let deserializer: StrDeserializer<Error> = s.into_deserializer();
+        State::deserialize(deserializer).map_err(|_| ())
     }
 }
 


### PR DESCRIPTION
This is a fairly straightforward feature for the relatively new custom_dbus block.