### PR TITLE
Document availability in home-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Stable releases are packaged on some distributions:
 
 * On NixOS: `nix-env -iA nixos.i3status-rust`
 
+* With [Home Manager](https://github.com/nix-community/home-manager): `programs.i3status-rust.enable = true` [see available options](https://nix-community.github.io/home-manager/options.html#opt-programs.i3status-rust.enable) 
+
 Otherwise, you can install from source:
 
 ```shell


### PR DESCRIPTION
`i3status-rust` is now availble as a [Home Manager](https://github.com/nix-community/home-manager) module for installation!

[Home Manager](https://github.com/nix-community/home-manager) provides for a declarative way to set up userland programs on all Linux distributions and MacOS (using [nix-darwin](https://github.com/LnL7/nix-darwin)) and is also a popular choice on NixOS.

Checkout [the list of available module options for i3status-rust here](https://nix-community.github.io/home-manager/options.html#opt-programs.i3status-rust.enable).