### PR TITLE
Stop printing mouse input events to stderr

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -76,7 +76,8 @@ where
         where
             E: de::Error,
         {
-            eprintln!("{}", value);
+            // TODO: put this behind `--debug` flag
+            //eprintln!("{}", value);
             Ok(match value {
                 1 => MouseButton::Left,
                 2 => MouseButton::Middle,


### PR DESCRIPTION
Looks like it was accidentally added in fe517af58a5c10d7596cb7d4d6096cd7d5739052

Remove it for now as it's not particularly helpful, however can introduce a --debug flag in the future.