### PR TITLE
net block: do not error out when arrays are empty

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -270,9 +270,7 @@ impl NetworkDevice {
             .flat_map(|dev| &dev.addr_info)
             .filter_map(|addr| addr.local.clone())
             .next();
-
-        ip.block_error("net", &format!("Malformed JSON: {}", output))
-            .map(Some)
+        return Ok(ip);
     }
 
     /// Queries the inet IPv6 of this device (using `ip`).
@@ -301,8 +299,7 @@ impl NetworkDevice {
             .flat_map(|dev| &dev.addr_info)
             .filter_map(|addr| addr.local.clone())
             .next();
-        ip.block_error("net", &format!("Malformed JSON: {}", output))
-            .map(Some)
+        return Ok(ip);
     }
 
     /// Queries the bitrate of this device


### PR DESCRIPTION
"Malformed JSON" doesn't make sense as an error since if the JSON itself was
invalid then serde would catch it earlier. We will trust that `ip` is outputting
a valid response, and if that response contains no ip address info then we can
just return None instead of erroring out.