### PR TITLE
Signal support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+
+[[package]]
 name = "assert_fs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +337,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "signal-hook",
  "swayipc",
  "toml",
  "uuid",
@@ -729,6 +736,26 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
+dependencies = [
+ "arc-swap",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 swayipc = "2.7"
 toml = "0.5"
+signal-hook = "0.1.16"
 uuid = { version = "0.8", features = ["v4"] }
 # Optional features/blocks
 libpulse-binding = { optional = true, version = "2.15.0", default-features = false }

--- a/blocks.md
+++ b/blocks.md
@@ -234,6 +234,16 @@ command = "uname -r"
 interval = "once"
 ```
 
+Display the screen brightness on an intel machine and update this only when `pkill -SIGRTMIN+4 i3status-rs` is called:
+
+```toml
+[[block]]
+block = "custom"
+command = ''' cat /sys/class/backlight/intel_backlight/brightness | awk '{print $1}' '''
+signal = 4
+interval = "once"
+```
+
 ### Options
 
 Note that `command` and `cycle` are mutually exclusive.
@@ -245,6 +255,7 @@ Key | Values | Required | Default
 `cycle` | Commands to execute and change when the button is clicked. | No | None
 `interval` | Update interval, in seconds (or `"once"` to update only once). | No | `10`
 `json` | Use JSON from command output to format the block. If the JSON is not valid, the block will error out. | No | `false`
+`signal` | Signal value that causes an update for this block with 0 corresponding to `-SIGRTMIN+0` and the largest value being `-SIGRTMAX` | No | None
 
 
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -112,6 +112,17 @@ pub trait Block {
         Ok(None)
     }
 
+    ///Sends a signal event with the provided signal, this function is called on every block
+    ///for every signal event
+    fn signal(&mut self, _signal: i32) -> Result<()> {
+        Ok(())
+    }
+
+    /// Returns the signal that this block is listening to, if any
+    fn get_signal(&self) -> Option<i32> {
+        None
+    }
+
     /// Sends click events to the block. This function is called on every block
     /// for every click; filter events by using the `event.name` property.
     fn click(&mut self, _event: &I3BarEvent) -> Result<()> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -40,6 +40,19 @@ impl I3BarEvent {
     }
 }
 
+/// Starts a thread that listens for provided signals and sends these on the provided channel
+pub fn process_signals(sender: Sender<i32>, signals: Vec<i32>) {
+    thread::Builder::new()
+        .name("signals".into())
+        .spawn(move || loop {
+            let signals = signal_hook::iterator::Signals::new(&signals).unwrap();
+            for sig in signals.forever() {
+                sender.send(sig).unwrap();
+            }
+        })
+        .unwrap();
+}
+
 pub fn process_events(sender: Sender<I3BarEvent>) {
     thread::Builder::new()
         .name("input".into())

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,9 +261,26 @@ fn run(matches: &ArgMatches) -> Result<()> {
             },
             // Receive signal events
             recv(rx_signals) -> res => if let Ok(sig) = res {
-                for block in block_map.values_mut() {
-                    block.signal(sig)?;
-                }
+                match sig {
+                    signal_hook::SIGUSR1 => {
+                        //USR1 signal that updates every block in the bar
+                        for block in block_map.values_mut() {
+                            block.update()?;
+                        }
+                    },
+                    signal_hook::SIGUSR2 => {
+                        //USR2 signal that should reload the config
+                        //TODO not implemented
+                        //unimplemented!("SIGUSR2 is meant to be used to reload the config toml, but this feature is yet not implemented");
+                    },
+                    _ => {
+                        //Real time signal that updates only the blocks listening
+                        //for that signal
+                        for block in block_map.values_mut() {
+                            block.signal(sig)?;
+                        }
+                    },
+                };
                 util::print_blocks(&order, &block_map, &config)?;
             }
         }

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,47 +1,65 @@
 use crate::errors::*;
 use crossbeam_channel::Sender;
 use std::thread;
-/// These are the SIGRTMIN and SIGRTMAX values used to determine the allowed range of signal values
-//FIXME currently these are hardcoded and tested on my system, I am not sure how to bring these in
-//dynamically from the host OS, as such they may vary with OS
-const SIGMIN: i32 = 34;
-const SIGMAX: i32 = 64;
 
 /// Starts a thread that listens for provided signals and sends these on the provided channel
 pub fn process_signals(sender: Sender<i32>) {
     thread::Builder::new()
         .name("signals".into())
-        .spawn(move || loop {
-            let signals =
-                signal_hook::iterator::Signals::new(&(SIGMIN..SIGMAX).collect::<Vec<_>>()).unwrap();
-            for sig in signals.forever() {
-                sender.send(sig).unwrap();
+        .spawn(move || {
+            let sigmin;
+            let sigmax;
+            unsafe {
+                sigmin = __libc_current_sigrtmin();
+                sigmax = __libc_current_sigrtmax();
+            }
+            loop {
+                let signals =
+                    signal_hook::iterator::Signals::new(&(sigmin..sigmax).collect::<Vec<_>>())
+                        .unwrap();
+                for sig in signals.forever() {
+                    sender.send(sig).unwrap();
+                }
             }
         })
         .unwrap();
 }
 
 pub fn convert_to_valid_signal(signal: i32) -> Result<i32> {
-    if signal < 0 || signal > SIGMAX - SIGMIN {
+    let sigmin;
+    let sigmax;
+    unsafe {
+        sigmin = __libc_current_sigrtmin();
+        sigmax = __libc_current_sigrtmax();
+    }
+    if signal < 0 || signal > sigmax - sigmin {
         //NOTE If some important information is encoded in the third field of this error this might
         //need to be added
         return Err(Error::ConfigurationError(
             format!(
             "A provided signal was out of bounds. An allowed signal needs to be between {} and {}",
             0,
-            SIGMAX - SIGMIN
+            sigmax - sigmin
         ),
             (
                 format!(
                     "Provided signal is {} which is not between {} and {}",
                     signal,
                     0,
-                    SIGMAX - SIGMIN
+                    sigmax - sigmin
                 ),
                 String::new(),
             ),
         ));
     } else {
-        return Ok(signal + SIGMIN);
+        return Ok(signal + sigmin);
     }
+}
+
+//TODO when libc exposes this through their library and even better when the nix crate does we
+//should be using that binding rather than a C-binding.
+///C bindings to SIGMIN and SIGMAX values
+extern "C" {
+    fn __libc_current_sigrtmin() -> i32;
+    fn __libc_current_sigrtmax() -> i32;
 }

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -14,9 +14,10 @@ pub fn process_signals(sender: Sender<i32>) {
                 sigmax = __libc_current_sigrtmax();
             }
             loop {
-                let signals =
-                    signal_hook::iterator::Signals::new(&(sigmin..sigmax).collect::<Vec<_>>())
-                        .unwrap();
+                let mut signals = (sigmin..sigmax).collect::<Vec<_>>();
+                signals.push(signal_hook::SIGUSR1);
+                signals.push(signal_hook::SIGUSR2);
+                let signals = signal_hook::iterator::Signals::new(&signals).unwrap();
                 for sig in signals.forever() {
                     sender.send(sig).unwrap();
                 }


### PR DESCRIPTION
Add a **status** field to the custom block that takes a value between 0 and 30. These correspond to SIGRTMIN+0 to SIGRTMIN+30.
This causes the block to be updated by sending the corresponding SIGRT signal to i3status-rs. This can be done via
`pkill -SIGRTMIN+1 i3status-rs` in order to send a signal to blocks listening for signal 1.

This feature allows custom blocks to not need to be updated on an interval, but instead can be updated via scripts sending a signal when they need to update.

A possible flaw is that I was not able to find a good way of pulling in the signal range dynamically from the users computer, instead the range is hard-coded to listen to signals between 34 and 64 (where this is the range on my computer).
The relevant constants can be found in **src/signals.rs**