### PR TITLE
music block: handle case when metadata is unavailable

### DIFF
--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -402,6 +402,10 @@ impl ConfigBlock for Music {
                                     p.title = Some(title);
                                     updated = true;
                                 }
+                            } else {
+                                p.artist = None;
+                                p.title = None;
+                                updated = true;
                             };
                             let raw_metadata = signal.changed_properties.get("PlaybackStatus");
                             if let Some(data) = raw_metadata {


### PR DESCRIPTION
Resolves #966
(Hopefully)