### PR TITLE
load block: fix CPU count

### DIFF
--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -1,14 +1,13 @@
-use serde_derive::Deserialize;
 use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::time::Duration;
 
 use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 use uuid::Uuid;
 
-use crate::blocks::Update;
-use crate::blocks::{Block, ConfigBlock};
+use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -1,6 +1,5 @@
-use std::fs::{File, OpenOptions};
+use std::fs::{read_to_string, OpenOptions};
 use std::io::prelude::*;
-use std::io::BufReader;
 use std::time::Duration;
 
 use crossbeam_channel::Sender;
@@ -85,22 +84,13 @@ impl ConfigBlock for Load {
             .with_icon("cogs")
             .with_state(State::Info);
 
-        let f = File::open("/proc/cpuinfo")
+        // borrowed from https://docs.rs/cpuinfo/0.1.1/src/cpuinfo/count/logical.rs.html#4-6
+        let content = read_to_string("/proc/cpuinfo")
             .block_error("load", "Your system doesn't support /proc/cpuinfo")?;
-        let f = BufReader::new(f);
-
-        let mut logical_cores = 0;
-
-        for line in f.lines().scan((), |_, x| x.ok()) {
-            // TODO: Does this value always represent the correct number of logical cores?
-            if line.starts_with("siblings") {
-                let split: Vec<&str> = (&line).split(' ').collect();
-                logical_cores = split[1]
-                    .parse::<u32>()
-                    .block_error("load", "Invalid Cpu info format!")?;
-                break;
-            }
-        }
+        let logical_cores = content
+            .lines()
+            .filter(|l| l.starts_with("processor"))
+            .count() as u32;
 
         Ok(Load {
             id: Uuid::new_v4().to_simple().to_string(),


### PR DESCRIPTION
Resolves #749, supersedes #748

This works on my system, but then again mine worked with the old code too.
This PR uses the same method as the `cpuinfo` crate to determine the CPU count.