### PR TITLE
Refactoring: use `block_error()` and handble DBus errors in battery.rs

### DIFF
--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -67,18 +67,11 @@ impl BacklitDevice {
             .read_dir() // Iterate over entries in the directory.
             .block_error("backlight", "Failed to read backlight device directory")?;
 
-        let first_device = match devices.take(1).next() {
-            None => Err(BlockError(
-                "backlight".to_string(),
-                "No backlit devices found".to_string(),
-            )),
-            Some(device) => device.map_err(|_| {
-                BlockError(
-                    "backlight".to_string(),
-                    "Failed to read default device file".to_string(),
-                )
-            }),
-        }?;
+        let first_device = devices
+            .take(1)
+            .next()
+            .block_error("backlight", "No backlit devices found")?
+            .block_error("backlight", "Failed to read default device file")?;
 
         let max_brightness = read_brightness(&first_device.path().join("max_brightness"))?;
 

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -171,15 +171,9 @@ impl Block for Custom {
             .unwrap_or_else(|e| e.to_string());
 
         if self.json {
-            let output: Output = match serde_json::from_str(&*raw_output) {
-                Err(e) => {
-                    return Err(BlockError(
-                        "custom".to_string(),
-                        format!("Error parsing JSON: {}", e),
-                    ));
-                }
-                Ok(s) => s,
-            };
+            let output: Output = serde_json::from_str(&*raw_output).map_err(|e| {
+                BlockError("custom".to_string(), format!("Error parsing JSON: {}", e))
+            })?;
             self.output.set_icon(&output.icon);
             self.output.set_state(output.state);
             self.is_empty = output.text.is_empty();

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -144,18 +144,15 @@ impl ConfigBlock for IBus {
             )?;
             let p = c.with_path("org.freedesktop.IBus", "/org/freedesktop/IBus", 5000);
             let info: arg::Variant<Box<dyn arg::RefArg>> =
-                match p.get("org.freedesktop.IBus", "GlobalEngine") {
-                    Ok(i) => i,
-                    Err(e) => {
-                        return Err(BlockError(
-                            "ibus".to_string(),
-                            format!(
-                                "Failed to query IBus for GlobalEngine at {} with error {}",
-                                ibus_address, e
-                            ),
-                        ))
-                    }
-                };
+                p.get("org.freedesktop.IBus", "GlobalEngine").map_err(|e| {
+                    BlockError(
+                        "ibus".to_string(),
+                        format!(
+                            "Failed to query IBus for GlobalEngine at {} with error {}",
+                            ibus_address, e
+                        ),
+                    )
+                })?;
 
             // `info` should contain something containing an array with the contents as such:
             // [name, longname, description, language, license, author, icon, layout, layout_variant, layout_option, rank, hotkeys, symbol, setup, version, textdomain, icon_prop_key]

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -77,22 +77,17 @@ fn setxkbmap_layouts() -> Result<String> {
     let layout = output
         .split('\n')
         .find(|line| line.starts_with("layout"))
-        .ok_or_else(|| {
-            BlockError(
-                "keyboard_layout".to_string(),
-                "Could not find the layout entry from setxkbmap.".to_string(),
-            )
-        })?
+        .block_error(
+            "keyboard_layout",
+            "Could not find the layout entry from setxkbmap.",
+        )?
         .split(char::is_whitespace)
         .last();
 
-    match layout {
-        Some(layout) => Ok(layout.to_string()),
-        None => Err(BlockError(
-            "keyboard_layout".to_string(),
-            "Could not read the layout entry from setxkbmap.".to_string(),
-        )),
-    }
+    layout.map(|s| s.to_string()).block_error(
+        "keyboard_layout",
+        "Could not read the layout entry from setxkbmap.",
+    )
 }
 
 impl KeyboardLayoutMonitor for SetXkbMap {

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -630,10 +630,7 @@ impl SoundDevice for PulseAudioSoundDevice {
     }
 
     fn set_volume(&mut self, step: i32, max_vol: Option<u32>) -> Result<()> {
-        let mut volume = match self.volume {
-            Some(volume) => volume,
-            None => return Err(BlockError("sound".into(), "volume unknown".into())),
-        };
+        let mut volume = self.volume.block_error("sound", "volume unknown")?;
 
         // apply step to volumes
         let step = (step as f32 * VOLUME_NORM.0 as f32 / 100.0).round() as i32;

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -362,13 +362,9 @@ impl PulseAudioClient {
             }
         };
         let thread_result = || -> Result<()> {
-            match recv_result.recv() {
-                Err(_) => Err(BlockError(
-                    "sound".into(),
-                    "failed to receive from pulseaudio thread channel".into(),
-                )),
-                Ok(result) => result,
-            }
+            recv_result
+                .recv()
+                .block_error("sound", "failed to receive from pulseaudio thread channel")?
         };
 
         // requests

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -148,10 +148,10 @@ impl ConfigBlock for Taskwarrior {
             .with_text("-");
         // If the deprecated `filter_tags` option has been set,
         // convert it to the new `filter` format.
-        let filters = if block_config.filter_tags.len() > 0 {
+        let filters = if !block_config.filter_tags.is_empty() {
             vec![
                 Filter::legacy("filtered".to_string(), &block_config.filter_tags),
-                Filter::legacy("all".to_string(), &vec![]),
+                Filter::legacy("all".to_string(), &[]),
             ]
         } else {
             block_config.filters


### PR DESCRIPTION
Use `block_error()` if possible since it makes code mode readable. Also handle some DBus errors instead of doing `unwrap()`.