### PR TITLE
Implement on_click for all blocks

### DIFF
--- a/src/blocks/base_block.rs
+++ b/src/blocks/base_block.rs
@@ -1,0 +1,62 @@
+//! A Base block for common behavior for all blocks
+
+use crate::errors::*;
+use crate::{
+    blocks::Update,
+    input::{I3BarEvent, MouseButton},
+    subprocess::spawn_child_async,
+    widget::I3BarWidget,
+    Block,
+};
+use serde_derive::Deserialize;
+
+pub(super) struct BaseBlock<T: Block> {
+    pub name: String,
+    pub inner: T,
+    pub on_click: Option<String>,
+}
+
+impl<T: Block> Block for BaseBlock<T> {
+    fn id(&self) -> &str {
+        self.inner.id()
+    }
+
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
+        self.inner.view()
+    }
+
+    fn update(&mut self) -> Result<Option<Update>> {
+        self.inner.update()
+    }
+
+    fn signal(&mut self, signal: i32) -> Result<()> {
+        self.inner.signal(signal)
+    }
+
+    fn click(&mut self, e: &I3BarEvent) -> Result<()> {
+        match &self.on_click {
+            Some(cmd) => {
+                if let Some(ref name) = e.name {
+                    if name.as_str() == self.id() {
+                        if let MouseButton::Left = e.button {
+                            spawn_child_async("sh", &["-c", &cmd])
+                                .block_error(&self.name, "could not spawn child")?;
+                        }
+                    }
+                }
+                Ok(())
+            }
+            None => self.inner.click(e),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub(super) struct BaseBlockConfig<T> {
+    /// Command to execute when the button is clicked
+    pub on_click: Option<String>,
+
+    #[serde(flatten)]
+    pub inner: T,
+}

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -670,10 +670,11 @@ impl ConfigBlock for Battery {
             )?),
         };
 
