### PR TITLE
net block: fix IW SSID regex parsing

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -991,18 +991,14 @@ fn get_iw_ssid(dev: &NetworkDevice) -> Result<Option<String>> {
     }
 
     let raw = raw.unwrap();
-    let bytes = raw.stdout.split(|c| *c == b'\n').next().unwrap();
-    let cap = IW_SSID_REGEX.captures(bytes);
-    if cap.is_none() {
-        return Ok(None);
-    }
-    let match_obj = cap.unwrap().get(1);
-    if match_obj.is_none() {
-        return Ok(None);
-    }
+    let result = raw
+        .stdout
+        .split(|c| *c == b'\n')
+        .filter_map(|x| IW_SSID_REGEX.captures_iter(x).next())
+        .filter_map(|x| x.get(1))
+        .next();
 
-    let caps = match_obj.unwrap().as_bytes();
-    maybe_ssid_convert(Some(caps))
+    maybe_ssid_convert(result.map(|x| x.as_bytes()))
 }
 
 #[inline]


### PR DESCRIPTION
1) don't include extraneous 'SSID: ' prefix. see #814 
2) an SSID is allowed to contain any character. update regex
   accordingly. in particular mine is of the form foo-1234
   and my ssid was reported as 'foo'.

I'm a rust beginner so any feedback on the code is welcome.
I think more can be fixed in this block (e.g. adjusting the other regexes etc), but one small step at a time :) 