### PR TITLE
Support multiple filters in Taskwarrior block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -1303,13 +1303,12 @@ Key | Values | Required | Default
 
 ## Taskwarrior
 
-Creates a block which displays number of pending and started tasks of the current users taskwarrior list.
+Creates a block which displays the number of tasks matching user-defined filters from the current user's taskwarrior list.
 
-Clicking the left mouse button on the icon updates the number of pending tasks immediately.
+Clicking the left mouse button on the icon updates the number of tasks immediately.
 
-Clicking the right mouse button on the icon toggles the view of the block between filtered (default) and non-filtered
-tasks. If there are no filters configured, the number of tasks stays the same and both modes are behaving
-equally.  
+Clicking the right mouse button on the icon cycles the view of the block through the user's filters.
+
 
 #### Examples
 
@@ -1317,12 +1316,17 @@ equally.
 [[block]]
 block = "taskwarrior"
 interval = 60
-format = "{count} open tasks"
-format_singular = "{count} open task"
+format = "{count} open tasks ({filter_name})"
+format_singular = "{count} open task ({filter_name})"
 format_everything_done = "nothing to do!"
 warning_threshold = 10
 critical_threshold = 20
-filter = "+work +important"
+[[block.filters]]
+name = "today"
+filter = "+PENDING +OVERDUE or +DUETODAY"
+[[block.filters]]
+name = "some-project"
+filter = "project:some-project +PENDING"
 ```
 
 #### Options
@@ -1332,8 +1336,8 @@ Key | Values | Required | Default
 `interval` | Update interval, in seconds. | No | `600` (10min)
 `warning_threshold` | The threshold of pending (or started) tasks when the block turns into a warning state. | No | `10`
 `critical_threshold` | The threshold of pending (or started) tasks when the block turns into a critical state. | No | `20`
-`filter_tags` | Deprecated in favour of `filter`. A list of tags a task has to have before its counted as a pending task. | No | ```<empty>```
-`filter` | A filter that a task has to match to be counted as a pending task. | No | ```<empty```
+`filter_tags` | Deprecated in favour of `filters`. A list of tags a task has to have before its counted as a pending task. The list of tags will be appended to the base filter `-COMPLETED -DELETED`. | No | ```<empty>```
+`filters` | A list of tables with the keys `name` and `filter`. `filter` specifies the criteria that must be met for a task to be counted towards this filter. | No | ```[{name = "pending", filter = "-COMPLETED -DELETED"}]```
 `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{count}"`
 `format_singular` | Same as `format` but for when exactly one task is pending. | No | `"{count}"`
 `format_everything_done` | Same as `format` but for when all tasks are completed. | No | `"{count}"`
@@ -1343,6 +1347,7 @@ Key | Values | Required | Default
 Key | Value
 ----|-------
 `{count}` | The number of pending tasks
+`{filter_name}` | The name of the current filter
 
 ###### [↥ back to top](#list-of-available-blocks)
 

--- a/blocks.md
+++ b/blocks.md
@@ -1322,7 +1322,7 @@ format_singular = "{count} open task"
 format_everything_done = "nothing to do!"
 warning_threshold = 10
 critical_threshold = 20
