### PR TITLE
WIP: Fix net hiding

### DIFF
--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -250,7 +250,7 @@ impl ConfigBlock for Music {
             on_click: block_config.on_click,
             on_collapsed_click_widget: ButtonWidget::new(config.clone(), "on_collapsed_click")
                 .with_icon("music")
-                .with_state(State::Info),
+                .with_state(State::Idle),
             on_collapsed_click: block_config.on_collapsed_click,
             dbus_conn: Connection::get_private(BusType::Session)
                 .block_error("music", "failed to establish D-Bus connection")?,

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -367,6 +367,7 @@ pub struct Net {
     speed_min_unit: Unit,
     speed_digits: usize,
     active: bool,
+    exists: bool,
     hide_inactive: bool,
     hide_missing: bool,
     last_update: Instant,
@@ -667,6 +668,7 @@ impl ConfigBlock for Net {
             rx_bytes: init_rx_bytes,
             tx_bytes: init_tx_bytes,
             active: true,
+            exists: true,
             hide_inactive: block_config.hide_inactive,
             hide_missing: block_config.hide_missing,
             last_update: Instant::now() - Duration::from_secs(30),
@@ -855,6 +857,8 @@ impl Block for Net {
         let is_up = self.device.is_up()?;
         if !exists || !is_up {
             self.active = false;
+            self.exists = exists;
+
             self.network.set_text("×".to_string());
             if let Some(ref mut tx) = self.output_tx {
                 *tx = "×".to_string();
@@ -925,10 +929,10 @@ impl Block for Net {
     fn view(&self) -> Vec<&dyn I3BarWidget> {
         if self.active {
             vec![&self.network, &self.output]
-        } else if !self.hide_inactive || !self.hide_missing {
-            vec![&self.network]
-        } else {
+        } else if self.hide_inactive || !self.exists && self.hide_missing {
             vec![]
+        } else {
+            vec![&self.network]
         }
     }
 

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -227,9 +227,9 @@ impl Block for SpeedTest {
                 #[allow(clippy::unknown_clippy_lints)]
                 #[allow(clippy::match_on_vec_items)]
                 self.text[0].set_state(match_range!(vals[0], default: (State::Critical) {
-                            0.0 ; 25.0 => State::Good,
-                            25.0 ; 60.0 => State::Info,
-                            60.0 ; 100.0 => State::Warning
+                            0.0 ; 50.0 => State::Idle,
+                            50.0 ; 100.0 => State::Info,
+                            100.0 ; 200.0 => State::Warning
                 }));
             }
 


### PR DESCRIPTION
Fix net block issue where both `hide_inactive` and `hide_missing` had to be enabled to ever hide the block on either case.

This PR implements the functionality as i would expect it:

- active = !exists || !up
- show full block if active
- hide block if inactive && hide_inactive || !exists && hide_missing
- otherwise, show only icon