### PR TITLE
Fix alternating tint logic when blocks are hidden

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -159,59 +159,15 @@ fn run(matches: &ArgMatches) -> Result<()> {
         return Ok(());
     }
 
-    let mut config_alternating_tint = config.clone();
-    {
-        let tint_bg = &config.theme.alternating_tint_bg;
-        config_alternating_tint.theme.idle_bg =
-            util::add_colors(&config_alternating_tint.theme.idle_bg, tint_bg)
-                .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.info_bg =
-            util::add_colors(&config_alternating_tint.theme.info_bg, tint_bg)
-                .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.good_bg =
-            util::add_colors(&config_alternating_tint.theme.good_bg, tint_bg)
-                .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.warning_bg =
-            util::add_colors(&config_alternating_tint.theme.warning_bg, tint_bg)
-                .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.critical_bg =
-            util::add_colors(&config_alternating_tint.theme.critical_bg, tint_bg)
-                .configuration_error("can't parse alternative_tint color code")?;
-
-        let tint_fg = &config.theme.alternating_tint_fg;
-        config_alternating_tint.theme.idle_fg =
-            util::add_colors(&config_alternating_tint.theme.idle_fg, tint_fg)
-                .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.info_fg =
-            util::add_colors(&config_alternating_tint.theme.info_fg, tint_fg)
-                .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.good_fg =
-            util::add_colors(&config_alternating_tint.theme.good_fg, tint_fg)
-                .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.warning_fg =
-            util::add_colors(&config_alternating_tint.theme.warning_fg, tint_fg)
-                .configuration_error("can't parse alternative_tint color code")?;
-        config_alternating_tint.theme.critical_fg =
-            util::add_colors(&config_alternating_tint.theme.critical_fg, tint_fg)
-                .configuration_error("can't parse alternative_tint color code")?;
-    }
-
-    let mut blocks: Vec<Box<dyn Block>> = Vec::new();
-
-    let mut alternator = false;
     // Initialize the blocks
+    let mut blocks: Vec<Box<dyn Block>> = Vec::new();
     for &(ref block_name, ref block_config) in &config.blocks {
         blocks.push(create_block(
             block_name,
             block_config.clone(),
-            if alternator {
-                config_alternating_tint.clone()
-            } else {
-                config.clone()
-            },
+            config.clone(),
             tx_update_requests.clone(),
         )?);
-        alternator = !alternator;
     }
 
     // We save the order of the blocks here,

--- a/src/util.rs
+++ b/src/util.rs
@@ -213,6 +213,7 @@ pub fn print_blocks(
         last_bg: None,
     };
 
+    let mut alternator = false;
     print!("[");
     for block_id in order {
         let block = &(*(block_map
@@ -223,12 +224,27 @@ pub fn print_blocks(
             continue;
         }
         let first = widgets[0];
-        let color = first.get_rendered()["background"]
-            .as_str()
-            .internal_error("util", "couldn't get background color")?;
+
+        let color = if alternator {
+            let mut first_json: serde_json::Value = first.get_rendered().to_owned();
+            *first_json.get_mut("background").unwrap() = json!(add_colors(
+                &first_json["background"].to_string()[1..],
+                &config.theme.alternating_tint_bg
+            )
+            .unwrap());
+            first_json["background"]
+                .as_str()
+                .internal_error("util", "couldn't get background color")?
+                .to_owned()
+        } else {
+            first.get_rendered()["background"]
+                .as_str()
+                .internal_error("util", "couldn't get background color")?
+                .to_owned()
+        };
 
         let sep_fg = if config.theme.separator_fg == "auto" {
-            color
+            &color
         } else {
             &config.theme.separator_fg
         };
@@ -255,23 +271,46 @@ pub fn print_blocks(
             if state.has_predecessor { "," } else { "" },
             separator.to_string()
         );
-        print!("{}", first.to_string());
+
+        if alternator {
+            let mut first_json: serde_json::Value = first.get_rendered().to_owned();
+            *first_json.get_mut("background").unwrap() = json!(add_colors(
+                &first_json["background"].to_string()[1..],
+                &config.theme.alternating_tint_bg
+            )
+            .unwrap());
+            print!("{}", first_json.to_string());
+        } else {
+            print!("{}", first.to_string());
+        }
         state.set_last_bg(color.to_owned());
         state.set_predecessor(true);
 
         for widget in widgets.iter().skip(1) {
+            let w = if alternator {
+                let mut w_json: serde_json::Value = widget.get_rendered().to_owned();
+                *w_json.get_mut("background").unwrap() = json!(add_colors(
+                    &w_json["background"].to_string()[1..],
+                    &config.theme.alternating_tint_bg
+                )
+                .unwrap());
+                w_json
+            } else {
+                widget.get_rendered().to_owned()
+            };
             print!(
                 "{}{}",
                 if state.has_predecessor { "," } else { "" },
-                widget.to_string()
+                w.to_string()
             );
             state.set_last_bg(String::from(
-                widget.get_rendered()["background"]
+                w["background"]
                     .as_str()
                     .internal_error("util", "couldn't get background color")?,
             ));
             state.set_predecessor(true);
         }
+        alternator = !alternator;
     }
     println!("],");
 


### PR DESCRIPTION
Fixes https://github.com/greshake/i3status-rust/issues/349

@GladOSkar would you like to give it a go and see if it's fixed? Testing with the below config showed the colours match the current behaviour so I assume it's working:

```toml
[theme]
name = "slick"
[theme.overrides]
separator = "SEPARATOR"

[icons]
name = "awesome"

[[block]]
block = "time"

[[block]]
block = "time"

[[block]]
block = "time"

[[block]]
block = "time"
```