### PR TITLE
Add parameter dynamic_width for music block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -692,6 +692,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `player` | Name of the music player. Must be the same name the player is registered with the MediaPlayer2 Interface.  If unset, it will automatically discover the active player.  | Yes | None
 `max_width` | Max width of the block in characters, not including the buttons | No | `21`
+`dynamic_width` | Bool to specify whether the block will change width depending on the text content or remain static always (= `max_width`) | No | `false`
 `marquee` | Bool to specify if a marquee style rotation should be used if the title + artist is longer than max-width | No | `true`
 `marquee_interval` | Marquee interval in seconds. This is the delay between each rotation. | No | `10`
 `marquee_speed` | Marquee speed in seconds. This is the scrolling time used per character. | No | `0.5`

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -250,7 +250,10 @@ impl Block for Music {
                 } else {
                     self.player_avail = true;
 
-                    if !self.smart_trim {
+                    let textlen = title.chars().count()
+                        + self.separator.chars().count()
+                        + artist.chars().count();
+                    if textlen < self.max_width || !self.smart_trim {
                         self.current_song
                             .set_text(format!("{}{}{}", title, self.separator, artist));
                     } else if title.is_empty() {
@@ -278,7 +281,6 @@ impl Block for Music {
                     } else {
                         // Below code is by https://github.com/jgbyrne
                         let text = format!("{}{}{}", title, self.separator, artist);
-                        let textlen = title.chars().count() + artist.chars().count() + 3;
                         if textlen > self.max_width {
                             // overshoot: # of chars we need to trim
                             // substance: # of chars available for trimming

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -54,6 +54,11 @@ pub struct MusicConfig {
     #[serde(default = "MusicConfig::default_max_width")]
     pub max_width: usize,
 
+    /// Bool to specify whether the block will change width depending on the text content
+    /// or remain static always (= max_width)
+    #[serde(default = "MusicConfig::default_dynamic_width")]
+    pub dynamic_width: bool,
+
     /// Bool to specify if a marquee style rotation should be used<br/> if the title + artist is longer than max-width
     #[serde(default = "MusicConfig::default_marquee")]
     pub marquee: bool,
@@ -91,6 +96,10 @@ pub struct MusicConfig {
 impl MusicConfig {
     fn default_max_width() -> usize {
         21
+    }
+
+    fn default_dynamic_width() -> bool {
+        false
     }
 
     fn default_marquee() -> bool {
@@ -187,6 +196,7 @@ impl ConfigBlock for Music {
                 Duration::new(block_config.marquee_interval.as_secs(), 0),
                 Duration::new(0, block_config.marquee_speed.subsec_nanos()),
                 block_config.max_width,
+                block_config.dynamic_width,
                 config.clone(),
             )
             .with_icon("music")

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -10,6 +10,7 @@ use crate::widget::{I3BarWidget, State};
 pub struct RotatingTextWidget {
     rotation_pos: usize,
     max_width: usize,
+    dynamic_width: bool,
     rotation_interval: Duration,
     rotation_speed: Duration,
     next_rotation: Option<Instant>,
@@ -28,11 +29,13 @@ impl RotatingTextWidget {
         interval: Duration,
         speed: Duration,
         max_width: usize,
+        dynamic_width: bool,
         config: Config,
     ) -> RotatingTextWidget {
         RotatingTextWidget {
             rotation_pos: 0,
             max_width,
+            dynamic_width,
             rotation_interval: interval,
             rotation_speed: speed,
             next_rotation: None,
@@ -146,7 +149,7 @@ impl RotatingTextWidget {
                 } else {
                     let text_width = self.get_rotated_content().chars().count();
                     let icon_width = icon.chars().count();
-                    if text_width < self.max_width {
+                    if self.dynamic_width && text_width < self.max_width {
                         "0".repeat(text_width + icon_width)
                     } else {
                         "0".repeat(self.max_width + icon_width + 1)

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -9,7 +9,7 @@ use crate::widget::{I3BarWidget, State};
 #[derive(Clone, Debug)]
 pub struct RotatingTextWidget {
     rotation_pos: usize,
-    width: usize,
+    max_width: usize,
     rotation_interval: Duration,
     rotation_speed: Duration,
     next_rotation: Option<Instant>,
@@ -27,12 +27,12 @@ impl RotatingTextWidget {
     pub fn new(
         interval: Duration,
         speed: Duration,
-        width: usize,
+        max_width: usize,
         config: Config,
     ) -> RotatingTextWidget {
         RotatingTextWidget {
             rotation_pos: 0,
-            width,
+            max_width,
             rotation_interval: interval,
             rotation_speed: speed,
             next_rotation: None,
@@ -67,7 +67,7 @@ impl RotatingTextWidget {
     pub fn with_text(mut self, content: &str) -> Self {
         self.content = String::from(content);
         self.rotation_pos = 0;
-        if self.content.chars().count() > self.width {
+        if self.content.chars().count() > self.max_width {
             self.next_rotation = Some(Instant::now() + self.rotation_interval);
         } else {
             self.next_rotation = None;
@@ -90,7 +90,7 @@ impl RotatingTextWidget {
         if self.content != content {
             self.content = content;
             self.rotation_pos = 0;
-            if self.content.chars().count() > self.width {
+            if self.content.chars().count() > self.max_width {
                 self.next_rotation = Some(Instant::now() + self.rotation_interval);
             } else {
                 self.next_rotation = None;
@@ -104,21 +104,21 @@ impl RotatingTextWidget {
     }
 
     fn get_rotated_content(&self) -> String {
-        if self.content.chars().count() > self.width {
+        if self.content.chars().count() > self.max_width {
             let missing =
-                (self.rotation_pos + self.width).saturating_sub(self.content.chars().count());
+                (self.rotation_pos + self.max_width).saturating_sub(self.content.chars().count());
             if missing == 0 {
                 self.content
                     .chars()
                     .skip(self.rotation_pos)
-                    .take(self.width)
+                    .take(self.max_width)
                     .collect()
             } else {
                 let mut avail: String = self
                     .content
                     .chars()
                     .skip(self.rotation_pos)
-                    .take(self.width)
+                    .take(self.max_width)
                     .collect();
                 avail.push_str("|");
                 avail.push_str(&self.content.chars().take(missing - 1).collect::<String>());
@@ -132,13 +132,26 @@ impl RotatingTextWidget {
     fn update(&mut self) {
         let (key_bg, key_fg) = self.state.theme_keys(&self.config.theme);
 
+        let icon = self.icon.clone().unwrap_or_else(|| String::from(" "));
+
         self.rendered = json!({
             "full_text": format!("{}{} ",
-                                self.icon.clone().unwrap_or_else(|| String::from(" ")),
+                                icon,
                                 self.get_rotated_content()),
             "separator": false,
             "separator_block_width": 0,
-            "min_width": if self.content == "" {"".to_string()} else {"0".repeat(self.width+self.icon.clone().unwrap_or_else(|| String::from(" ")).chars().count()+1)},
+            "min_width":
+                if self.content == "" {
+                    "".to_string()
+                } else {
+                    let text_width = self.get_rotated_content().chars().count();
+                    let icon_width = icon.chars().count();
+                    if text_width < self.max_width {
+                        "0".repeat(text_width + icon_width)
+                    } else {
+                        "0".repeat(self.max_width + icon_width + 1)
+                    }
+                },
             "align": "left",
             "background": key_bg,
             "color": key_fg


### PR DESCRIPTION
By default, the music block has a static width (= `max_width`), and when the name of the music is too short, it looks very ugly: just unnecessary free space inside the bar.

When `dynamic_width` is set to true and the name of the music is longer than `max_width`, block width will be set to `max_width` (marquee option remains available), but when name is less than `max_width`, block width will be set equal to the name of the music, so no free space left.
P.S. I have the music block in the first place (counting from the left), so dynamic width looks very cool. But if people have it in the middle or at the end, then music block will affect next blocks after music and jumpy text can be annoying, so we have this behavior as a config parameter.