### PR TITLE
Fix spacing for inline widgets

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -24,7 +24,7 @@ use crate::subprocess::spawn_child_async;
 use crate::util::{
     escape_pango_text, format_percent_bar, format_speed, format_vec_to_bar_graph, FormatTemplate,
 };
-use crate::widget::I3BarWidget;
+use crate::widget::{I3BarWidget, Spacing};
 use crate::widgets::button::ButtonWidget;
 
 lazy_static! {
@@ -596,7 +596,9 @@ impl ConfigBlock for Net {
             update_interval: block_config.interval,
             format: FormatTemplate::from_string(&format)
                 .block_error("net", "Invalid format specified")?,
-            output: ButtonWidget::new(config.clone(), "").with_text(""),
+            output: ButtonWidget::new(config.clone(), "")
+                .with_text("")
+                .with_spacing(Spacing::Inline),
             config: config.clone(),
             use_bits: block_config.use_bits,
             speed_min_unit: block_config.speed_min_unit,

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -12,7 +12,7 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::widget::{I3BarWidget, State};
+use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::text::TextWidget;
 
@@ -182,7 +182,9 @@ impl ConfigBlock for NvidiaGpu {
             gpu_enabled: false,
             gpu_id: block_config.gpu_id,
 
-            name_widget: ButtonWidget::new(config.clone(), &id).with_icon("gpu"),
+            name_widget: ButtonWidget::new(config.clone(), &id)
+                .with_icon("gpu")
+                .with_spacing(Spacing::Inline),
             name_widget_mode: if block_config.label.is_some() {
                 NameWidgetMode::ShowLabel
             } else {
@@ -195,26 +197,26 @@ impl ConfigBlock for NvidiaGpu {
             },
 
             show_memory: if block_config.show_memory {
-                Some(ButtonWidget::new(config.clone(), &id_memory))
+                Some(ButtonWidget::new(config.clone(), &id_memory).with_spacing(Spacing::Inline))
             } else {
                 None
             },
             memory_widget_mode: MemoryWidgetMode::ShowUsedMemory,
 
             show_utilization: if block_config.show_utilization {
-                Some(TextWidget::new(config.clone()))
+                Some(TextWidget::new(config.clone()).with_spacing(Spacing::Inline))
             } else {
                 None
             },
 
             show_temperature: if block_config.show_temperature {
-                Some(TextWidget::new(config.clone()))
+                Some(TextWidget::new(config.clone()).with_spacing(Spacing::Inline))
             } else {
                 None
             },
 
             show_fan: if block_config.show_fan_speed {
-                Some(ButtonWidget::new(config.clone(), &id_fans))
+                Some(ButtonWidget::new(config.clone(), &id_fans).with_spacing(Spacing::Inline))
             } else {
                 None
             },
@@ -223,7 +225,7 @@ impl ConfigBlock for NvidiaGpu {
             scrolling: config.scrolling,
 
             show_clocks: if block_config.show_clocks {
-                Some(TextWidget::new(config.clone()))
+                Some(TextWidget::new(config.clone()).with_spacing(Spacing::Inline))
             } else {
                 None
             },
@@ -293,8 +295,16 @@ impl Block for NvidiaGpu {
             let memory_total = result[1].to_string();
 
             match self.name_widget_mode {
-                NameWidgetMode::ShowDefaultName => self.name_widget.set_text(gpu_name.to_string()),
+                NameWidgetMode::ShowDefaultName => {
+                    self.name_widget.set_text(gpu_name.to_string());
+                    self.name_widget.set_spacing(Spacing::Inline);
+                }
                 NameWidgetMode::ShowLabel => {
+                    if self.label.is_empty() {
+                        self.name_widget.set_spacing(Spacing::Hidden);
+                    } else {
+                        self.name_widget.set_spacing(Spacing::Inline);
+                    }
                     self.name_widget.set_text(self.label.to_string());
                 }
             }

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -14,7 +14,7 @@ use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::util::FormatTemplate;
-use crate::widget::{I3BarWidget, State};
+use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct Temperature {
@@ -124,7 +124,13 @@ impl ConfigBlock for Temperature {
         let id = Uuid::new_v4().to_simple().to_string();
         Ok(Temperature {
             update_interval: block_config.interval,
-            text: ButtonWidget::new(config, &id).with_icon("thermometer"),
+            text: ButtonWidget::new(config, &id)
+                .with_icon("thermometer")
+                .with_spacing(if block_config.collapsed {
+                    Spacing::Hidden
+                } else {
+                    Spacing::Normal
+                }),
             output: String::new(),
             collapsed: block_config.collapsed,
             id,
@@ -232,8 +238,10 @@ impl Block for Temperature {
                 self.collapsed = !self.collapsed;
                 if self.collapsed {
                     self.text.set_text(String::new());
+                    self.text.set_spacing(Spacing::Hidden);
                 } else {
                     self.text.set_text(self.output.clone());
+                    self.text.set_spacing(Spacing::Normal);
                 }
             }
         }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -8,6 +8,16 @@ use serde_json::value::Value;
 use crate::themes::Theme;
 
 #[derive(Debug, Copy, Clone, Deserialize)]
+pub enum Spacing {
+    /// Add a leading and trailing space around the widget contents
+    Normal,
+    /// Hide the leading space when the widget is inline
+    Inline,
+    /// Hide both leading and trailing spaces when widget is hidden
+    Hidden,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize)]
 pub enum State {
     Idle,
     Info,

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -2,6 +2,7 @@ use serde_json::value::Value;
 
 use super::super::widget::I3BarWidget;
 use crate::config::Config;
+use crate::widget::Spacing;
 use crate::widget::State;
 
 #[derive(Clone, Debug)]
@@ -9,6 +10,7 @@ pub struct ButtonWidget {
     content: Option<String>,
     icon: Option<String>,
     state: State,
+    spacing: Spacing,
     id: String,
     rendered: Value,
     cached_output: Option<String>,
@@ -21,6 +23,7 @@ impl ButtonWidget {
             content: None,
             icon: None,
             state: State::Idle,
+            spacing: Spacing::Normal,
             id: String::from(id),
             rendered: json!({
                 "full_text": "",
@@ -59,6 +62,12 @@ impl ButtonWidget {
         self
     }
 
+    pub fn with_spacing(mut self, spacing: Spacing) -> Self {
+        self.spacing = spacing;
+        self.update();
+        self
+    }
+
     pub fn set_text<S: Into<String>>(&mut self, content: S) {
         self.content = Some(content.into());
         self.update();
@@ -74,13 +83,29 @@ impl ButtonWidget {
         self.update();
     }
 
+    pub fn set_spacing(&mut self, spacing: Spacing) {
+        self.spacing = spacing;
+        self.update();
+    }
+
     fn update(&mut self) {
         let (key_bg, key_fg) = self.state.theme_keys(&self.config.theme);
 
+        // When rendered inline, remove the leading space
         self.rendered = json!({
-            "full_text": format!("{}{} ",
-                                self.icon.clone().unwrap_or_else(|| String::from(" ")),
-                                self.content.clone().unwrap_or_else(|| String::from(""))),
+            "full_text": format!("{}{}{}",
+                                self.icon.clone().unwrap_or_else(|| {
+                                    match self.spacing {
+                                        Spacing::Normal => String::from(" "),
+                                        _ => String::from("")
+                                    }
+                                }),
+                                self.content.clone().unwrap_or_else(|| String::from("")),
+                                match self.spacing {
+                                    Spacing::Hidden => String::from(""),
+                                    _ => String::from(" ")
+                                }
+                            ),
             "separator": false,
             "name": self.id.clone(),
             "separator_block_width": 0,

--- a/src/widgets/graph.rs
+++ b/src/widgets/graph.rs
@@ -3,6 +3,7 @@ use serde_json::value::Value;
 
 use super::super::widget::I3BarWidget;
 use crate::config::Config;
+use crate::widget::Spacing;
 use crate::widget::State;
 
 #[derive(Clone, Debug)]
@@ -10,6 +11,7 @@ pub struct GraphWidget {
     content: Option<String>,
     icon: Option<String>,
     state: State,
+    spacing: Spacing,
     rendered: Value,
     cached_output: Option<String>,
     config: Config,
@@ -21,6 +23,7 @@ impl GraphWidget {
             content: None,
             icon: None,
             state: State::Idle,
+            spacing: Spacing::Normal,
             rendered: json!({
                 "full_text": "",
                 "separator": false,
@@ -41,6 +44,12 @@ impl GraphWidget {
 
     pub fn with_state(mut self, state: State) -> Self {
         self.state = state;
+        self.update();
+        self
+    }
+
+    pub fn with_spacing(mut self, spacing: Spacing) -> Self {
+        self.spacing = spacing;
         self.update();
         self
     }
@@ -93,9 +102,19 @@ impl GraphWidget {
         let (key_bg, key_fg) = self.state.theme_keys(&self.config.theme);
 
         self.rendered = json!({
-            "full_text": format!("{}{} ",
-                                self.icon.clone().unwrap_or_else(|| String::from(" ")),
-                                self.content.clone().unwrap_or_else(|| String::from(""))),
+            "full_text": format!("{}{}{}",
+                                self.icon.clone().unwrap_or_else(|| {
+                                    match self.spacing {
+                                        Spacing::Normal => String::from(" "),
+                                        _ => String::from("")
+                                    }
+                                }),
+                                self.content.clone().unwrap_or_else(|| String::from("")),
+                                match self.spacing {
+                                    Spacing::Hidden => String::from(""),
+                                    _ => String::from(" ")
+                                }
+                            ),
             "separator": false,
             "separator_block_width": 0,
             "background": key_bg.to_owned(),


### PR DESCRIPTION
I have added a spacing setting for each widget that can control the spacing.
The `Inline` setting will remove the leading space, which is very useful for sub-widget in some blocks.
The `Hidden` setting will remove both the leading space and trailing space, which is useful for hidden blocks.

To demonstrate the usage, I have also fixed the spacing for `nvidia_gpu` block.

This PR should resolve the issue #800.