### PR TITLE
Refactored weather block to use curl crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e268162af1a5fe89917ae25ba3b0a77c8da752bdc58e7dbb4f15b91fbd33756e"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.39+curl-7.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a8ce861e7b68a0b394e814d7ee9f1b2750ff8bd10372c6ad3bacc10e86f874"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi",
+]
+
+[[package]]
 name = "dbus"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +405,7 @@ dependencies = [
  "clap",
  "cpuprofiler",
  "crossbeam-channel",
+ "curl",
  "dbus",
  "getrandom 0.2.0",
  "inotify",
@@ -504,6 +535,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +655,25 @@ name = "object"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parse-zoneinfo"
@@ -802,6 +864,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +922,17 @@ checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
 dependencies = [
  "arc-swap",
  "libc",
+]
+
+[[package]]
+name = "socket2"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -977,6 +1060,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0"
 swayipc = "2.7"
 toml = "0.5"
 signal-hook = "0.1.16"
+curl = "0.4"
 
 # Optional features/blocks
 libpulse-binding = { optional = true, version = "2.15.0", default-features = false }

--- a/blocks.md
+++ b/blocks.md
@@ -1531,9 +1531,10 @@ Key | Values | Required | Default
 `api_key` | Your OpenWeatherMap API key. | Yes | None
 `city_id` | OpenWeatherMap's ID for the city. | Yes* | None
 `place` | OpenWeatherMap 'By city name' search query. See [here](https://openweathermap.org/current) | Yes* | None
+`coordinates` | GPS latitude longitude coordinates as a tuple, example: `["39.236229089090216","9.331730718685696"]`
 `units` | Either `metric` or `imperial`. | Yes | `metric`
 
-Either one of `city_id` or `place` is required. If both are supplied, `city_id` takes precedence.
+One of `city_id`, `place` or `coordinates` is required. If more than one are supplied, `city_id` takes precedence over `place` which takes place over `coordinates`.
 
 The options `api_key`, `city_id`, `place` can be omitted from configuration,
 in which case they must be provided in the environment variables

--- a/blocks.md
+++ b/blocks.md
@@ -1549,6 +1549,7 @@ Key | Value
 `{humidity}` | Humidity
 `{weather}` | Textual description of the weather, e.g. "Raining"
 `{wind}` | Wind speed
+`{wind_kmh}` | Wind speed. The wind speed in km/h.
 `{direction}` | Wind direction, e.g. "NE"
 
 ###### [↥ back to top](#list-of-available-blocks)

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::process::Command;
 use std::time::Duration;
 
 use crossbeam_channel::Sender;

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -8,12 +8,12 @@ use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
+use crate::http;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::util::{pseudo_uuid, FormatTemplate};
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
-use crate::http;
 
 pub struct Docker {
     text: TextWidget,

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -199,7 +199,7 @@ impl<'a> Notifications<'a> {
 
         let header_value = format!("Bearer {}", self.token);
         let headers = vec![("Authorization", header_value.as_str())];
-        let result = http::http_get_json(&self.next_page_url, Duration::from_secs(3), headers)?;
+        let result = http::http_get_json(&self.next_page_url, Some(Duration::from_secs(3)), headers)?;
 
         self.next_page_url = result.headers.iter().find_map(|header| {
             if header.starts_with("Link:") {

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap};
-use std::process::Command;
 use std::time::Duration;
 
 use crossbeam_channel::Sender;
@@ -16,6 +15,7 @@ use crate::scheduler::Task;
 use crate::util::{pseudo_uuid, FormatTemplate};
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
+use crate::http;
 
 const GITHUB_TOKEN_ENV: &str = "I3RS_GITHUB_TOKEN";
 
@@ -197,48 +197,19 @@ impl<'a> Notifications<'a> {
             return Ok(None);
         }
 
-        let result = Command::new("sh")
-            .args(&[
-                "-c",
-                &format!(
-                    "curl --silent --dump-header - --header \"Authorization: Bearer {token}\" -m 3 \"{next_page_url}\"",
-                    token = self.token,
-                    next_page_url = self.next_page_url,
-                ),
-            ])
-            .output()?;
+        let header_value = format!("Bearer {}", self.token);
+        let headers = vec![("Authorization", header_value.as_str())];
+        let result = http::http_get_json(&self.next_page_url, Duration::from_secs(3), headers)?;
 
-        // Catch all errors, if response status is not 200, then curl wont exit with status code 0.
-        if !result.status.success() {
-            return Err(Box::new(BlockError(
-                "github".to_owned(),
-                "curl status code different than 0".to_owned(),
-            )));
-        }
+        self.next_page_url = result.headers.iter().find_map(|header| {
+            if header.starts_with("Link:") {
+                parse_links_header(header).get("next").cloned()
+           } else {
+                None
+            }
+        }).unwrap_or(&"").to_string();
 
-        let output = String::from_utf8(result.stdout)?;
-
-        // Status / headers sections are separed by a blank line.
-        let split: Vec<&str> = output.split("\r\n\r\n").collect();
-        if split.len() != 2 {
-            return Err(Box::new(BlockError(
-                "github".to_owned(),
-                "unexpected curl output".to_owned(),
-            )));
-        }
-
-        let (meta, body) = (split[0], split[1]);
-
-        let next = match meta.lines().find(|&l| l.starts_with("Link:")) {
-            Some(v) => match parse_links_header(v).get("next") {
-                Some(next) => next,
-                None => "",
-            },
-            None => "",
-        };
-        self.next_page_url = next.to_owned();
-
-        let notifications: Vec<Notification> = serde_json::from_str(body)?;
+        let notifications: Vec<Notification> =  serde_json::from_value(result.content)?;
         self.notifications = notifications.into_iter();
 
         Ok(self.notifications.next())

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -234,6 +234,8 @@ impl Weather {
                     raw_wind_speed * 0.447
                 };
 
+                let kmh_wind_speed = metric_wind_speed * 3600.0 / 1000.0;
+
                 let metric_apparent_temp =
                     temp_celsius + 0.33 * water_vapor_pressure - 0.7 * metric_wind_speed - 4.0;
                 let apparent_temp = if metric {
@@ -273,6 +275,7 @@ impl Weather {
                                   "{humidity}" => format!("{:.0}", raw_humidity),
                                   "{apparent}" => format!("{:.0}",apparent_temp),
                                   "{wind}" => format!("{:.1}", raw_wind_speed),
+                                  "{wind_kmh}" => format!("{:.1}", kmh_wind_speed),
                                   "{direction}" => convert_wind_direction(raw_wind_direction),
                                   "{location}" => raw_location);
                 Ok(())

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -81,7 +81,7 @@ impl Weather {
             } => {
                 // TODO: might be good to allow for different geolocation services to be used, similar to how we have `service` for the weather API
                 let geoip_city = if self.autolocate {
-                    let http_call_result = http::http_get_json("https://ipapi.co/json/", Duration::from_secs(3));
+                    let http_call_result = http::http_get_json("https://ipapi.co/json/", Duration::from_secs(3), vec![]);
 
                     if let Ok(geoip_response) = http_call_result {
                         geoip_response.content

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,74 @@
+use std::time::Duration;
+use serde_json::value::Value;
+
+use crate::errors::{Result, ResultExtInternal};
+use crate::errors;
+
+
+pub fn http_get(url: &str, timeout: Duration) -> Result<(u32, String)> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut easy = curl::easy::Easy::new();
+
+    easy.url(url)?;
+    easy.timeout(timeout)?;
+
+    {
+        let mut transfer = easy.transfer();
+
+        (transfer.write_function(|data| {
+            buf.extend_from_slice(data);
+            Ok(data.len())
+        }))?;
+
+        transfer.perform()?;
+    }
+
+    let response_code = easy.response_code()?;
+
+    let response_str = String::from_utf8(buf)
+        .internal_error("curl", "Received non-UTF8 characters in http response")?;
+
+    Ok((response_code, response_str))
+}
+
+pub struct HttpResponse<T> {
+    pub code: u32,
+    pub content: T
+}
+
+pub fn http_get_json(url: &str, timeout: Duration) -> Result<HttpResponse<Value>> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut easy = curl::easy::Easy::new();
+
+    easy.url(url)?;
+    easy.timeout(timeout)?;
+
+    {
+        let mut transfer = easy.transfer();
+
+        (transfer.write_function(|data| {
+            buf.extend_from_slice(data);
+            Ok(data.len())
+        }))?;
+
+        transfer.perform()?;
+    }
+
+    let code = easy.response_code()?;
+
+    let content = serde_json::from_slice(&buf)
+        .internal_error("curl", "could not parse json response from server")?;
+
+    Ok(HttpResponse { code, content })
+}
+
+
+impl From<curl::Error> for errors::Error {
+    fn from(err: curl::Error) -> Self {
+        errors::InternalError(
+            "curl".to_owned(),
+            "error running curl".to_owned(),
+            Some((format!("{}", err), format!("{:?}", err))),
+        )
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,36 +1,9 @@
 use std::time::Duration;
 use serde_json::value::Value;
+use curl::easy::Easy;
 
 use crate::errors::{Result, ResultExtInternal};
 use crate::errors;
-
-
-
-pub fn http_get(url: &str, timeout: Duration) -> Result<(u32, String)> {
-    let mut buf: Vec<u8> = Vec::new();
-    let mut easy = curl::easy::Easy::new();
-
-    easy.url(url)?;
-    easy.timeout(timeout)?;
-
-    {
-        let mut transfer = easy.transfer();
-
-        (transfer.write_function(|data| {
-            buf.extend_from_slice(data);
-            Ok(data.len())
-        }))?;
-
-        transfer.perform()?;
-    }
-
-    let response_code = easy.response_code()?;
-
-    let response_str = String::from_utf8(buf)
-        .internal_error("curl", "Received non-UTF8 characters in http response")?;
-
-    Ok((response_code, response_str))
-}
 
 pub struct HttpResponse<T> {
     pub code: u32,
@@ -38,48 +11,9 @@ pub struct HttpResponse<T> {
     pub headers: Vec<String>,
 }
 
-pub fn http_get_socket_json(path: std::path::PathBuf, url: &str) -> Result<HttpResponse<Value>> {
+fn http_easy(mut easy: Easy) -> Result<HttpResponse<Vec<u8>>> {
     let mut buf: Vec<u8> = Vec::new();
     let mut headers: Vec<String> = Vec::new();
-    let mut easy = curl::easy::Easy::new();
-
-    easy.url(url)?;
-    easy.unix_socket_path(Some(path))?;
-
-    {
-        let mut transfer = easy.transfer();
-
-        transfer.write_function(|data| {
-            buf.extend_from_slice(data);
-            Ok(data.len())
-        })?;
-
-        transfer.perform()?;
-    }
-
-    let code = easy.response_code()?;
-
-    let content = serde_json::from_slice(&buf)
-        .internal_error("curl", "could not parse json response from server")?;
-
-    Ok(HttpResponse { code, content, headers })
-}
-
-pub fn http_get_json(url: &str, timeout: Duration, request_headers: Vec<(&str, &str)>) -> Result<HttpResponse<Value>> {
-    let mut buf: Vec<u8> = Vec::new();
-    let mut headers: Vec<String> = Vec::new();
-    let mut easy = curl::easy::Easy::new();
-
-    easy.url(url)?;
-    easy.timeout(timeout)?;
-
-    let mut header_list = curl::easy::List::new();
-
-    for (k, v) in request_headers.iter() {
-        header_list.append(&format!("{}: {}", k, v))?;
-    }
-
-    easy.http_headers(header_list)?;
 
     {
         let mut transfer = easy.transfer();
@@ -89,6 +23,7 @@ pub fn http_get_json(url: &str, timeout: Duration, request_headers: Vec<(&str, &
             true
         })?;
 
+
         transfer.write_function(|data| {
             buf.extend_from_slice(data);
             Ok(data.len())
@@ -99,10 +34,46 @@ pub fn http_get_json(url: &str, timeout: Duration, request_headers: Vec<(&str, &
 
     let code = easy.response_code()?;
 
-    let content = serde_json::from_slice(&buf)
+    Ok(HttpResponse { code, content: buf, headers })
+}
+
+pub fn http_get_socket_json(path: std::path::PathBuf, url: &str) -> Result<HttpResponse<Value>> {
+    let mut easy = curl::easy::Easy::new();
+
+    easy.url(url)?;
+    easy.unix_socket_path(Some(path))?;
+
+    let response = http_easy(easy)?;
+
+    let content = serde_json::from_slice(&response.content)
         .internal_error("curl", "could not parse json response from server")?;
 
-    Ok(HttpResponse { code, content, headers })
+    Ok(HttpResponse { code: response.code, content, headers: response.headers })
+}
+
+pub fn http_get_json(url: &str, timeout: Option<Duration>, request_headers: Vec<(&str, &str)>) -> Result<HttpResponse<Value>> {
+    let mut easy = curl::easy::Easy::new();
+
+    easy.url(url)?;
+
+    if let Some(t) = timeout {
+        easy.timeout(t)?;
+    }
+
+    let mut header_list = curl::easy::List::new();
+
+    for (k, v) in request_headers.iter() {
+        header_list.append(&format!("{}: {}", k, v))?;
+    }
+
+    easy.http_headers(header_list)?;
+
+    let response = http_easy(easy)?;
+
+    let content = serde_json::from_slice(&response.content)
+        .internal_error("curl", "could not parse json response from server")?;
+
+    Ok(HttpResponse { code: response.code, content, headers: response.headers })
 }
 
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,9 +1,9 @@
-use std::time::Duration;
-use serde_json::value::Value;
 use curl::easy::Easy;
+use serde_json::value::Value;
+use std::time::Duration;
 
-use crate::errors::{Result, ResultExtInternal};
 use crate::errors;
+use crate::errors::{Result, ResultExtInternal};
 
 pub struct HttpResponse<T> {
     pub code: u32,
@@ -23,7 +23,6 @@ fn http_easy(mut easy: Easy) -> Result<HttpResponse<Vec<u8>>> {
             true
         })?;
 
-
         transfer.write_function(|data| {
             buf.extend_from_slice(data);
             Ok(data.len())
@@ -34,7 +33,11 @@ fn http_easy(mut easy: Easy) -> Result<HttpResponse<Vec<u8>>> {
 
     let code = easy.response_code()?;
 
-    Ok(HttpResponse { code, content: buf, headers })
+    Ok(HttpResponse {
+        code,
+        content: buf,
+        headers,
+    })
 }
 
 pub fn http_get_socket_json(path: std::path::PathBuf, url: &str) -> Result<HttpResponse<Value>> {
@@ -48,10 +51,18 @@ pub fn http_get_socket_json(path: std::path::PathBuf, url: &str) -> Result<HttpR
     let content = serde_json::from_slice(&response.content)
         .internal_error("curl", "could not parse json response from server")?;
 
-    Ok(HttpResponse { code: response.code, content, headers: response.headers })
+    Ok(HttpResponse {
+        code: response.code,
+        content,
+        headers: response.headers,
+    })
 }
 
-pub fn http_get_json(url: &str, timeout: Option<Duration>, request_headers: Vec<(&str, &str)>) -> Result<HttpResponse<Value>> {
+pub fn http_get_json(
+    url: &str,
+    timeout: Option<Duration>,
+    request_headers: Vec<(&str, &str)>,
+) -> Result<HttpResponse<Value>> {
     let mut easy = curl::easy::Easy::new();
 
     easy.url(url)?;
@@ -73,9 +84,12 @@ pub fn http_get_json(url: &str, timeout: Option<Duration>, request_headers: Vec<
     let content = serde_json::from_slice(&response.content)
         .internal_error("curl", "could not parse json response from server")?;
 
-    Ok(HttpResponse { code: response.code, content, headers: response.headers })
+    Ok(HttpResponse {
+        code: response.code,
+        content,
+        headers: response.headers,
+    })
 }
-
 
 impl From<curl::Error> for errors::Error {
     fn from(err: curl::Error) -> Self {

--- a/src/http.rs
+++ b/src/http.rs
@@ -77,6 +77,8 @@ pub fn http_get_json(
         header_list.append(&format!("{}: {}", k, v))?;
     }
 
+    easy.useragent("i3status")?;
+
     easy.http_headers(header_list)?;
 
     let response = http_easy(easy)?;

--- a/src/http.rs
+++ b/src/http.rs
@@ -5,6 +5,7 @@ use crate::errors::{Result, ResultExtInternal};
 use crate::errors;
 
 
+
 pub fn http_get(url: &str, timeout: Duration) -> Result<(u32, String)> {
     let mut buf: Vec<u8> = Vec::new();
     let mut easy = curl::easy::Easy::new();
@@ -33,23 +34,38 @@ pub fn http_get(url: &str, timeout: Duration) -> Result<(u32, String)> {
 
 pub struct HttpResponse<T> {
     pub code: u32,
-    pub content: T
+    pub content: T,
+    pub headers: Vec<String>,
 }
 
-pub fn http_get_json(url: &str, timeout: Duration) -> Result<HttpResponse<Value>> {
+pub fn http_get_json(url: &str, timeout: Duration, request_headers: Vec<(&str, &str)>) -> Result<HttpResponse<Value>> {
     let mut buf: Vec<u8> = Vec::new();
+    let mut headers: Vec<String> = Vec::new();
     let mut easy = curl::easy::Easy::new();
 
     easy.url(url)?;
     easy.timeout(timeout)?;
 
+    let mut header_list = curl::easy::List::new();
+
+    for (k, v) in request_headers.iter() {
+        header_list.append(&format!("{}: {}", k, v))?;
+    }
+
+    easy.http_headers(header_list)?;
+
     {
         let mut transfer = easy.transfer();
 
-        (transfer.write_function(|data| {
+        transfer.header_function(|header| {
+            headers.push(String::from_utf8_lossy(header).to_string());
+            true
+        })?;
+
+        transfer.write_function(|data| {
             buf.extend_from_slice(data);
             Ok(data.len())
-        }))?;
+        })?;
 
         transfer.perform()?;
     }
@@ -59,7 +75,7 @@ pub fn http_get_json(url: &str, timeout: Duration) -> Result<HttpResponse<Value>
     let content = serde_json::from_slice(&buf)
         .internal_error("curl", "could not parse json response from server")?;
 
-    Ok(HttpResponse { code, content })
+    Ok(HttpResponse { code, content, headers })
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod util;
 pub mod blocks;
 mod config;
 mod errors;
+mod http;
 mod icons;
 mod input;
 mod scheduler;
@@ -18,7 +19,6 @@ mod subprocess;
 mod themes;
 mod widget;
 mod widgets;
-mod http;
 
 #[cfg(feature = "profiling")]
 use cpuprofiler::PROFILER;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod subprocess;
 mod themes;
 mod widget;
 mod widgets;
+mod http;
 
 #[cfg(feature = "profiling")]
 use cpuprofiler::PROFILER;


### PR DESCRIPTION
This commit makes the weather block use the curl bindings through the
`curl` crate rather than start a sub process to execute the curl binary.

This has a few advantages:

- Is faster and uses less resources as no shell is started

- We can use simpler code to parse the errors, status codes and output

- The user does not need to depend on the `curl` binary.  The `curl`
crate depends on `curl-sys` which can be configured to link to libcurl statically or dynamically.

Change the `docker` and `github` blocks to use these bindings as well.

Additionally, some improvements to the weather block were implemented:

Allow the user to configure the block with coordinates in addition to `city_id` or `place`.

Implement new format specifier `wind_kmh` with the value of wind speed in km/h. This is a feature forecast.io used to provide, so I believe many users are used to this.

Refactored code to make it easier to understand and read.

Handle different `Err` values and do not crash the entire bar if an error occurs. Show an error to the user or a simple `x` depending on the severity of the error, but keep the other blocks visible to the user.