+        let output = TextWidget::new(config, &id);
         Ok(Battery {
             id,
             update_interval: block_config.interval,
-            output: TextWidget::new(config),
+            output,
             device,
             format: FormatTemplate::from_string(&format)?,
             full_format: FormatTemplate::from_string(&block_config.full_format)?,

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -48,9 +48,6 @@ pub struct CustomConfig {
     /// Shell Command to execute & display
     pub command: Option<String>,
 
-    /// Command to execute when the button is clicked
-    pub on_click: Option<String>,
-
     /// Commands to execute and change when the button is clicked
     pub cycle: Option<Vec<String>>,
 
@@ -112,10 +109,6 @@ impl ConfigBlock for Custom {
         };
         custom.output = ButtonWidget::new(config, &custom.id);
 
-        if let Some(on_click) = block_config.on_click {
-            custom.on_click = Some(on_click)
-        };
-
         if let Some(signal) = block_config.signal {
             // If the signal is not in the valid range we return an error
             custom.signal = Some(convert_to_valid_signal(signal)?);
@@ -138,6 +131,10 @@ impl ConfigBlock for Custom {
         };
 
         Ok(custom)
+    }
+
+    fn override_on_click(&mut self) -> Option<&mut Option<String>> {
+        Some(&mut self.on_click)
     }
 }
 

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -129,9 +129,10 @@ impl ConfigBlock for CustomDBus {
             })
             .unwrap();
 
+        let text = TextWidget::new(config, &id_copy).with_text("CustomDBus");
         Ok(CustomDBus {
             id: id_copy,
-            text: TextWidget::new(config).with_text("CustomDBus"),
+            text,
             status,
         })
     }

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -220,10 +220,12 @@ impl ConfigBlock for DiskSpace {
             .cloned()
             .unwrap_or_else(|| "".to_string());
 
+        let id = pseudo_uuid();
+        let disk_space = TextWidget::new(config, &id);
         Ok(DiskSpace {
-            id: pseudo_uuid(),
+            id,
             update_interval: block_config.interval,
-            disk_space: TextWidget::new(config),
+            disk_space,
             alias: block_config.alias,
             path: block_config.path,
             format: FormatTemplate::from_string(&block_config.format)?,

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -76,9 +76,13 @@ impl ConfigBlock for Docker {
     type Config = DockerConfig;
 
     fn new(block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
+        let id = pseudo_uuid();
+        let text = TextWidget::new(config, &id)
+            .with_text("N/A")
+            .with_icon("docker");
         Ok(Docker {
-            id: pseudo_uuid(),
-            text: TextWidget::new(config).with_text("N/A").with_icon("docker"),
+            id,
+            text,
             format: FormatTemplate::from_string(&block_config.format)
                 .block_error("docker", "Invalid format specified")?,
             update_interval: block_config.interval,

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -186,9 +186,10 @@ impl ConfigBlock for FocusedWindow {
             })
             .expect("failed to start watching thread for `window` block");
 
+        let text = TextWidget::new(config, &id);
         Ok(FocusedWindow {
             id,
-            text: TextWidget::new(config),
+            text,
             max_width: block_config.max_width,
             show_marks: block_config.show_marks,
             title,

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -81,10 +81,14 @@ impl ConfigBlock for Github {
             }
         };
 
+        let id = pseudo_uuid();
+        let text = TextWidget::new(config, &id)
+            .with_text("x")
+            .with_icon("github");
         Ok(Github {
-            id: pseudo_uuid(),
+            id,
             update_interval: block_config.interval,
-            text: TextWidget::new(config).with_text("x").with_icon("github"),
+            text,
             api_server: block_config.api_server,
             token,
             format: FormatTemplate::from_string(&block_config.format)

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -217,9 +217,10 @@ impl ConfigBlock for IBus {
             })
             .unwrap();
 
+        let text = TextWidget::new(config, &id_copy).with_text("IBus");
         Ok(IBus {
             id: id_copy,
-            text: TextWidget::new(config).with_text("IBus"),
+            text,
             engine: engine_original,
             mappings: block_config.mappings,
             format: FormatTemplate::from_string(&block_config.format)?,

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -492,9 +492,10 @@ impl ConfigBlock for KeyboardLayout {
         } else {
             None
         };
+        let output = TextWidget::new(config, &id);
         Ok(KeyboardLayout {
             id,
-            output: TextWidget::new(config),
+            output,
             monitor,
             update_interval,
             format: FormatTemplate::from_string(&block_config.format).block_error(

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -87,7 +87,8 @@ impl ConfigBlock for Load {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let text = TextWidget::new(config)
+        let id = pseudo_uuid();
+        let text = TextWidget::new(config, &id)
             .with_icon("cogs")
             .with_state(State::Info);
 
@@ -100,7 +101,7 @@ impl ConfigBlock for Load {
             .count() as u32;
 
         Ok(Load {
-            id: pseudo_uuid(),
+            id,
             logical_cores,
             update_interval: block_config.interval,
             minimum_info: block_config.info,

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -97,9 +97,10 @@ impl ConfigBlock for Maildir {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let widget = TextWidget::new(config).with_text("");
+        let id = pseudo_uuid();
+        let widget = TextWidget::new(config, &id).with_text("");
         Ok(Maildir {
-            id: pseudo_uuid(),
+            id,
             update_interval: block_config.interval,
             text: if block_config.icon {
                 widget.with_icon("mail")

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -200,9 +200,6 @@ pub struct MusicConfig {
     #[serde(default = "MusicConfig::default_on_collapsed_click")]
     pub on_collapsed_click: Option<String>,
 
-    #[serde(default = "MusicConfig::default_on_click")]
-    pub on_click: Option<String>,
-
     // Number of microseconds to seek forward/backward when scrolling on the bar.
     #[serde(default = "MusicConfig::default_seek_step")]
     pub seek_step: i64,
@@ -256,10 +253,6 @@ impl MusicConfig {
     }
 
     fn default_on_collapsed_click() -> Option<String> {
-        None
-    }
-
-    fn default_on_click() -> Option<String> {
         None
     }
 
@@ -545,7 +538,7 @@ impl ConfigBlock for Music {
             prev,
             play,
             next,
-            on_click: block_config.on_click,
+            on_click: None,
             on_collapsed_click_widget: ButtonWidget::new(config.clone(), &id_collapsed)
                 .with_icon("music")
                 .with_state(State::Info)
@@ -565,6 +558,10 @@ impl ConfigBlock for Music {
             send: send3,
             format: FormatTemplate::from_string(&block_config.format)?,
         })
+    }
+
+    fn override_on_click(&mut self) -> Option<&mut Option<String>> {
+        Some(&mut self.on_click)
     }
 }
 

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -120,12 +120,13 @@ impl ConfigBlock for Notmuch {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let mut widget = TextWidget::new(config);
+        let id = pseudo_uuid();
+        let mut widget = TextWidget::new(config, &id);
         if !block_config.no_icon {
             widget.set_icon("mail");
         }
         Ok(Notmuch {
-            id: pseudo_uuid().to_string(),
+            id,
             update_interval: block_config.interval,
             db: block_config.maildir,
             query: block_config.query,

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -211,13 +211,13 @@ impl ConfigBlock for NvidiaGpu {
             memory_widget_mode: MemoryWidgetMode::ShowUsedMemory,
 
             show_utilization: if block_config.show_utilization {
-                Some(TextWidget::new(config.clone()).with_spacing(Spacing::Inline))
+                Some(TextWidget::new(config.clone(), &id).with_spacing(Spacing::Inline))
             } else {
                 None
             },
 
             show_temperature: if block_config.show_temperature {
-                Some(TextWidget::new(config.clone()).with_spacing(Spacing::Inline))
+                Some(TextWidget::new(config.clone(), &id).with_spacing(Spacing::Inline))
             } else {
                 None
             },
@@ -232,7 +232,7 @@ impl ConfigBlock for NvidiaGpu {
             scrolling: config.scrolling,
 
             show_clocks: if block_config.show_clocks {
-                Some(TextWidget::new(config).with_spacing(Spacing::Inline))
+                Some(TextWidget::new(config, &id).with_spacing(Spacing::Inline))
             } else {
                 None
             },

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -754,9 +754,6 @@ pub struct SoundConfig {
     #[serde(default = "SoundConfig::default_format")]
     pub format: String,
 
-    #[serde(default = "SoundConfig::default_on_click")]
-    pub on_click: Option<String>,
-
     #[serde(default = "SoundConfig::default_show_volume_when_muted")]
     pub show_volume_when_muted: bool,
 
@@ -808,10 +805,6 @@ impl SoundConfig {
 
     fn default_format() -> String {
         "{volume}%".into()
-    }
-
-    fn default_on_click() -> Option<String> {
-        None
     }
 
     fn default_show_volume_when_muted() -> bool {
@@ -951,7 +944,7 @@ impl ConfigBlock for Sound {
             format: FormatTemplate::from_string(&block_config.format)?,
             step_width,
             config,
-            on_click: block_config.on_click,
+            on_click: None,
             show_volume_when_muted: block_config.show_volume_when_muted,
             bar: block_config.bar,
             mappings: block_config.mappings,
@@ -961,6 +954,10 @@ impl ConfigBlock for Sound {
         sound.device.monitor(id, tx_update_request)?;
 
         Ok(sound)
+    }
+
+    fn override_on_click(&mut self) -> Option<&mut Option<String>> {
+        Some(&mut self.on_click)
     }
 }
 

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -58,10 +58,13 @@ impl ConfigBlock for Template {
         config: Config,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
+        let id = pseudo_uuid();
+        let text = TextWidget::new(config.clone(), &id).with_text("Template");
+
         Ok(Template {
-            id: pseudo_uuid(),
+            id,
             update_interval: block_config.interval,
-            text: TextWidget::new(config.clone()).with_text("Template"),
+            text,
             tx_update_request,
             config,
         })

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -56,10 +56,13 @@ impl ConfigBlock for Uptime {
         config: Config,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
+        let id = pseudo_uuid();
+        let text = TextWidget::new(config.clone(), &id).with_icon("uptime");
+
         Ok(Uptime {
-            id: pseudo_uuid(),
+            id,
             update_interval: block_config.interval,
-            text: TextWidget::new(config.clone()).with_icon("uptime"),
+            text,
             tx_update_request,
             config,
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
             ::std::process::exit(1);
         }
 
-        let error_widget = TextWidget::new(Default::default())
+        let error_widget = TextWidget::new(Default::default(), "error")
             .with_state(State::Critical)
             .with_text(&format!("{:?}", error));
         let error_rendered = error_widget.get_rendered();

--- a/src/widgets/graph.rs
+++ b/src/widgets/graph.rs
@@ -12,18 +12,20 @@ pub struct GraphWidget {
     icon: Option<String>,
     state: State,
     spacing: Spacing,
+    id: String,
     rendered: Value,
     cached_output: Option<String>,
     config: Config,
 }
 #[allow(dead_code)]
 impl GraphWidget {
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: Config, id: &str) -> Self {
         GraphWidget {
             content: None,
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
+            id: id.to_string(),
             rendered: json!({
                 "full_text": "",
                 "separator": false,
@@ -117,6 +119,7 @@ impl GraphWidget {
                             ),
             "separator": false,
             "separator_block_width": 0,
+            "name": self.id,
             "background": key_bg.to_owned(),
             "color": key_fg.to_owned()
         });

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -161,6 +161,7 @@ impl RotatingTextWidget {
                                 }),
             "separator": false,
             "separator_block_width": 0,
+            "name" : self.id,
             "min_width":
                 if self.content == "" {
                     "".to_string()

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -11,18 +11,20 @@ pub struct TextWidget {
     icon: Option<String>,
     state: State,
     spacing: Spacing,
+    id: String,
     rendered: Value,
     cached_output: Option<String>,
     config: Config,
 }
 
 impl TextWidget {
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: Config, id: &str) -> Self {
         TextWidget {
             content: None,
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
+            id: id.to_string(),
             rendered: json!({
                 "full_text": "",
                 "separator": false,
@@ -98,6 +100,7 @@ impl TextWidget {
                             ),
             "separator": false,
             "separator_block_width": 0,
+            "name": self.id.clone(),
             "background": key_bg.to_owned(),
             "color": key_fg.to_owned()
         });


### PR DESCRIPTION
This PR allow allow all blocks to support `on_click` properties by implementing following things:

1. Add `BaseBlock` for common properties for blocks (right now only 'on_click')
2. Allow child block override this `on_click` behavior by adding a trait method in `Block` trait. It is because some blocks maybe have a complicated flow for clicking.
3. Added id for `TextWidget` ,`GraphWidget` and RotatingTextWidget` for letting `I3BarEvent` name available.

It partially fixes #697, other common properties could be added in the same fashion later.

Document is lacking, but will be submitted later if needed.