### PR TITLE
Add documentation for color_overrides

### DIFF
--- a/themes.md
+++ b/themes.md
@@ -89,7 +89,9 @@ For example:
 ```toml
 [[block]]
 block = "cpu"
-color_overrides = {idle_bg = "#123456", idle_fg = "#abcdef"}
+[block.theme_overrides]
+idle_bg = "#123456"
+idle_fg = "#abcdef"
 ```
 
 # Available theme overrides

--- a/themes.md
+++ b/themes.md
@@ -84,6 +84,14 @@ bat_discharging = " |v| "
 
 Example configurations can be found as `example_theme.toml` and `example_icon.toml`.
 
+Besides global overrides you may also use per-block overrides using the `color_overrides` option available for all blocks.
+For example:
+```toml
+[[block]]
+block = "cpu"
+color_overrides = {idle_bg = "#123456", idle_fg = "#abcdef"}
+```
+
 # Available theme overrides
 
 * `alternating_tint_bg`


### PR DESCRIPTION
Adds a mention to the possibility of overriding the theme locally within a block using the `color_overrides` option. I could not find any mention of this option anywhere; I had to go looking into the code wondering whether this was even technically possible, only to find that it was already implemented; just not documented.

It could be argued that this modification belongs to the blocks documentation, or in both places; feel free to change it if you deem it better.

Also, I guess the man pages should be regenerated but I do not have pandoc installed... I would appreciate it if anybody can run the generation script and add the commit to the pull request before potential merging...