### PR TITLE
nvidia block: if label is provided then show it first

### DIFF
--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -69,7 +69,7 @@ pub struct NvidiaGpuConfig {
 
     /// Label to show instead of the default GPU name from `nvidia-smi`
     #[serde(default = "NvidiaGpuConfig::default_label")]
-    pub label: String,
+    pub label: Option<String>,
 
     /// GPU id in system
     #[serde(default = "NvidiaGpuConfig::default_gpu_id")]
@@ -117,8 +117,8 @@ impl NvidiaGpuConfig {
         Duration::from_secs(3)
     }
 
-    fn default_label() -> String {
-        "".to_string()
+    fn default_label() -> Option<String> {
+        None
     }
 
     fn default_gpu_id() -> u64 {
@@ -183,8 +183,16 @@ impl ConfigBlock for NvidiaGpu {
             gpu_id: block_config.gpu_id,
 
             name_widget: ButtonWidget::new(config.clone(), &id).with_icon("gpu"),
-            name_widget_mode: NameWidgetMode::ShowDefaultName,
-            label: block_config.label,
+            name_widget_mode: if block_config.label.is_some() {
+                NameWidgetMode::ShowLabel
+            } else {
+                NameWidgetMode::ShowDefaultName
+            },
+            label: if block_config.label.is_some() {
+                block_config.label.unwrap()
+            } else {
+                "".to_string()
+            },
 
             show_memory: if block_config.show_memory {
                 Some(ButtonWidget::new(config.clone(), &id_memory))


### PR DESCRIPTION
If someone sets `label` in their config then it is a pretty good bet that they want the bar to display that instead of the default GPU name from `nvidia-smi`.

Up until now those users would have had to click the bar after startup to get the widget to show the label, but now it will show the label first by default.

Should resolve the usecase desired by #754