### PR TITLE
Implement per-block colour overrides

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -149,7 +149,34 @@ macro_rules! block {
         let block_config: <$block_type as ConfigBlock>::Config =
             <$block_type as ConfigBlock>::Config::deserialize($block_config)
                 .configuration_error("Failed to deserialize block config.")?;
-        Ok(Box::new($block_type::new(block_config, $config, $update_request)?) as Box<dyn Block>)
+        let mut main_config = $config;
+        if let Some(ref overrides) = block_config.color_overrides {
+            for entry in overrides {
+                match entry.0.as_str() {
+                    "idle_fg" => main_config.theme.idle_fg = Some(entry.1.to_string()),
+                    "idle_bg" => main_config.theme.idle_bg = Some(entry.1.to_string()),
+                    "info_fg" => main_config.theme.info_fg = Some(entry.1.to_string()),
+                    "info_bg" => main_config.theme.info_bg = Some(entry.1.to_string()),
+                    "good_fg" => main_config.theme.good_fg = Some(entry.1.to_string()),
+                    "good_bg" => main_config.theme.good_bg = Some(entry.1.to_string()),
+                    "warning_fg" => main_config.theme.warning_fg = Some(entry.1.to_string()),
+                    "warning_bg" => main_config.theme.warning_bg = Some(entry.1.to_string()),
+                    "critical_fg" => main_config.theme.critical_fg = Some(entry.1.to_string()),
+                    "critical_bg" => main_config.theme.critical_bg = Some(entry.1.to_string()),
+                    // TODO the below as well?
+                    // "separator"
+                    // "separator_bg"
+                    // "separator_fg"
+                    // "alternating_tint_bg"
+                    _ => (),
+                }
+            }
+        }
+        Ok(Box::new($block_type::new(
+            block_config,
+            main_config,
+            $update_request,
+        )?) as Box<dyn Block>)
     }};
 }
 

--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -1,7 +1,7 @@
+use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::io::Write;
-
 use std::process::Command;
 use std::time::Duration;
 
@@ -63,6 +63,9 @@ pub struct AptConfig {
     /// Default behaviour is that no package updates are deemed critical
     #[serde(default = "AptConfig::default_critical_updates_regex")]
     pub critical_updates_regex: Option<String>,
+
+    #[serde(default = "AptConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl AptConfig {
@@ -79,6 +82,10 @@ impl AptConfig {
     }
 
     fn default_critical_updates_regex() -> Option<String> {
+        None
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
         None
     }
 }

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -7,6 +7,7 @@
 //! brightness levels using `xrandr`, see the
 //! [`Xrandr`](../xrandr/struct.Xrandr.html) block.
 
