### PR TITLE
keyboard_layout: split layout name and variant in sway driver

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -674,7 +674,7 @@ Key | Values | Required | Default
   Key    | Value
 ---------|-------
 `{layout}` | Keyboard layout name
-`{variant}` | Keyboard variant (only `localebus` is supported so far)
+`{variant}` | Keyboard variant (only `localebus` and `sway` are supported so far)
 
 ###### [↥ back to top](#list-of-available-blocks)
 


### PR DESCRIPTION
If I'm right, sway's keyboard layout is either `layout (variant)` or `layout` if there is no variant. If so, then it is possible to implement [this TODO](https://github.com/greshake/i3status-rust/blob/aaec57f85e150eaa0b13c5a4238df16b41649e41/src/blocks/keyboard_layout.rs#L365).