### PR TITLE
backlight: support nonlinear brightness

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -66,6 +66,11 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `device` | The `/sys/class/backlight` device to read brightness information from. | No | Default device
 `step_width` | The brightness increment to use when scrolling, in percent. | No | `5`
+`root_scaling` | Scaling exponent reciprocal (ie. root). | No | `1.0`
+
+Some devices expose raw values that are best handled with nonlinear scaling. The human perception of lightness is close to the cube root of relative luminance, so settings for `root_scaling` between 2.4 and 3.0 are worth trying. For devices with few discrete steps this should be 1.0 (linear).
+
+More information: <https://en.wikipedia.org/wiki/Lightness>
 
 ### Setting Brightness with the Mouse Wheel
 


### PR DESCRIPTION
The raw brightness values are quite useless on some hardware. Add an
option to scale the raw backlight PWM values on a power scale.

Since there is no single correct exponent even in the CIELAB L* function
and the mapping between raw hardware brightness value and relative
luminance is unknown, the implementation allows user to fine-tune the
exponent.