### PR TITLE
Fix: TaskWarrior - Don't count deleted items

### DIFF
--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -167,7 +167,7 @@ fn get_number_of_pending_tasks(tags: &[String]) -> Result<u32> {
         Command::new("sh")
             .args(&[
                 "-c",
-                &format!("task rc.gc=off -COMPLETED {} count", tags_to_filter(tags)),
+                &format!("task rc.gc=off -COMPLETED -DELETED {} count", tags_to_filter(tags)),
             ])
             .output()
             .block_error(


### PR DESCRIPTION
The task command count the deleted tasks as pending , adding `-DELETED` to the task command give the correct count of current pending tasks