### PR TITLE
keyboard_layout: add default fallback for sway driver

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -564,7 +564,7 @@ Key | Values | Required | Default
 `driver` | One of `"setxkbmap"`, `"localebus"`, `"kbddbus"` or `"sway"`, depending on your system. | No | `"setxkbmap"`
 `interval` | Update interval, in seconds. Only used by the `"setxkbmap"` driver. | No | `60`
 `format` | Format string, e.g. " {layout}" | No | `"{layout}"`
-`sway_kb_identifier` | Identifier of the device you want to monitor, as found in the output of `swaymsg -t get_inputs` | No | ""
+`sway_kb_identifier` | Identifier of the device you want to monitor, as found in the output of `swaymsg -t get_inputs` | No | Defaults to first input found
 
 ## Load
 

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -306,15 +306,29 @@ pub struct Sway {
 
 impl Sway {
     pub fn new(sway_kb_identifier: String) -> Result<Self> {
-        let layout = swayipc::Connection::new()
-            .unwrap()
-            .get_inputs()
-            .unwrap()
-            .into_iter()
-            .find(|input| input.identifier == sway_kb_identifier && input.input_type == "keyboard")
-            .and_then(|input| input.xkb_active_layout_name)
-            .ok_or_else(|| "".to_string())
-            .block_error("sway", "Failed to get xkb_active_layout_name.")?;
+        let layout = if sway_kb_identifier.is_empty() {
+            swayipc::Connection::new()
+                .unwrap()
+                .get_inputs()
+                .unwrap()
+                .into_iter()
+                .find(|input| input.input_type == "keyboard")
+                .and_then(|input| input.xkb_active_layout_name)
+                .ok_or_else(|| "".to_string())
+                .block_error("sway", "Failed to get xkb_active_layout_name.")?
+        } else {
+            swayipc::Connection::new()
+                .unwrap()
+                .get_inputs()
+                .unwrap()
+                .into_iter()
+                .find(|input| {
+                    input.identifier == sway_kb_identifier && input.input_type == "keyboard"
+                })
+                .and_then(|input| input.xkb_active_layout_name)
+                .ok_or_else(|| "".to_string())
+                .block_error("sway", "Failed to get xkb_active_layout_name.")?
+        };
 
         Ok(Sway {
             sway_kb_layout: Arc::new(Mutex::new(layout)),


### PR DESCRIPTION
Otherwise it would panic on startup if `sway_kb_identifier` was set to an empty string. Now it will just grab the first input found, and even though it may not be a useful one it's better than crashing the bar.