### PR TITLE
[blocks] fix equal spacing in battery & sound & networkmanager

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -22,7 +22,7 @@ use crate::scheduler::Task;
 use crate::util::{
     battery_level_to_icon, format_percent_bar, pseudo_uuid, read_file, FormatTemplate,
 };
-use crate::widget::{I3BarWidget, State};
+use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::text::TextWidget;
 
 /// A battery device can be queried for a few properties relevant to the user.
@@ -746,6 +746,7 @@ impl Block for Battery {
             self.output
                 .set_text(self.full_format.render_static_str(&values)?);
             self.output.set_state(State::Good);
+            self.output.set_spacing(Spacing::Hidden);
         } else {
             self.output
                 .set_text(self.format.render_static_str(&values)?);
@@ -781,6 +782,7 @@ impl Block for Battery {
                 "Charging" => "bat_charging",
                 _ => battery_level_to_icon(capacity),
             });
+            self.output.set_spacing(Spacing::Normal);
         }
 
         match self.driver {

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -22,7 +22,7 @@ use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
 use crate::util::{pseudo_uuid, FormatTemplate};
-use crate::widget::{I3BarWidget, State};
+use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 
 enum NetworkState {
@@ -652,7 +652,9 @@ impl Block for NetworkManager {
                 connections
                     .into_iter()
                     .filter_map(|conn| {
-                        let mut widget = ButtonWidget::new(self.config.clone(), &self.id);
+                        // inline spacing for no leading space, because the icon is set in the string
+                        let mut widget = ButtonWidget::new(self.config.clone(), &self.id)
+                            .with_spacing(Spacing::Inline);
 
                         // Set the state for this connection
                         widget.set_state(if let Ok(conn_state) = conn.state(&self.dbus_conn) {

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -38,7 +38,7 @@ use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
 use crate::util::{format_percent_bar, pseudo_uuid, FormatTemplate};
-use crate::widget::{I3BarWidget, State};
+use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 
 trait SoundDevice {
@@ -872,8 +872,10 @@ impl Sound {
                 } else {
                     self.text.set_text(text);
                 }
+                self.text.set_spacing(Spacing::Normal);
             } else {
                 self.text.set_text("");
+                self.text.set_spacing(Spacing::Hidden);
             }
             self.text.set_state(State::Warning);
         } else {
@@ -883,6 +885,7 @@ impl Sound {
             } else {
                 text
             });
+            self.text.set_spacing(Spacing::Normal);
             self.text.set_state(State::Idle);
         }
 

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -74,6 +74,11 @@ impl TextWidget {
         self.update();
     }
 
+    pub fn set_spacing(&mut self, spacing: Spacing) {
+        self.spacing = spacing;
+        self.update();
+    }
+
     fn update(&mut self) {
         let (key_bg, key_fg) = self.state.theme_keys(&self.config.theme);
 


### PR DESCRIPTION
related to #900 .

If the battery if fully charged, then the percentage does not have an additonal space.

Same if the volume if muted (and percentage not printed)