### PR TITLE
Fix net block hiding issue

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -790,8 +790,8 @@ Key | Values | Required | Default
 `speed_min_unit` | Smallest unit to use when displaying speeds. Possible choices: `"B"`, `"K"`, `"M"`, `"G"`, `"T"`.| No | `"K"`
 `use_bits` | Display speeds in bits instead of bytes. | No | `false`
 `interval` | Update interval, in seconds. Note: the update interval for SSID and IP address is fixed at 30 seconds, and bitrate fixed at 10 seconds. | No | `1`
-`hide_missing` | Whether to hide networks that are missing. | No | `false`
-`hide_inactive` | Whether to hide networks that are down/inactive completely. | No | `false`
+`hide_missing` | Whether to hide interfaces that don't exist on the system. | No | `false`
+`hide_inactive` | Whether to hide interfaces that are not connected (or missing). | No | `false`
 
 ### Format String
 Placeholder | Description

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -367,6 +367,7 @@ pub struct Net {
     speed_min_unit: Unit,
     speed_digits: usize,
     active: bool,
+    exists: bool,
     hide_inactive: bool,
     hide_missing: bool,
     last_update: Instant,
@@ -667,6 +668,7 @@ impl ConfigBlock for Net {
             rx_bytes: init_rx_bytes,
             tx_bytes: init_tx_bytes,
             active: true,
+            exists: true,
             hide_inactive: block_config.hide_inactive,
             hide_missing: block_config.hide_missing,
             last_update: Instant::now() - Duration::from_secs(30),
@@ -855,6 +857,8 @@ impl Block for Net {
         let is_up = self.device.is_up()?;
         if !exists || !is_up {
             self.active = false;
+            self.exists = exists;
+
             self.network.set_text("×".to_string());
             if let Some(ref mut tx) = self.output_tx {
                 *tx = "×".to_string();
@@ -925,10 +929,10 @@ impl Block for Net {
     fn view(&self) -> Vec<&dyn I3BarWidget> {
         if self.active {
             vec![&self.network, &self.output]
-        } else if !self.hide_inactive || !self.hide_missing {
-            vec![&self.network]
-        } else {
+        } else if self.hide_inactive || !self.exists && self.hide_missing {
             vec![]
+        } else {
+            vec![&self.network]
         }
     }
 

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -868,7 +868,6 @@ impl Block for Net {
             return Ok(Some(self.update_interval.into()));
         }
 
-        self.active = true;
         self.network.set_text("".to_string());
 
         // Update SSID and IP address every 30s and the bitrate every 10s

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -853,11 +853,9 @@ impl Block for Net {
         self.update_device();
 
         // skip updating if device is not up.
-        let exists = self.device.exists()?;
-        let is_up = self.device.is_up()?;
-        if !exists || !is_up {
-            self.active = false;
-            self.exists = exists;
+        self.exists = self.device.exists()?;
+        self.active = self.exists && self.device.is_up()?;
+        if !self.active {
 
             self.network.set_text("×".to_string());
             if let Some(ref mut tx) = self.output_tx {


### PR DESCRIPTION
Fix net block issue where both `hide_inactive` and `hide_missing` had to be enabled to ever hide the block on either case. (#891)

This PR implements the functionality as i would expect it:

- active = !exists || !up
- show full block if active
- hide block if inactive && hide_inactive || !exists && hide_missing
- otherwise, show only icon

I tested all cases and it works as described.

Does that sound correct to you, @ammgws @mvdan ?