### PR TITLE
Music block: Fix `hide_when_empty` not working

### DIFF
--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -677,7 +677,7 @@ impl Block for Music {
             .players
             .lock()
             .expect("failed to acquire lock for `players`");
-        if players.len() == 0 && self.hide_when_empty {
+        if self.current_song_widget.is_empty() && self.hide_when_empty {
             vec![]
         } else if players.len() > 0 && !self.current_song_widget.is_empty() {
             let mut elements: Vec<&dyn I3BarWidget> = Vec::new();


### PR DESCRIPTION
So for some reason my `music` block wasn't hiding with `hide_when_empty = true` even though i had no players open.

This change fixed that, although i don't _really_ know why or what the different variables actually mean.

Hope this is okay?