+use std::collections::BTreeMap;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -215,6 +216,9 @@ pub struct BacklightConfig {
     /// For devices with few discrete steps this should be 1.0 (linear).
     #[serde(default = "BacklightConfig::default_root_scaling")]
     pub root_scaling: f64,
+
+    #[serde(default = "BacklightConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl BacklightConfig {
@@ -228,6 +232,10 @@ impl BacklightConfig {
 
     fn default_root_scaling() -> f64 {
         1f64
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -4,6 +4,7 @@
 //! display the status, capacity, and time remaining for (dis)charge for an
 //! internal power supply.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -569,6 +570,9 @@ pub struct BatteryConfig {
     /// If the battery device cannot be found, completely hide this block.
     #[serde(default = "BatteryConfig::default_hide_missing")]
     pub hide_missing: bool,
+
+    #[serde(default = "BatteryConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl BatteryConfig {
@@ -618,6 +622,10 @@ impl BatteryConfig {
 
     fn default_hide_missing() -> bool {
         false
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -1,4 +1,5 @@
 use serde_derive::Deserialize;
+use std::collections::BTreeMap;
 use std::thread;
 use std::time::Instant;
 
@@ -167,11 +168,17 @@ pub struct BluetoothConfig {
     pub label: Option<String>,
     #[serde(default = "BluetoothConfig::default_hide_disconnected")]
     pub hide_disconnected: bool,
+    #[serde(default = "BluetoothConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl BluetoothConfig {
     fn default_hide_disconnected() -> bool {
         false
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
@@ -72,6 +73,9 @@ pub struct CpuConfig {
     /// Compute the metrics (utilization and frequency) per core.
     #[serde(default)]
     pub per_core: bool,
+
+    #[serde(default = "CpuConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl CpuConfig {
@@ -100,6 +104,10 @@ impl CpuConfig {
     }
 
     fn default_on_click() -> Option<String> {
+        None
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
         None
     }
 }

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::env;
 use std::iter::{Cycle, Peekable};
 use std::process::Command;
@@ -64,6 +65,9 @@ pub struct CustomConfig {
     pub hide_when_empty: bool,
 
     pub shell: Option<String>,
+
+    #[serde(default = "CustomConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl CustomConfig {
@@ -77,6 +81,10 @@ impl CustomConfig {
 
     fn hide_when_empty() -> bool {
         false
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -35,6 +36,15 @@ pub struct CustomDBus {
 #[serde(deny_unknown_fields)]
 pub struct CustomDBusConfig {
     pub name: String,
+
+    #[serde(default = "CustomDBusConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
+}
+
+impl CustomDBusConfig {
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
+    }
 }
 
 impl ConfigBlock for CustomDBus {
@@ -50,6 +60,7 @@ impl ConfigBlock for CustomDBus {
             state: State::Idle,
         }));
         let status = status_original.clone();
+        let name = block_config.name.clone();
         thread::Builder::new()
             .name("custom_dbus".into())
             .spawn(move || {
@@ -63,7 +74,7 @@ impl ConfigBlock for CustomDBus {
                 let tree = f
                     .tree(())
                     .add(
-                        f.object_path(format!("/{}", block_config.name), ())
+                        f.object_path(format!("/{}", name), ())
                             .introspectable()
                             .add(
                                 f.interface("i3.status.rs", ()).add_m(

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::time::Duration;
 
@@ -118,6 +119,9 @@ pub struct DiskSpaceConfig {
     /// use absolute (unit) values for disk space alerts
     #[serde(default = "DiskSpaceConfig::default_alert_absolute")]
     pub alert_absolute: bool,
+
+    #[serde(default = "DiskSpaceConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl DiskSpaceConfig {
@@ -165,6 +169,10 @@ impl DiskSpaceConfig {
 
     fn default_alert_absolute() -> bool {
         false
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::process::Command;
 use std::time::Duration;
 
@@ -52,14 +53,22 @@ pub struct DockerConfig {
     /// Format override
     #[serde(default = "DockerConfig::default_format")]
     pub format: String,
+
+    #[serde(default = "DockerConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl DockerConfig {
     fn default_interval() -> Duration {
         Duration::from_secs(5)
     }
+
     fn default_format() -> String {
         "{running}%".to_owned()
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Instant;
@@ -42,6 +43,9 @@ pub struct FocusedWindowConfig {
     /// Show marks in place of title (if exist)
     #[serde(default = "FocusedWindowConfig::default_show_marks")]
     pub show_marks: MarksType,
+
+    #[serde(default = "FocusedWindowConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl FocusedWindowConfig {
@@ -51,6 +55,10 @@ impl FocusedWindowConfig {
 
     fn default_show_marks() -> MarksType {
         MarksType::None
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::process::Command;
 use std::time::Duration;
 
@@ -44,6 +44,9 @@ pub struct GithubConfig {
     /// Format override
     #[serde(default = "GithubConfig::default_format")]
     pub format: String,
+
+    #[serde(default = "GithubConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl GithubConfig {
@@ -57,6 +60,10 @@ impl GithubConfig {
 
     fn default_format() -> String {
         "{total}".to_owned()
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/hueshift.rs
+++ b/src/blocks/hueshift.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::process::Command;
 use std::time::Duration;
 
@@ -68,6 +69,9 @@ pub struct HueshiftConfig {
     pub step: u16,
     #[serde(default = "HueshiftConfig::default_click_temp")]
     pub click_temp: u16,
+
+    #[serde(default = "HueshiftConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl HueshiftConfig {
@@ -107,6 +111,10 @@ impl HueshiftConfig {
 
     fn default_click_temp() -> u16 {
         6500 as u16
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -43,6 +43,9 @@ pub struct IBusConfig {
 
     #[serde(default = "IBusConfig::default_format")]
     pub format: String,
+
+    #[serde(default = "IBusConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl IBusConfig {
@@ -52,6 +55,10 @@ impl IBusConfig {
 
     fn default_format() -> String {
         "{engine}".into()
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -66,6 +67,9 @@ pub struct KDEConnectConfig {
     /// Format string for displaying phone information when it is disconnected.
     #[serde(default = "KDEConnectConfig::default_format_disconnected")]
     pub format_disconnected: String,
+
+    #[serde(default = "KDEConnectConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl KDEConnectConfig {
@@ -95,6 +99,10 @@ impl KDEConnectConfig {
 
     fn default_format_disconnected() -> String {
         "{name}".into()
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -436,6 +437,9 @@ pub struct KeyboardLayoutConfig {
     interval: Duration,
 
     sway_kb_identifier: String,
+
+    #[serde(default = "KeyboardLayoutConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl KeyboardLayoutConfig {
@@ -445,6 +449,10 @@ impl KeyboardLayoutConfig {
 
     fn default_interval() -> Duration {
         Duration::from_secs(60)
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::{read_to_string, OpenOptions};
 use std::io::prelude::*;
 use std::time::Duration;
@@ -47,6 +48,9 @@ pub struct LoadConfig {
     /// Minimum load, where state is set to critical
     #[serde(default = "LoadConfig::default_critical")]
     pub critical: f32,
+
+    #[serde(default = "LoadConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl LoadConfig {
@@ -68,6 +72,10 @@ impl LoadConfig {
 
     fn default_critical() -> f32 {
         0.9
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use crossbeam_channel::Sender;
@@ -66,6 +67,8 @@ pub struct MaildirConfig {
     pub display_type: MailType,
     #[serde(default = "MaildirConfig::default_icon")]
     pub icon: bool,
+    #[serde(default = "MaildirConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl MaildirConfig {
@@ -80,6 +83,9 @@ impl MaildirConfig {
     }
     fn default_icon() -> bool {
         true
+    }
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -1,10 +1,12 @@
-use crossbeam_channel::Sender;
-use serde_derive::Deserialize;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::str::FromStr;
 use std::time::{Duration, Instant};
+
+use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 
 use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::Config;
@@ -209,6 +211,9 @@ pub struct MemoryConfig {
     /// Percentage of swap usage, where state is set to critical
     #[serde(default = "MemoryConfig::default_critical_swap")]
     pub critical_swap: f64,
+
+    #[serde(default = "MemoryConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl MemoryConfig {
@@ -250,6 +255,10 @@ impl MemoryConfig {
 
     fn default_critical_swap() -> f64 {
         95.0
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -1,4 +1,5 @@
 use std::boxed::Box;
+use std::collections::BTreeMap;
 use std::result;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -209,6 +210,9 @@ pub struct MusicConfig {
 
     #[serde(default = "MusicConfig::default_hide_when_empty")]
     pub hide_when_empty: bool,
+
+    #[serde(default = "MusicConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl MusicConfig {
@@ -262,6 +266,10 @@ impl MusicConfig {
 
     fn default_hide_when_empty() -> bool {
         false
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{read_to_string, OpenOptions};
@@ -488,6 +489,9 @@ pub struct NetConfig {
 
     #[serde(default = "NetConfig::default_on_click")]
     pub on_click: Option<String>,
+
+    #[serde(default = "NetConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl NetConfig {
@@ -575,6 +579,10 @@ impl NetConfig {
     }
 
     fn default_on_click() -> Option<String> {
+        None
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
         None
     }
 }

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fmt;
 use std::net::Ipv4Addr;
 use std::result;
@@ -492,6 +493,9 @@ pub struct NetworkManagerConfig {
     /// Interface name regex patterns to ignore.
     #[serde(default = "NetworkManagerConfig::default_interface_name_exclude_patterns")]
     pub interface_name_include: Vec<String>,
+
+    #[serde(default = "NetworkManagerConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl NetworkManagerConfig {
@@ -525,6 +529,10 @@ impl NetworkManagerConfig {
 
     fn default_interface_name_exclude_patterns() -> Vec<String> {
         vec![]
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/notify.rs
+++ b/src/blocks/notify.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Instant;
@@ -33,12 +34,19 @@ pub struct NotifyConfig {
     /// Format string for displaying phone information.
     #[serde(default = "NotifyConfig::default_format")]
     pub format: String,
+
+    #[serde(default = "NotifyConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl NotifyConfig {
     fn default_format() -> String {
         // display just the bell icon
         "".into()
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::env;
 use std::time::Duration;
 
@@ -52,6 +53,9 @@ pub struct NotmuchConfig {
     pub name: Option<String>,
     #[serde(default = "NotmuchConfig::default_no_icon")]
     pub no_icon: bool,
+
+    #[serde(default = "NotmuchConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl NotmuchConfig {
@@ -92,8 +96,13 @@ impl NotmuchConfig {
     fn default_name() -> Option<String> {
         None
     }
+
     fn default_no_icon() -> bool {
         false
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 
@@ -125,7 +134,6 @@ impl ConfigBlock for Notmuch {
             threshold_warning: block_config.threshold_warning,
             threshold_critical: block_config.threshold_critical,
             name: block_config.name,
-
             text: widget,
         })
     }

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::process::Command;
 use std::time::Duration;
 
@@ -109,6 +110,9 @@ pub struct NvidiaGpuConfig {
     /// Maximum temperature, below which state is set to warning
     #[serde(default = "NvidiaGpuConfig::default_warning")]
     pub warning: u64,
+
+    #[serde(default = "NvidiaGpuConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl NvidiaGpuConfig {
@@ -158,6 +162,10 @@ impl NvidiaGpuConfig {
 
     fn default_warning() -> u64 {
         80
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
@@ -77,6 +78,9 @@ pub struct PacmanConfig {
     /// Optional AUR command, listing available updates
     #[serde()]
     pub aur_command: Option<String>,
+
+    #[serde(default = "PacmanConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl PacmanConfig {
@@ -93,6 +97,10 @@ impl PacmanConfig {
     }
 
     fn default_critical_updates_regex() -> Option<String> {
+        None
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
         None
     }
 

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fmt;
 use std::time::{Duration, Instant};
 
@@ -102,6 +103,8 @@ pub struct PomodoroConfig {
     pub use_nag: bool,
     #[serde(default = "PomodoroConfig::default_nag_path")]
     pub nag_path: std::path::PathBuf,
+    #[serde(default = "PomodoroConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl PomodoroConfig {
@@ -127,6 +130,10 @@ impl PomodoroConfig {
 
     fn default_nag_path() -> std::path::PathBuf {
         std::path::PathBuf::from("i3-nagbar")
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -769,6 +769,9 @@ pub struct SoundConfig {
 
     #[serde(default = "SoundConfig::default_max_vol")]
     pub max_vol: Option<u32>,
+
+    #[serde(default = "SoundConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Deserialize, Copy, Clone, Debug)]
@@ -824,6 +827,10 @@ impl SoundConfig {
     }
 
     fn default_max_vol() -> Option<u32> {
+        None
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
         None
     }
 }

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fmt;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
@@ -67,6 +68,9 @@ pub struct SpeedTestConfig {
     /// Minimum unit to display for throughput indicators.
     #[serde(default = "SpeedTestConfig::default_speed_min_unit")]
     pub speed_min_unit: Unit,
+
+    #[serde(default = "SpeedTestConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl SpeedTestConfig {
@@ -84,6 +88,10 @@ impl SpeedTestConfig {
 
     fn default_speed_digits() -> usize {
         3
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 
@@ -180,7 +188,7 @@ impl ConfigBlock for SpeedTest {
             ],
             id,
             send,
-            config: block_config,
+            config: block_config.clone(),
         })
     }
 }

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::process::Command;
 use std::time::Duration;
 
@@ -66,6 +67,9 @@ pub struct TaskwarriorConfig {
     /// Format override if all tasks are completed
     #[serde(default = "TaskwarriorConfig::default_format")]
     pub format_everything_done: String,
+
+    #[serde(default = "TaskwarriorConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 enum TaskwarriorBlockMode {
@@ -94,6 +98,10 @@ impl TaskwarriorConfig {
 
     fn default_format() -> String {
         "{count}".to_owned()
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::process::Command;
 use std::time::Duration;
 
@@ -89,6 +89,9 @@ pub struct TemperatureConfig {
     /// Inputs whitelist
     #[serde(default = "TemperatureConfig::default_inputs")]
     pub inputs: Option<Vec<String>>,
+
+    #[serde(default = "TemperatureConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl TemperatureConfig {
@@ -109,6 +112,10 @@ impl TemperatureConfig {
     }
 
     fn default_inputs() -> Option<Vec<String>> {
+        None
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
         None
     }
 }

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use crossbeam_channel::Sender;
@@ -34,11 +35,18 @@ pub struct TemplateConfig {
         deserialize_with = "deserialize_duration"
     )]
     pub interval: Duration,
+
+    #[serde(default = "TemplateConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl TemplateConfig {
     fn default_interval() -> Duration {
         Duration::from_secs(5)
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::time::Duration;
 
@@ -52,6 +53,9 @@ pub struct TimeConfig {
 
     #[serde(default = "TimeConfig::default_locale")]
     pub locale: Option<String>,
+
+    #[serde(default = "TimeConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl TimeConfig {
@@ -72,6 +76,10 @@ impl TimeConfig {
     }
 
     fn default_locale() -> Option<String> {
+        None
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
         None
     }
 }

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -1,15 +1,17 @@
-use crate::scheduler::Task;
-use crossbeam_channel::Sender;
-use serde_derive::Deserialize;
+use std::collections::BTreeMap;
 use std::env;
 use std::process::Command;
 use std::time::Duration;
+
+use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 
 use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::Config;
 use crate::de::deserialize_opt_duration;
 use crate::errors::*;
 use crate::input::I3BarEvent;
+use crate::scheduler::Task;
 use crate::util::pseudo_uuid;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
@@ -52,6 +54,8 @@ pub struct ToggleConfig {
 
     /// Text to display in i3bar for this block
     pub text: Option<String>,
+    #[serde(default = "ToggleConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl ToggleConfig {
@@ -61,6 +65,9 @@ impl ToggleConfig {
 
     fn default_icon_off() -> String {
         "toggle_off".to_owned()
+    }
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::time::Duration;
 
@@ -34,11 +35,16 @@ pub struct UptimeConfig {
         deserialize_with = "deserialize_duration"
     )]
     pub interval: Duration,
+    #[serde(default = "UptimeConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl UptimeConfig {
     fn default_interval() -> Duration {
         Duration::from_secs(60)
+    }
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
@@ -44,6 +45,9 @@ pub struct WatsonConfig {
     /// Show time spent
     #[serde(default = "WatsonConfig::default_show_time")]
     pub show_time: bool,
+
+    #[serde(default = "WatsonConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl WatsonConfig {
@@ -57,6 +61,9 @@ impl WatsonConfig {
     }
     fn default_show_time() -> bool {
         false
+    }
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -1,9 +1,10 @@
-use crossbeam_channel::Sender;
-use serde_derive::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::process::Command;
 use std::time::Duration;
+
+use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
 
 use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::Config;
@@ -306,6 +307,8 @@ pub struct WeatherConfig {
     pub service: WeatherService,
     #[serde(default = "WeatherConfig::default_autolocate")]
     pub autolocate: bool,
+    #[serde(default = "WeatherConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl WeatherConfig {
@@ -319,6 +322,10 @@ impl WeatherConfig {
 
     fn default_autolocate() -> bool {
         false
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::process::Command;
 use std::str::FromStr;
 use std::time::Duration;
@@ -83,6 +84,9 @@ pub struct XrandrConfig {
     /// The steps brightness is in/decreased for the selected screen (When greater than 50 it gets limited to 50)
     #[serde(default = "XrandrConfig::default_step_width")]
     pub step_width: u32,
+
+    #[serde(default = "XrandrConfig::default_color_overrides")]
+    pub color_overrides: Option<BTreeMap<String, String>>,
 }
 
 impl XrandrConfig {
@@ -100,6 +104,10 @@ impl XrandrConfig {
 
     fn default_step_width() -> u32 {
         5 as u32
+    }
+
+    fn default_color_overrides() -> Option<BTreeMap<String, String>> {
+        None
     }
 }
 


### PR DESCRIPTION
This will allow you to override colours on a per-block basis:
![image](https://user-images.githubusercontent.com/20397027/100237240-fdc09a00-2f71-11eb-9935-18284f0a8cdc.png)
```toml
icons = "awesome5"

[[block]]
block = "uptime"
[block.color_overrides]
idle_fg = "#00ff00"
idle_bg = "#da11ff"

[[block]]
block = "time"
[block.color_overrides]
idle_fg = "#ff0000ff"
idle_bg = "#00aabbff"

[[block]]
block = "music"
[block.color_overrides]
info_fg = "#0000ff"
info_bg = "#aabbcc"

[[block]]
block = "time"
[block.color_overrides]
idle_fg = "#ff0000ff"
idle_bg = "#deadbeef"
```

The implementation may be a bit hacky but there doesn't seem to be a better way to achieve this, and I don't foresee the config changing regardless of the implementation in code (so any future rewrites should not break existing configs using block.color_overrides). I would rather have this feature out sooner than keeping users waiting (possibly forever) for a rewrite of the codebase.

It's possible some more work may be required so anyone willing to test this would be greatly appreciated!