### PR TITLE
add `on_click` setting for cpu block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -184,6 +184,7 @@ Key | Values | Required | Default
 `format` | A format string. Possible placeholders: `{barchart}` (barchart of each CPU's core utilization), `{utilization}` (average CPU utilization in percent) and `{frequency}` (CPU frequency). | No | `"{utilization}%"`
 `frequency` | Deprecated in favour of `format`. Sets format to `{utilization}% {frequency}GHz` | No | `false`
 `per_core` | Display CPU frequencies and utilization per core. | No | `false`
+`on_click` | Command to execute when the button is clicked. The command will be passed to whatever is specified in your `$SHELL` variable and - if not set - fallback to `sh`. | No | None
 
 
 ## Custom


### PR DESCRIPTION
I wanted this so I can easily open a terminal with `top` running when my cpu usage is high.

Note: this is my first time working with rust. I pretty much just copy pasted code from other blocks.
Took me quite a while to figure out i needed to switch from textwidget to buttonwidget, to make the "name" identifier be emitted for the cpu block, such that click events can have the corresponding name and we can link it back to the cpu block.
some basic instructions for new developers could be helpful for people like me, but otherwise great project :+1: 

