### PR TITLE
Add universal formatter

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -1295,7 +1295,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `bytes` | Whether to use bytes or bits in the display (true for bytes, false for bits). | No | `false`
 `interval` | Update interval in seconds. | No | `1800`
-`speed_digits` | Number of digits to use when displaying speeds. | No | `3`
+`speed_digits` | Number of digits to use when displaying speeds and latencies. | No | `3`
 `speed_min_unit` | Smallest unit to use when displaying speeds. Possible choices: `"B"`, `"K"`, `"M"`, `"G"`, `"T"`. | No | `"K"`
 
 ###### [↥ back to top](#list-of-available-blocks)

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -21,7 +21,7 @@ use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
 use crate::util::{
-    escape_pango_text, format_percent_bar, format_speed, format_vec_to_bar_graph, pseudo_uuid,
+    escape_pango_text, format_number, format_percent_bar, format_vec_to_bar_graph, pseudo_uuid,
     FormatTemplate,
 };
 use crate::widget::{I3BarWidget, Spacing};
@@ -825,11 +825,15 @@ impl Net {
             self.tx_bytes = current_tx;
 
             if let Some(ref mut tx) = self.output_tx {
-                *tx = format_speed(
-                    tx_bytes,
+                *tx = format_number(
+                    if self.use_bits {
+                        tx_bytes * 8
+                    } else {
+                        tx_bytes
+                    } as f64,
                     self.speed_digits,
                     &self.speed_min_unit.to_string(),
-                    self.use_bits,
+                    if self.use_bits { "b" } else { "B" },
                 );
             };
 
@@ -845,11 +849,15 @@ impl Net {
             self.rx_bytes = current_rx;
 
             if let Some(ref mut rx) = self.output_rx {
-                *rx = format_speed(
-                    rx_bytes,
+                *rx = format_number(
+                    if self.use_bits {
+                        rx_bytes * 8
+                    } else {
+                        rx_bytes
+                    } as f64,
                     self.speed_digits,
                     &self.speed_min_unit.to_string(),
-                    self.use_bits,
+                    if self.use_bits { "b" } else { "B" },
                 );
             };
 

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -14,7 +14,7 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::{format_speed, pseudo_uuid};
+use crate::util::{format_number, pseudo_uuid};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -204,38 +204,30 @@ impl Block for SpeedTest {
             *updated = false;
 
             if vals.len() == 3 {
-                self.text[0].set_text(format!("{}ms", vals[0]));
-                let (down_bytes, up_bytes) = if self.config.bytes {
-                    (vals[1] * 1_000_000.0, vals[2] * 1_000_000.0)
-                } else {
-                    (vals[1] * 125_000.0, vals[2] * 125_000.0)
-                };
-                self.text[1].set_text(format!(
-                    "{}/s",
-                    format_speed(
-                        down_bytes as u64,
-                        self.config.speed_digits,
-                        &self.config.speed_min_unit.to_string(),
-                        !self.config.bytes
-                    )
+                let ping = vals[0] as f64 / 1_000.0;
+                let down = vals[1] as f64 * 1_000_000.0;
+                let up = vals[2] as f64 * 1_000_000.0;
+                self.text[0].set_text(format_number(ping, self.config.speed_digits, "", "s"));
+                self.text[1].set_text(format_number(
+                    down,
+                    self.config.speed_digits,
+                    &self.config.speed_min_unit.to_string(),
+                    if self.config.bytes { "B/s" } else { "b/s" },
                 ));
-                self.text[2].set_text(format!(
-                    "{}/s",
-                    format_speed(
-                        up_bytes as u64,
-                        self.config.speed_digits,
-                        &self.config.speed_min_unit.to_string(),
-                        !self.config.bytes
-                    )
+                self.text[2].set_text(format_number(
+                    up,
+                    self.config.speed_digits,
+                    &self.config.speed_min_unit.to_string(),
+                    if self.config.bytes { "B/s" } else { "b/s" },
                 ));
 
                 // TODO: remove clippy workaround
                 #[allow(clippy::unknown_clippy_lints)]
                 #[allow(clippy::match_on_vec_items)]
                 self.text[0].set_state(match_range!(vals[0], default: (State::Critical) {
-                            0.0 ; 25.0 => State::Good,
-                            25.0 ; 60.0 => State::Info,
-                            60.0 ; 100.0 => State::Warning
+                    0.0 ; 25.0 => State::Good,
+                    25.0 ; 60.0 => State::Info,
+                    60.0 ; 100.0 => State::Warning
                 }));
             }
 


### PR DESCRIPTION
I was annoyed by the fact that the ping in the `speedtest` block always has 2-3 decimals, not adhering to the `speed_digits` option that the up/down values use.

So i changed the `format_speed` function to `format_number` and made it unit-agnostic so it can be used for any SI-scaled units.

What do you think @ammgws?

(Maybe technically there should be a separate `ping_digits` but i figured that'd be overkill)