### PR TITLE
[theme-plain] have seperator without extra space

### DIFF
--- a/src/themes.rs
+++ b/src/themes.rs
@@ -90,7 +90,7 @@ lazy_static! {
         warning_fg: "#b58900".to_owned(),
         critical_bg: "#000000".to_owned(),
         critical_fg: "#dc322f".to_owned(),
-        separator: "| ".to_owned(),
+        separator: "|".to_owned(),
         separator_bg: "#000000".to_owned(),
         separator_fg: "#a9a9a9".to_owned(),
         alternating_tint_bg: "#000000".to_owned(),


### PR DESCRIPTION
currently the plain theme has a weird spacing with the separator. I expect this is not intentional.

![Screenshot-2020-10-22_150211](https://user-images.githubusercontent.com/1315818/96875697-cf820300-1477-11eb-804c-f8c6eed1ed17.png)
