### PR TITLE
graph widget: add braille dot format

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -829,7 +829,7 @@ impl Net {
             if let Some(ref mut graph_tx) = self.graph_tx {
                 self.tx_buff.remove(0);
                 self.tx_buff.push(tx_bytes);
-                *graph_tx = format_vec_to_bar_graph(&self.tx_buff, None, None);
+                *graph_tx = format_vec_to_bar_graph(&self.tx_buff, None, None, true);
             }
         }
         if self.output_rx.is_some() || self.graph_rx.is_some() {
@@ -849,7 +849,7 @@ impl Net {
             if let Some(ref mut graph_rx) = self.graph_rx {
                 self.rx_buff.remove(0);
                 self.rx_buff.push(rx_bytes);
-                *graph_rx = format_vec_to_bar_graph(&self.rx_buff, None, None);
+                *graph_rx = format_vec_to_bar_graph(&self.rx_buff, None, None, true);
             }
         }
         Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -348,15 +348,29 @@ pub fn format_percent_bar(percent: f32) -> String {
         .collect()
 }
 
-pub fn format_vec_to_bar_graph<T>(content: &[T], min: Option<T>, max: Option<T>) -> String
+pub fn format_vec_to_bar_graph<T>(
+    content: &[T],
+    min: Option<T>,
+    max: Option<T>,
+    dots: bool,
+) -> String
 where
     T: Ord + ToPrimitive,
 {
-    // (x * one eighth block) https://en.wikipedia.org/wiki/Block_Elements
-    let bars = [
-        '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}', '\u{2585}', '\u{2586}', '\u{2587}',
-        '\u{2588}',
-    ];
+    let bars = if dots {
+        vec![
+            '\u{2880}', '\u{28a0}', '\u{28b0}', '\u{28b8}', '\u{2840}', '\u{28c0}', '\u{28e0}',
+            '\u{28f0}', '\u{28f8}', '\u{2844}', '\u{28c4}', '\u{28e4}', '\u{28f4}', '\u{28fc}',
+            '\u{2846}', '\u{28c6}', '\u{28e6}', '\u{28f6}', '\u{28fe}', '\u{2847}', '\u{28c7}',
+            '\u{28e7}', '\u{28f7}', '\u{28ff}',
+        ]
+    } else {
+        // (x * one eighth block) https://en.wikipedia.org/wiki/Block_Elements
+        vec![
+            '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}', '\u{2585}', '\u{2586}', '\u{2587}',
+            '\u{2588}',
+        ]
+    };
     let min: f64 = match min {
         Some(x) => x.to_f64().unwrap(),
         None => content.iter().min().unwrap().to_f64().unwrap(),


### PR DESCRIPTION
This is what it looks like at the moment, however I am not sure whether this is what the desired view is:
![image](https://user-images.githubusercontent.com/20397027/100542493-851d4e80-328d-11eb-8e04-853d0ed70887.png)