-filter_tags = ["work", "important"]
+filter = "+work +important"
 ```
 
 #### Options
@@ -1332,7 +1332,8 @@ Key | Values | Required | Default
 `interval` | Update interval, in seconds. | No | `600` (10min)
 `warning_threshold` | The threshold of pending (or started) tasks when the block turns into a warning state. | No | `10`
 `critical_threshold` | The threshold of pending (or started) tasks when the block turns into a critical state. | No | `20`
-`filter_tags` | A list of tags a task has to have before its counted as a pending task. | No | ```<empty>```
+`filter_tags` | Deprecated in favour of `filter`. A list of tags a task has to have before its counted as a pending task. | No | ```<empty>```
+`filter` | A filter that a task has to match to be counted as a pending task. | No | ```<empty```
 `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{count}"`
 `format_singular` | Same as `format` but for when exactly one task is pending. | No | `"{count}"`
 `format_everything_done` | Same as `format` but for when all tasks are completed. | No | `"{count}"`

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -21,8 +21,8 @@ pub struct Taskwarrior {
     update_interval: Duration,
     warning_threshold: u32,
     critical_threshold: u32,
-    filter: String,
-    block_mode: TaskwarriorBlockMode,
+    filters: Vec<Filter>,
+    filter_index: usize,
     format: FormatTemplate,
     format_singular: FormatTemplate,
     format_everything_done: FormatTemplate,
@@ -32,6 +32,29 @@ pub struct Taskwarrior {
     config: Config,
     #[allow(dead_code)]
     tx_update_request: Sender<Task>,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct Filter {
+    pub name: String,
+    pub filter: String,
+}
+
+impl Filter {
+    pub fn new(name: String, filter: String) -> Self {
+        Filter { name, filter }
+    }
+
+    pub fn legacy(name: String, tags: &[String]) -> Self {
+        let tags = tags
+            .iter()
+            .map(|element| format!("+{}", element))
+            .collect::<Vec<String>>()
+            .join(" ");
+        let filter = format!("-COMPLETED -DELETED {}", tags);
+        Self::new(name, filter)
+    }
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -53,35 +76,29 @@ pub struct TaskwarriorConfig {
     pub critical_threshold: u32,
 
     /// A list of tags a task has to have before it's used for counting pending tasks
-    /// (DEPRECATED) use filter instead
+    /// (DEPRECATED) use filters instead
     #[serde(default = "TaskwarriorConfig::default_filter_tags")]
     pub filter_tags: Vec<String>,
 
-    /// The search criteria that matching tasks must have to be counted
-    #[serde(default = "TaskwarriorConfig::default_filter")]
-    pub filter: String,
+    /// A list of named filter criteria which must be fulfilled to be counted towards
+    /// the total, when that filter is active.
+    #[serde(default = "TaskwarriorConfig::default_filters")]
+    pub filters: Vec<Filter>,
 
     /// Format override
     #[serde(default = "TaskwarriorConfig::default_format")]
     pub format: String,
 
-    /// Format override if exactly one task is pending
+    /// Format override if the count is one
     #[serde(default = "TaskwarriorConfig::default_format")]
     pub format_singular: String,
 
-    /// Format override if all tasks are completed
+    /// Format override if the count is zero
     #[serde(default = "TaskwarriorConfig::default_format")]
     pub format_everything_done: String,
 
     #[serde(default = "TaskwarriorConfig::default_color_overrides")]
     pub color_overrides: Option<BTreeMap<String, String>>,
-}
-
-enum TaskwarriorBlockMode {
-    // Show only the tasks which are filtered by the set tags and which are not completed.
-    OnlyFilteredPendingTasks,
-    // Show all pending tasks and ignore the filtering tags.
-    AllPendingTasks,
 }
 
 impl TaskwarriorConfig {
@@ -101,8 +118,11 @@ impl TaskwarriorConfig {
         vec![]
     }
 
-    fn default_filter() -> String {
-        String::new()
+    fn default_filters() -> Vec<Filter> {
+        vec![Filter::new(
+            "pending".to_string(),
+            "-COMPLETED -DELETED".to_string(),
+        )]
     }
 
     fn default_format() -> String {
@@ -126,19 +146,22 @@ impl ConfigBlock for Taskwarrior {
         let output = ButtonWidget::new(config.clone(), &id)
             .with_icon("tasks")
             .with_text("-");
+        // If the deprecated `filter_tags` option has been set,
+        // convert it to the new `filter` format.
+        let filters = if block_config.filter_tags.len() > 0 {
+            vec![
+                Filter::legacy("filtered".to_string(), &block_config.filter_tags),
+                Filter::legacy("all".to_string(), &vec![]),
+            ]
+        } else {
+            block_config.filters
+        };
 
         Ok(Taskwarrior {
             id: pseudo_uuid(),
             update_interval: block_config.interval,
             warning_threshold: block_config.warning_threshold,
             critical_threshold: block_config.critical_threshold,
-            filter: if block_config.filter_tags.len() > 0 {
-                tags_to_filter(&block_config.filter_tags)
-            } else {
-                block_config.filter
-            },
-            block_mode: TaskwarriorBlockMode::OnlyFilteredPendingTasks,
-            output,
             format: FormatTemplate::from_string(&block_config.format).block_error(
                 "taskwarrior",
                 "Invalid format specified for taskwarrior::format",
@@ -156,7 +179,10 @@ impl ConfigBlock for Taskwarrior {
                 "Invalid format specified for taskwarrior::format_everything_done",
             )?,
             tx_update_request,
+            filter_index: 0,
             config,
+            filters,
+            output,
         })
     }
 }
@@ -177,33 +203,20 @@ fn has_taskwarrior() -> Result<bool> {
         != "")
 }
 
-fn tags_to_filter(tags: &[String]) -> String {
-    tags.iter()
-        .map(|element| format!("+{}", element))
-        .collect::<Vec<String>>()
-        .join(" ")
-}
-
-fn get_number_of_pending_tasks(filter: &str) -> Result<u32> {
+fn get_number_of_tasks(filter: &str) -> Result<u32> {
     String::from_utf8(
         Command::new("sh")
-            .args(&[
-                "-c",
-                &format!(
-                    "task rc.gc=off -COMPLETED -DELETED {} count",
-                    filter
-                ),
-            ])
+            .args(&["-c", &format!("task rc.gc=off {} count", filter)])
             .output()
             .block_error(
                 "taskwarrior",
-                "failed to run taskwarrior for getting the number of pending tasks",
+                "failed to run taskwarrior for getting the number of tasks",
             )?
             .stdout,
     )
     .block_error(
         "taskwarrior",
-        "failed to get the number of pending tasks from taskwarrior",
+        "failed to get the number of tasks from taskwarrior",
     )?
     .trim()
     .parse::<u32>()
@@ -215,20 +228,23 @@ impl Block for Taskwarrior {
         if !has_taskwarrior()? {
             self.output.set_text("?")
         } else {
-            let filter = match self.block_mode {
-                TaskwarriorBlockMode::OnlyFilteredPendingTasks => &self.filter,
-                TaskwarriorBlockMode::AllPendingTasks => "",
-            };
-            let number_of_pending_tasks = get_number_of_pending_tasks(filter)?;
-            let values = map!("{count}" => number_of_pending_tasks);
-            self.output.set_text(match number_of_pending_tasks {
+            let filter = self.filters.get(self.filter_index).block_error(
+                "taskwarrior",
+                &format!("Filter at index {} does not exist", self.filter_index),
+            )?;
+            let number_of_tasks = get_number_of_tasks(&filter.filter)?;
+            let values = map!(
+                "{count}" => number_of_tasks.to_string(),
+                "{filter_name}" => filter.name.clone()
+            );
+            self.output.set_text(match number_of_tasks {
                 0 => self.format_everything_done.render_static_str(&values)?,
                 1 => self.format_singular.render_static_str(&values)?,
                 _ => self.format.render_static_str(&values)?,
             });
-            if number_of_pending_tasks >= self.critical_threshold {
+            if number_of_tasks >= self.critical_threshold {
                 self.output.set_state(State::Critical);
-            } else if number_of_pending_tasks >= self.warning_threshold {
+            } else if number_of_tasks >= self.warning_threshold {
                 self.output.set_state(State::Warning);
             } else {
                 self.output.set_state(State::Idle);
@@ -250,14 +266,8 @@ impl Block for Taskwarrior {
                     self.update()?;
                 }
                 MouseButton::Right => {
-                    match self.block_mode {
-                        TaskwarriorBlockMode::OnlyFilteredPendingTasks => {
-                            self.block_mode = TaskwarriorBlockMode::AllPendingTasks
-                        }
-                        TaskwarriorBlockMode::AllPendingTasks => {
-                            self.block_mode = TaskwarriorBlockMode::OnlyFilteredPendingTasks
-                        }
-                    }
+                    // Increment the filter_index, rotating at the end
+                    self.filter_index = (self.filter_index + 1) % self.filters.len();
                     self.update()?;
                 }
                 _ => {}


### PR DESCRIPTION
Hi there!

First of all, thanks for the work on this great project. It's something that I use every single day, and is always visible on my monitor  and working very well :-)

Secondly, this is my first contribution to this project, so apologies in advance if I've missed something.

------

This PR addresses #905 and generalizes the Taskwarrior block by supporting an arbitrary number of filters.

Multiple filters can be specified as follows:

```toml
[[block.filters]]
name = "today"
filter = "+PENDING +OVERDUE or +DUETODAY"
[[block.filters]]
name = "work"
filter = "proj:work +PENDING +OVERDUE or +DUETODAY"
```

Deprecations:

* `filter_tags` are deprecated in favour of `filters`
* `TaskwarriorBlockMode` is removed in favour of `filter_index` since we can now cycle through all filters
* If `filter_tags` are specified, two filters are created to emulate existing `TaskwarriorBlockMode` behaviour:
  * all: `-COMPLETED -DELETED`
  * filtered: `-COMPLETED -DELETED <tags>`
* New-style `filters` do not prepend the `-COMPLETED -DELETED` criteria, since a user may want to specify something other than pending tasks. The user is completely free in specifying this value.

Just an additional note: the first commit in this PR (49336c0f3c86dc3c7e22e8dd27ab1453e269d1b6) was my initial solution, where only a single, more flexible filter can be specified. I built on that to a solution which I personally think is better, but if you prefer the first solution, you can take a look and let me know.