### PR TITLE
Change IDs to be `usize` instead of `String`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,17 +356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
 name = "gimli"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,7 +396,6 @@ dependencies = [
  "crossbeam-channel",
  "curl",
  "dbus",
- "getrandom 0.2.0",
  "inotify",
  "lazy_static",
  "libpulse-binding",
@@ -774,7 +762,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -797,7 +785,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ profiling = ["cpuprofiler", "progress"]
 [dependencies]
 crossbeam-channel = "0.5"
 dbus = "0.8"
-getrandom = "0.2"
 lazy_static = "1.0"
 maildir = "0.4"
 nix = "0.19.0"

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -110,7 +110,7 @@ impl Into<Update> for Duration {
 
 pub trait Block {
     /// A unique id for the block.
-    fn id(&self) -> &str;
+    fn id(&self) -> u64;
 
     /// The current "view" of the block, comprised of widgets.
     fn view(&self) -> Vec<&dyn I3BarWidget>;

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -138,6 +138,7 @@ pub trait ConfigBlock: Block {
 
     /// Creates a new block from the relevant configuration.
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         update_request: Sender<Task>,
@@ -151,7 +152,7 @@ pub trait ConfigBlock: Block {
 }
 
 macro_rules! block {
-    ($block_type:ident, $block_config:expr, $config:expr, $update_request:expr) => {{
+    ($block_type:ident, $id:expr, $block_config:expr, $config:expr, $update_request:expr) => {{
         let common_config = BaseBlockConfig::extract(&mut $block_config);
         let mut common_config = BaseBlockConfig::deserialize(common_config)
             .configuration_error("Failed to deserialize common block config.")?;
@@ -184,7 +185,7 @@ macro_rules! block {
             }
         }
 
-        let mut block = $block_type::new(block_config, main_config, $update_request)?;
+        let mut block = $block_type::new($id, block_config, main_config, $update_request)?;
         if let Some(overrided) = block.override_on_click() {
             *overrided = common_config.on_click.take();
         }
@@ -198,6 +199,7 @@ macro_rules! block {
 }
 
 pub fn create_block(
+    id: u64,
     name: &str,
     mut block_config: Value,
     config: Config,
@@ -205,44 +207,44 @@ pub fn create_block(
 ) -> Result<Box<dyn Block>> {
     match name {
         // Please keep these in alphabetical order.
-        "apt" => block!(Apt, block_config, config, update_request),
-        "backlight" => block!(Backlight, block_config, config, update_request),
-        "battery" => block!(Battery, block_config, config, update_request),
-        "bluetooth" => block!(Bluetooth, block_config, config, update_request),
-        "cpu" => block!(Cpu, block_config, config, update_request),
-        "custom" => block!(Custom, block_config, config, update_request),
-        "custom_dbus" => block!(CustomDBus, block_config, config, update_request),
-        "disk_space" => block!(DiskSpace, block_config, config, update_request),
-        "docker" => block!(Docker, block_config, config, update_request),
-        "focused_window" => block!(FocusedWindow, block_config, config, update_request),
-        "github" => block!(Github, block_config, config, update_request),
-        "hueshift" => block!(Hueshift, block_config, config, update_request),
-        "ibus" => block!(IBus, block_config, config, update_request),
-        "kdeconnect" => block!(KDEConnect, block_config, config, update_request),
-        "keyboard_layout" => block!(KeyboardLayout, block_config, config, update_request),
-        "load" => block!(Load, block_config, config, update_request),
-        "maildir" => block!(Maildir, block_config, config, update_request),
-        "memory" => block!(Memory, block_config, config, update_request),
-        "music" => block!(Music, block_config, config, update_request),
-        "net" => block!(Net, block_config, config, update_request),
-        "networkmanager" => block!(NetworkManager, block_config, config, update_request),
-        "notify" => block!(Notify, block_config, config, update_request),
+        "apt" => block!(Apt, id, block_config, config, update_request),
+        "backlight" => block!(Backlight, id, block_config, config, update_request),
+        "battery" => block!(Battery, id, block_config, config, update_request),
+        "bluetooth" => block!(Bluetooth, id, block_config, config, update_request),
+        "cpu" => block!(Cpu, id, block_config, config, update_request),
+        "custom" => block!(Custom, id, block_config, config, update_request),
+        "custom_dbus" => block!(CustomDBus, id, block_config, config, update_request),
+        "disk_space" => block!(DiskSpace, id, block_config, config, update_request),
+        "docker" => block!(Docker, id, block_config, config, update_request),
+        "focused_window" => block!(FocusedWindow, id, block_config, config, update_request),
+        "github" => block!(Github, id, block_config, config, update_request),
+        "hueshift" => block!(Hueshift, id, block_config, config, update_request),
+        "ibus" => block!(IBus, id, block_config, config, update_request),
+        "kdeconnect" => block!(KDEConnect, id, block_config, config, update_request),
+        "keyboard_layout" => block!(KeyboardLayout, id, block_config, config, update_request),
+        "load" => block!(Load, id, block_config, config, update_request),
+        "maildir" => block!(Maildir, id, block_config, config, update_request),
+        "memory" => block!(Memory, id, block_config, config, update_request),
+        "music" => block!(Music, id, block_config, config, update_request),
+        "net" => block!(Net, id, block_config, config, update_request),
+        "networkmanager" => block!(NetworkManager, id, block_config, config, update_request),
+        "notify" => block!(Notify, id, block_config, config, update_request),
         #[cfg(feature = "notmuch")]
-        "notmuch" => block!(Notmuch, block_config, config, update_request),
-        "nvidia_gpu" => block!(NvidiaGpu, block_config, config, update_request),
-        "pacman" => block!(Pacman, block_config, config, update_request),
-        "pomodoro" => block!(Pomodoro, block_config, config, update_request),
-        "sound" => block!(Sound, block_config, config, update_request),
-        "speedtest" => block!(SpeedTest, block_config, config, update_request),
-        "taskwarrior" => block!(Taskwarrior, block_config, config, update_request),
-        "temperature" => block!(Temperature, block_config, config, update_request),
-        "template" => block!(Template, block_config, config, update_request),
-        "time" => block!(Time, block_config, config, update_request),
-        "toggle" => block!(Toggle, block_config, config, update_request),
-        "uptime" => block!(Uptime, block_config, config, update_request),
-        "watson" => block!(Watson, block_config, config, update_request),
-        "weather" => block!(Weather, block_config, config, update_request),
-        "xrandr" => block!(Xrandr, block_config, config, update_request),
+        "notmuch" => block!(Notmuch, id, block_config, config, update_request),
+        "nvidia_gpu" => block!(NvidiaGpu, id, block_config, config, update_request),
+        "pacman" => block!(Pacman, id, block_config, config, update_request),
+        "pomodoro" => block!(Pomodoro, id, block_config, config, update_request),
+        "sound" => block!(Sound, id, block_config, config, update_request),
+        "speedtest" => block!(SpeedTest, id, block_config, config, update_request),
+        "taskwarrior" => block!(Taskwarrior, id, block_config, config, update_request),
+        "temperature" => block!(Temperature, id, block_config, config, update_request),
+        "template" => block!(Template, id, block_config, config, update_request),
+        "time" => block!(Time, id, block_config, config, update_request),
+        "toggle" => block!(Toggle, id, block_config, config, update_request),
+        "uptime" => block!(Uptime, id, block_config, config, update_request),
+        "watson" => block!(Watson, id, block_config, config, update_request),
+        "weather" => block!(Weather, id, block_config, config, update_request),
+        "xrandr" => block!(Xrandr, id, block_config, config, update_request),
         other => Err(BlockError(other.to_string(), "Unknown block!".to_string())),
     }
 }

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -110,7 +110,7 @@ impl Into<Update> for Duration {
 
 pub trait Block {
     /// A unique id for the block.
-    fn id(&self) -> u64;
+    fn id(&self) -> usize;
 
     /// The current "view" of the block, comprised of widgets.
     fn view(&self) -> Vec<&dyn I3BarWidget>;
@@ -138,7 +138,7 @@ pub trait ConfigBlock: Block {
 
     /// Creates a new block from the relevant configuration.
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         update_request: Sender<Task>,
@@ -199,7 +199,7 @@ macro_rules! block {
 }
 
 pub fn create_block(
-    id: u64,
+    id: usize,
     name: &str,
     mut block_config: Value,
     config: Config,

--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -20,7 +20,7 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct Apt {
-    id: u64,
+    id: usize,
     output: ButtonWidget,
     update_interval: Duration,
     format: FormatTemplate,
@@ -94,7 +94,7 @@ impl ConfigBlock for Apt {
     type Config = AptConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -201,7 +201,7 @@ fn get_update_count(updates: &str) -> usize {
 }
 
 impl Block for Apt {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -15,7 +15,7 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -94,12 +94,11 @@ impl ConfigBlock for Apt {
     type Config = AptConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let mut cache_dir = env::temp_dir();
         cache_dir.push("i3rs-apt");
         if !cache_dir.exists() {

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -180,7 +180,7 @@ impl BacklitDevice {
 
 /// A block for displaying the brightness of a backlit device.
 pub struct Backlight {
-    id: u64,
+    id: usize,
     output: ButtonWidget,
     device: BacklitDevice,
     step_width: u64,
@@ -235,7 +235,7 @@ impl ConfigBlock for Backlight {
     type Config = BacklightConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
@@ -331,7 +331,7 @@ impl Block for Backlight {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -23,7 +23,6 @@ use crate::config::{Config, LogicalDirection, Scrolling};
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::pseudo_uuid;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 
@@ -236,12 +235,11 @@ impl ConfigBlock for Backlight {
     type Config = BacklightConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let device = match block_config.device {
             Some(path) => BacklitDevice::from_device(path, block_config.root_scaling),
             None => BacklitDevice::default(block_config.root_scaling),

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -252,7 +252,7 @@ impl ConfigBlock for Backlight {
         let scrolling = config.scrolling;
         let backlight = Backlight {
             output: ButtonWidget::new(config, id),
-            id: id.clone(),
+            id,
             device,
             step_width: block_config.step_width,
             scrolling,
@@ -277,7 +277,7 @@ impl ConfigBlock for Backlight {
                     if events.any(|event| event.mask.contains(EventMask::MODIFY)) {
                         tx_update_request
                             .send(Task {
-                                id: id.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();

--- a/src/blocks/base_block.rs
+++ b/src/blocks/base_block.rs
@@ -18,7 +18,7 @@ pub(super) struct BaseBlock<T: Block> {
 }
 
 impl<T: Block> Block for BaseBlock<T> {
-    fn id(&self) -> &str {
+    fn id(&self) -> u64 {
         self.inner.id()
     }
 
@@ -37,12 +37,10 @@ impl<T: Block> Block for BaseBlock<T> {
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
         match &self.on_click {
             Some(cmd) => {
-                if let Some(ref name) = e.name {
-                    if name.as_str() == self.id() {
-                        if let MouseButton::Left = e.button {
-                            spawn_child_async("sh", &["-c", &cmd])
-                                .block_error(&self.name, "could not spawn child")?;
-                        }
+                if e.matches_id(self.id()) {
+                    if let MouseButton::Left = e.button {
+                        spawn_child_async("sh", &["-c", &cmd])
+                            .block_error(&self.name, "could not spawn child")?;
                     }
                 }
                 Ok(())

--- a/src/blocks/base_block.rs
+++ b/src/blocks/base_block.rs
@@ -18,7 +18,7 @@ pub(super) struct BaseBlock<T: Block> {
 }
 
 impl<T: Block> Block for BaseBlock<T> {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.inner.id()
     }
 

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -367,7 +367,7 @@ impl UpowerDevice {
 
     /// Monitor UPower property changes in a separate thread and send updates
     /// via the `update_request` channel.
-    pub fn monitor(&self, id: u64, update_request: Sender<Task>) {
+    pub fn monitor(&self, id: usize, update_request: Sender<Task>) {
         let path = self.device_path.clone();
         thread::Builder::new()
             .name("battery".into())
@@ -478,7 +478,7 @@ impl BatteryDevice for UpowerDevice {
 
 /// A block for displaying information about an internal power supply.
 pub struct Battery {
-    id: u64,
+    id: usize,
     output: TextWidget,
     update_interval: Duration,
     device: Box<dyn BatteryDevice>,
@@ -635,7 +635,7 @@ impl ConfigBlock for Battery {
     type Config = BatteryConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         update_request: Sender<Task>,
@@ -810,7 +810,7 @@ impl Block for Battery {
         vec![&self.output]
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -19,9 +19,7 @@ use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::scheduler::Task;
-use crate::util::{
-    battery_level_to_icon, format_percent_bar, pseudo_uuid, read_file, FormatTemplate,
-};
+use crate::util::{battery_level_to_icon, format_percent_bar, read_file, FormatTemplate};
 use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::text::TextWidget;
 
@@ -637,12 +635,11 @@ impl ConfigBlock for Battery {
     type Config = BatteryConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         // TODO: remove deprecated show types eventually
         let format = match block_config.show {
             Some(show) => match show.as_ref() {

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -394,7 +394,7 @@ impl UpowerDevice {
                     if con.incoming(10_000).next().is_some() {
                         update_request
                             .send(Task {
-                                id: id.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();
@@ -666,7 +666,7 @@ impl ConfigBlock for Battery {
         let device: Box<dyn BatteryDevice> = match driver {
             BatteryDriver::Upower => {
                 let out = UpowerDevice::from_device(&block_config.device)?;
-                out.monitor(id.clone(), update_request);
+                out.monitor(id, update_request);
                 Box::new(out)
             }
             BatteryDriver::Sysfs => Box::new(PowerSupplyDevice::from_device(

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -189,7 +189,7 @@ impl ConfigBlock for Bluetooth {
         let id = pseudo_uuid();
 
         let device = BluetoothDevice::new(block_config.mac, block_config.label)?;
-        device.monitor(id.clone(), send);
+        device.monitor(id, send);
 
         Ok(Bluetooth {
             id,

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -117,7 +117,7 @@ impl BluetoothDevice {
 
     /// Monitor Bluetooth property changes in a separate thread and send updates
     /// via the `update_request` channel.
-    pub fn monitor(&self, id: u64, update_request: Sender<Task>) {
+    pub fn monitor(&self, id: usize, update_request: Sender<Task>) {
         let path = self.path.clone();
         thread::Builder::new()
             .name("bluetooth".into())
@@ -154,7 +154,7 @@ impl BluetoothDevice {
 }
 
 pub struct Bluetooth {
-    id: u64,
+    id: usize,
     output: ButtonWidget,
     device: BluetoothDevice,
     hide_disconnected: bool,
@@ -185,7 +185,7 @@ impl ConfigBlock for Bluetooth {
     type Config = BluetoothConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         send: Sender<Task>,
@@ -209,7 +209,7 @@ impl ConfigBlock for Bluetooth {
 }
 
 impl Block for Bluetooth {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -11,7 +11,6 @@ use crate::config::Config;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::pseudo_uuid;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -185,9 +184,12 @@ impl BluetoothConfig {
 impl ConfigBlock for Bluetooth {
     type Config = BluetoothConfig;
 
-    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(
+        id: u64,
+        block_config: Self::Config,
+        config: Config,
+        send: Sender<Task>,
+    ) -> Result<Self> {
         let device = BluetoothDevice::new(block_config.mac, block_config.label)?;
         device.monitor(id, send);
 

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -20,10 +20,10 @@ use crate::widgets::button::ButtonWidget;
 const MAX_CPUS: usize = 32;
 
 pub struct Cpu {
+    id: u64,
     output: ButtonWidget,
     prev_idles: [u64; MAX_CPUS],
     prev_non_idles: [u64; MAX_CPUS],
-    id: String,
     update_interval: Duration,
     minimum_info: u64,
     minimum_warning: u64,
@@ -119,9 +119,9 @@ impl ConfigBlock for Cpu {
         let id = pseudo_uuid();
 
         Ok(Cpu {
-            id: id.clone(),
+            id,
             update_interval: block_config.interval,
-            output: ButtonWidget::new(config, &id).with_icon("cpu"),
+            output: ButtonWidget::new(config, id).with_icon("cpu"),
             prev_idles: [0; MAX_CPUS],
             prev_non_idles: [0; MAX_CPUS],
             minimum_info: block_config.info,
@@ -248,8 +248,8 @@ impl Block for Cpu {
         vec![&self.output]
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }
 

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -20,7 +20,7 @@ use crate::widgets::button::ButtonWidget;
 const MAX_CPUS: usize = 32;
 
 pub struct Cpu {
-    id: u64,
+    id: usize,
     output: ButtonWidget,
     prev_idles: [u64; MAX_CPUS],
     prev_non_idles: [u64; MAX_CPUS],
@@ -106,7 +106,7 @@ impl ConfigBlock for Cpu {
     type Config = CpuConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -247,7 +247,7 @@ impl Block for Cpu {
         vec![&self.output]
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -12,7 +12,7 @@ use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::scheduler::Task;
-use crate::util::{format_percent_bar, pseudo_uuid, FormatTemplate};
+use crate::util::{format_percent_bar, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -106,6 +106,7 @@ impl ConfigBlock for Cpu {
     type Config = CpuConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -115,8 +116,6 @@ impl ConfigBlock for Cpu {
         } else {
             block_config.format
         };
-
-        let id = pseudo_uuid();
 
         Ok(Cpu {
             id,

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -94,7 +94,7 @@ impl ConfigBlock for Custom {
         let mut custom = Custom {
             id,
             update_interval: block_config.interval,
-            output: ButtonWidget::new(config.clone(), id),
+            output: ButtonWidget::new(config, id),
             command: None,
             on_click: None,
             cycle: None,
@@ -199,7 +199,7 @@ impl Block for Custom {
         if let Some(sig) = self.signal {
             if sig == signal {
                 self.tx_update_request.send(Task {
-                    id: self.id.clone(),
+                    id: self.id,
                     update_time: Instant::now(),
                 })?;
             }
@@ -223,7 +223,7 @@ impl Block for Custom {
 
             if update {
                 self.tx_update_request.send(Task {
-                    id: self.id.clone(),
+                    id: self.id,
                     update_time: Instant::now(),
                 })?;
             }

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -20,7 +20,7 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct Custom {
-    id: u64,
+    id: usize,
     update_interval: Update,
     output: ButtonWidget,
     command: Option<String>,
@@ -87,7 +87,12 @@ impl CustomConfig {
 impl ConfigBlock for Custom {
     type Config = CustomConfig;
 
-    fn new(id: u64, block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
+    fn new(
+        id: usize,
+        block_config: Self::Config,
+        config: Config,
+        tx: Sender<Task>,
+    ) -> Result<Self> {
         let mut custom = Custom {
             id,
             update_interval: block_config.interval,
@@ -229,7 +234,7 @@ impl Block for Custom {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -16,7 +16,6 @@ use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::signals::convert_to_valid_signal;
 use crate::subprocess::spawn_child_async;
-use crate::util::pseudo_uuid;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -88,9 +87,7 @@ impl CustomConfig {
 impl ConfigBlock for Custom {
     type Config = CustomConfig;
 
-    fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(id: u64, block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
         let mut custom = Custom {
             id,
             update_interval: block_config.interval,

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -21,7 +21,7 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct Custom {
-    id: String,
+    id: u64,
     update_interval: Update,
     output: ButtonWidget,
     command: Option<String>,
@@ -89,10 +89,12 @@ impl ConfigBlock for Custom {
     type Config = CustomConfig;
 
     fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
+        let id = pseudo_uuid();
+
         let mut custom = Custom {
-            id: pseudo_uuid(),
+            id,
             update_interval: block_config.interval,
-            output: ButtonWidget::new(config.clone(), ""),
+            output: ButtonWidget::new(config.clone(), id),
             command: None,
             on_click: None,
             cycle: None,
@@ -107,7 +109,6 @@ impl ConfigBlock for Custom {
                 env::var("SHELL").unwrap_or_else(|_| "sh".to_owned())
             },
         };
-        custom.output = ButtonWidget::new(config, &custom.id);
 
         if let Some(signal) = block_config.signal {
             // If the signal is not in the valid range we return an error
@@ -207,37 +208,31 @@ impl Block for Custom {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if let Some(ref name) = event.name {
-            if name != &self.id {
-                return Ok(());
+        if event.matches_id(self.id) {
+            let mut update = false;
+
+            if let Some(ref on_click) = self.on_click {
+                spawn_child_async(&self.shell, &["-c", on_click]).ok();
+                update = true;
             }
-        } else {
-            return Ok(());
-        }
 
-        let mut update = false;
+            if let Some(ref mut cycle) = self.cycle {
+                cycle.next();
+                update = true;
+            }
 
-        if let Some(ref on_click) = self.on_click {
-            spawn_child_async(&self.shell, &["-c", on_click]).ok();
-            update = true;
-        }
-
-        if let Some(ref mut cycle) = self.cycle {
-            cycle.next();
-            update = true;
-        }
-
-        if update {
-            self.tx_update_request.send(Task {
-                id: self.id.clone(),
-                update_time: Instant::now(),
-            })?;
+            if update {
+                self.tx_update_request.send(Task {
+                    id: self.id.clone(),
+                    update_time: Instant::now(),
+                })?;
+            }
         }
 
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -100,7 +100,7 @@ impl ConfigBlock for CustomDBus {
 
                                         // Tell block to update now.
                                         send.send(Task {
-                                            id: id.clone(),
+                                            id,
                                             update_time: Instant::now(),
                                         })
                                         .unwrap();

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -15,7 +15,6 @@ use crate::config::Config;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::pseudo_uuid;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
 
@@ -50,9 +49,12 @@ impl CustomDBusConfig {
 impl ConfigBlock for CustomDBus {
     type Config = CustomDBusConfig;
 
-    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(
+        id: u64,
+        block_config: Self::Config,
+        config: Config,
+        send: Sender<Task>,
+    ) -> Result<Self> {
         let status_original = Arc::new(Mutex::new(CustomDBusStatus {
             content: String::from("??"),
             icon: String::from(""),

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -26,7 +26,7 @@ struct CustomDBusStatus {
 }
 
 pub struct CustomDBus {
-    id: u64,
+    id: usize,
     text: TextWidget,
     status: Arc<Mutex<CustomDBusStatus>>,
 }
@@ -50,7 +50,7 @@ impl ConfigBlock for CustomDBus {
     type Config = CustomDBusConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         send: Sender<Task>,
@@ -136,7 +136,7 @@ impl ConfigBlock for CustomDBus {
 }
 
 impl Block for CustomDBus {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -27,7 +27,7 @@ struct CustomDBusStatus {
 }
 
 pub struct CustomDBus {
-    id: String,
+    id: u64,
     text: TextWidget,
     status: Arc<Mutex<CustomDBusStatus>>,
 }
@@ -51,8 +51,7 @@ impl ConfigBlock for CustomDBus {
     type Config = CustomDBusConfig;
 
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id: String = pseudo_uuid();
-        let id_copy = id.clone();
+        let id = pseudo_uuid();
 
         let status_original = Arc::new(Mutex::new(CustomDBusStatus {
             content: String::from("??"),
@@ -129,18 +128,14 @@ impl ConfigBlock for CustomDBus {
             })
             .unwrap();
 
-        let text = TextWidget::new(config, &id_copy).with_text("CustomDBus");
-        Ok(CustomDBus {
-            id: id_copy,
-            text,
-            status,
-        })
+        let text = TextWidget::new(config, id).with_text("CustomDBus");
+        Ok(CustomDBus { id, text, status })
     }
 }
 
 impl Block for CustomDBus {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 
     // Updates the internal state of the block.

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -50,8 +50,8 @@ pub enum InfoType {
 }
 
 pub struct DiskSpace {
+    id: u64,
     disk_space: TextWidget,
-    id: String,
     update_interval: Duration,
     alias: String,
     path: String,
@@ -214,14 +214,11 @@ impl ConfigBlock for DiskSpace {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let icon = config
-            .icons
-            .get("disk_drive")
-            .cloned()
-            .unwrap_or_else(|| "".to_string());
-
         let id = pseudo_uuid();
-        let disk_space = TextWidget::new(config, &id);
+
+        let icon = config.icons.get("disk_drive").cloned().unwrap_or_default();
+
+        let disk_space = TextWidget::new(config, id);
         Ok(DiskSpace {
             id,
             update_interval: block_config.interval,
@@ -316,7 +313,7 @@ impl Block for DiskSpace {
         vec![&self.disk_space]
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -11,7 +11,7 @@ use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::scheduler::Task;
-use crate::util::{format_percent_bar, pseudo_uuid, FormatTemplate};
+use crate::util::{format_percent_bar, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
 
@@ -210,12 +210,11 @@ impl ConfigBlock for DiskSpace {
     type Config = DiskSpaceConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let icon = config.icons.get("disk_drive").cloned().unwrap_or_default();
 
         let disk_space = TextWidget::new(config, id);

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -50,7 +50,7 @@ pub enum InfoType {
 }
 
 pub struct DiskSpace {
-    id: u64,
+    id: usize,
     disk_space: TextWidget,
     update_interval: Duration,
     alias: String,
@@ -210,7 +210,7 @@ impl ConfigBlock for DiskSpace {
     type Config = DiskSpaceConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -312,7 +312,7 @@ impl Block for DiskSpace {
         vec![&self.disk_space]
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -16,8 +16,8 @@ use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
 pub struct Docker {
+    id: u64,
     text: TextWidget,
-    id: String,
     format: FormatTemplate,
     update_interval: Duration,
 }
@@ -77,7 +77,8 @@ impl ConfigBlock for Docker {
 
     fn new(block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
         let id = pseudo_uuid();
-        let text = TextWidget::new(config, &id)
+
+        let text = TextWidget::new(config, id)
             .with_text("N/A")
             .with_icon("docker");
         Ok(Docker {
@@ -124,7 +125,7 @@ impl Block for Docker {
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -16,7 +16,7 @@ use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
 pub struct Docker {
-    id: u64,
+    id: usize,
     text: TextWidget,
     format: FormatTemplate,
     update_interval: Duration,
@@ -75,7 +75,7 @@ impl DockerConfig {
 impl ConfigBlock for Docker {
     type Config = DockerConfig;
 
-    fn new(id: u64, block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
+    fn new(id: usize, block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
         let text = TextWidget::new(config, id)
             .with_text("N/A")
             .with_icon("docker");
@@ -123,7 +123,7 @@ impl Block for Docker {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -11,7 +11,7 @@ use crate::errors::*;
 use crate::http;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
@@ -75,9 +75,7 @@ impl DockerConfig {
 impl ConfigBlock for Docker {
     type Config = DockerConfig;
 
-    fn new(block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(id: u64, block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
         let text = TextWidget::new(config, id)
             .with_text("N/A")
             .with_icon("docker");

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -24,7 +24,7 @@ pub enum MarksType {
 }
 
 pub struct FocusedWindow {
-    id: u64,
+    id: usize,
     text: TextWidget,
     title: Arc<Mutex<String>>,
     marks: Arc<Mutex<String>>,
@@ -64,7 +64,12 @@ impl FocusedWindowConfig {
 impl ConfigBlock for FocusedWindow {
     type Config = FocusedWindowConfig;
 
-    fn new(id: u64, block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
+    fn new(
+        id: usize,
+        block_config: Self::Config,
+        config: Config,
+        tx: Sender<Task>,
+    ) -> Result<Self> {
         let title = Arc::new(Mutex::new(String::from("")));
         let marks = Arc::new(Mutex::new(String::from("")));
         let marks_type = block_config.show_marks;
@@ -236,7 +241,7 @@ impl Block for FocusedWindow {
         }
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -12,7 +12,6 @@ use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::Config;
 use crate::errors::*;
 use crate::scheduler::Task;
-use crate::util::pseudo_uuid;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
@@ -65,9 +64,7 @@ impl FocusedWindowConfig {
 impl ConfigBlock for FocusedWindow {
     type Config = FocusedWindowConfig;
 
-    fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(id: u64, block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
         let title = Arc::new(Mutex::new(String::from("")));
         let marks = Arc::new(Mutex::new(String::from("")));
         let marks_type = block_config.show_marks;

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -25,12 +25,12 @@ pub enum MarksType {
 }
 
 pub struct FocusedWindow {
+    id: u64,
     text: TextWidget,
     title: Arc<Mutex<String>>,
     marks: Arc<Mutex<String>>,
     show_marks: MarksType,
     max_width: usize,
-    id: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -67,7 +67,6 @@ impl ConfigBlock for FocusedWindow {
 
     fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
         let id = pseudo_uuid();
-        let id_clone = id.clone();
 
         let title = Arc::new(Mutex::new(String::from("")));
         let marks = Arc::new(Mutex::new(String::from("")));
@@ -177,7 +176,7 @@ impl ConfigBlock for FocusedWindow {
 
                     if updated {
                         tx.send(Task {
-                            id: id_clone.clone(),
+                            id,
                             update_time: Instant::now(),
                         })
                         .expect("could not communicate with channel in `window` block");
@@ -186,7 +185,7 @@ impl ConfigBlock for FocusedWindow {
             })
             .expect("failed to start watching thread for `window` block");
 
-        let text = TextWidget::new(config, &id);
+        let text = TextWidget::new(config, id);
         Ok(FocusedWindow {
             id,
             text,
@@ -240,7 +239,7 @@ impl Block for FocusedWindow {
         }
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -13,7 +13,7 @@ use crate::errors::*;
 use crate::http;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
@@ -79,11 +79,10 @@ impl GithubConfig {
 impl ConfigBlock for Github {
     type Config = GithubConfig;
 
-    fn new(block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
+    fn new(id: u64, block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
         let token = std::env::var(GITHUB_TOKEN_ENV)
             .block_error("github", "missing I3RS_GITHUB_TOKEN environment variable")?;
 
-        let id = pseudo_uuid();
         let text = TextWidget::new(config, id)
             .with_text("x")
             .with_icon("github");

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -21,7 +21,7 @@ const GITHUB_TOKEN_ENV: &str = "I3RS_GITHUB_TOKEN";
 
 pub struct Github {
     text: TextWidget,
-    id: String,
+    id: u64,
     update_interval: Duration,
     api_server: String,
     token: String,
@@ -84,7 +84,7 @@ impl ConfigBlock for Github {
             .block_error("github", "missing I3RS_GITHUB_TOKEN environment variable")?;
 
         let id = pseudo_uuid();
-        let text = TextWidget::new(config, &id)
+        let text = TextWidget::new(config, id)
             .with_text("x")
             .with_icon("github");
         Ok(Github {
@@ -158,8 +158,8 @@ impl Block for Github {
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }
 

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -21,7 +21,7 @@ const GITHUB_TOKEN_ENV: &str = "I3RS_GITHUB_TOKEN";
 
 pub struct Github {
     text: TextWidget,
-    id: u64,
+    id: usize,
     update_interval: Duration,
     api_server: String,
     token: String,
@@ -79,7 +79,7 @@ impl GithubConfig {
 impl ConfigBlock for Github {
     type Config = GithubConfig;
 
-    fn new(id: u64, block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
+    fn new(id: usize, block_config: Self::Config, config: Config, _: Sender<Task>) -> Result<Self> {
         let token = std::env::var(GITHUB_TOKEN_ENV)
             .block_error("github", "missing I3RS_GITHUB_TOKEN environment variable")?;
 
@@ -157,7 +157,7 @@ impl Block for Github {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/hueshift.rs
+++ b/src/blocks/hueshift.rs
@@ -16,7 +16,7 @@ use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 
 pub struct Hueshift {
-    id: u64,
+    id: usize,
     text: ButtonWidget,
     update_interval: Duration,
     step: u16,
@@ -198,7 +198,7 @@ impl ConfigBlock for Hueshift {
     type Config = HueshiftConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
@@ -295,7 +295,7 @@ impl Block for Hueshift {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/hueshift.rs
+++ b/src/blocks/hueshift.rs
@@ -11,7 +11,7 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::{has_command, pseudo_uuid};
+use crate::util::has_command;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 
@@ -198,12 +198,11 @@ impl ConfigBlock for Hueshift {
     type Config = HueshiftConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let current_temp = block_config.current_temp;
         let mut step = block_config.step;
         let mut max_temp = block_config.max_temp;

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -28,7 +28,7 @@ use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
 pub struct IBus {
-    id: u64,
+    id: usize,
     text: TextWidget,
     engine: Arc<Mutex<String>>,
     mappings: Option<BTreeMap<String, String>>,
@@ -67,7 +67,7 @@ impl ConfigBlock for IBus {
 
     #[allow(clippy::many_single_char_names)]
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         send: Sender<Task>,
@@ -228,7 +228,7 @@ impl ConfigBlock for IBus {
 }
 
 impl Block for IBus {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -28,7 +28,7 @@ use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
 pub struct IBus {
-    id: String,
+    id: u64,
     text: TextWidget,
     engine: Arc<Mutex<String>>,
     mappings: Option<BTreeMap<String, String>>,
@@ -67,9 +67,8 @@ impl ConfigBlock for IBus {
 
     #[allow(clippy::many_single_char_names)]
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id: String = pseudo_uuid();
-        let id_copy = id.clone();
-        let id_copy2 = id.clone();
+        let id = pseudo_uuid();
+
         let send2 = send.clone();
 
         let engine_original = Arc::new(Mutex::new(String::from("??")));
@@ -117,7 +116,7 @@ impl ConfigBlock for IBus {
                             // see comment on L167
                             *engine = "Reload the bar!".to_string();
 							send2.send(Task {
-								id: id_copy2.clone(),
+								id,
 								update_time: Instant::now(),
 							}).unwrap();
 						} else if name.contains("IBus") && old_owner.is_empty() && !new_owner.is_empty() {
@@ -127,7 +126,7 @@ impl ConfigBlock for IBus {
 							cvar.notify_one();
 
 							send2.send(Task {
-						   		id: id_copy2.clone(),
+						   		id,
 						   		update_time: Instant::now(),
 							}).unwrap();
 						}
@@ -214,9 +213,9 @@ impl ConfigBlock for IBus {
             })
             .unwrap();
 
-        let text = TextWidget::new(config, &id_copy).with_text("IBus");
+        let text = TextWidget::new(config, id).with_text("IBus");
         Ok(IBus {
-            id: id_copy,
+            id,
             text,
             engine: engine_original,
             mappings: block_config.mappings,
@@ -226,8 +225,8 @@ impl ConfigBlock for IBus {
 }
 
 impl Block for IBus {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 
     // Updates the internal state of the block.

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -203,7 +203,7 @@ impl ConfigBlock for IBus {
                             *engine = engine_name.to_string();
                             // Tell block to update now.
                             send.send(Task {
-                                id: id.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -23,7 +23,7 @@ use crate::config::Config;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, xdg_config_home, FormatTemplate};
+use crate::util::{xdg_config_home, FormatTemplate};
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
@@ -66,9 +66,12 @@ impl ConfigBlock for IBus {
     type Config = IBusConfig;
 
     #[allow(clippy::many_single_char_names)]
-    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(
+        id: u64,
+        block_config: Self::Config,
+        config: Config,
+        send: Sender<Task>,
+    ) -> Result<Self> {
         let send2 = send.clone();
 
         let engine_original = Arc::new(Mutex::new(String::from("??")));

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -332,7 +332,7 @@ impl ConfigBlock for KDEConnect {
                             // in one of the two battery signal handlers. Hopefully
                             // one day they add proper PropertiesChanged signals.
                             send.send(Task {
-                                id: id1.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();
@@ -368,7 +368,7 @@ impl ConfigBlock for KDEConnect {
                             *charge = s.charge;
 
                             send.send(Task {
-                                id: id1.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();
@@ -389,7 +389,7 @@ impl ConfigBlock for KDEConnect {
                             // Tell block to update now.
                             send3
                                 .send(Task {
-                                    id: id3.clone(),
+                                    id,
                                     update_time: Instant::now(),
                                 })
                                 .unwrap();
@@ -412,7 +412,7 @@ impl ConfigBlock for KDEConnect {
                             // Tell block to update now.
                             send4
                                 .send(Task {
-                                    id: id4.clone(),
+                                    id,
                                     update_time: Instant::now(),
                                 })
                                 .unwrap();
@@ -431,7 +431,7 @@ impl ConfigBlock for KDEConnect {
                             // Tell block to update now.
                             send5
                                 .send(Task {
-                                    id: id5.clone(),
+                                    id,
                                     update_time: Instant::now(),
                                 })
                                 .unwrap();
@@ -459,7 +459,7 @@ impl ConfigBlock for KDEConnect {
                             // Tell block to update now.
                             send3
                                 .send(Task {
-                                    id: id3.clone(),
+                                    id,
                                     update_time: Instant::now(),
                                 })
                                 .unwrap();
@@ -482,7 +482,7 @@ impl ConfigBlock for KDEConnect {
                             // Tell block to update now.
                             send4
                                 .send(Task {
-                                    id: id4.clone(),
+                                    id,
                                     update_time: Instant::now(),
                                 })
                                 .unwrap();
@@ -501,7 +501,7 @@ impl ConfigBlock for KDEConnect {
                             // Tell block to update now.
                             send5
                                 .send(Task {
-                                    id: id5.clone(),
+                                    id,
                                     update_time: Instant::now(),
                                 })
                                 .unwrap();

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -14,12 +14,12 @@ use crate::config::Config;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::{battery_level_to_icon, pseudo_uuid, FormatTemplate};
+use crate::util::{battery_level_to_icon, hash, pseudo_uuid, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct KDEConnect {
-    id: String,
+    id: u64,
     device_id: String,
     device_name: Arc<Mutex<String>>,
     battery_charge: Arc<Mutex<i32>>,
@@ -110,15 +110,8 @@ impl ConfigBlock for KDEConnect {
     type Config = KDEConnectConfig;
 
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id: String = pseudo_uuid();
+        let id = pseudo_uuid();
 
-        let id1 = id.clone();
-        let id2 = id.clone();
-        let id3 = id.clone();
-        let id4 = id.clone();
-        let id5 = id.clone();
-        let id6 = id.clone();
-        let id7 = id.clone();
         let send2 = send.clone();
         let send3 = send.clone();
         let send4 = send.clone();
@@ -241,7 +234,7 @@ impl ConfigBlock for KDEConnect {
                         // in one of the two battery signal handlers. Hopefully
                         // one day they add proper PropertiesChanged signals.
                         send.send(Task {
-                            id: id1.clone(),
+                            id,
                             update_time: Instant::now(),
                         })
                         .unwrap();
@@ -269,7 +262,7 @@ impl ConfigBlock for KDEConnect {
                         // Tell block to update now.
                         send2
                             .send(Task {
-                                id: id2.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();
@@ -288,7 +281,7 @@ impl ConfigBlock for KDEConnect {
                         // Tell block to update now.
                         send3
                             .send(Task {
-                                id: id3.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();
@@ -311,7 +304,7 @@ impl ConfigBlock for KDEConnect {
                         // Tell block to update now.
                         send4
                             .send(Task {
-                                id: id4.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();
@@ -330,7 +323,7 @@ impl ConfigBlock for KDEConnect {
                         // Tell block to update now.
                         send5
                             .send(Task {
-                                id: id5.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();
@@ -357,7 +350,7 @@ impl ConfigBlock for KDEConnect {
                         // one day they add proper PropertiesChanged signals.
                         send6
                             .send(Task {
-                                id: id6.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();
@@ -383,7 +376,7 @@ impl ConfigBlock for KDEConnect {
                         // Tell block to update now.
                         send7
                             .send(Task {
-                                id: id7.clone(),
+                                id,
                                 update_time: Instant::now(),
                             })
                             .unwrap();
@@ -414,15 +407,15 @@ impl ConfigBlock for KDEConnect {
             bat_critical: block_config.bat_critical,
             format: FormatTemplate::from_string(&block_config.format)?,
             format_disconnected: FormatTemplate::from_string(&block_config.format_disconnected)?,
-            output: ButtonWidget::new(config.clone(), "kdeconnect").with_icon("phone"),
+            output: ButtonWidget::new(config.clone(), hash("kdeconnect")).with_icon("phone"),
             config,
         })
     }
 }
 
 impl Block for KDEConnect {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 
     fn update(&mut self) -> Result<Option<Update>> {

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -14,7 +14,7 @@ use crate::config::Config;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::{battery_level_to_icon, hash, pseudo_uuid, FormatTemplate};
+use crate::util::{battery_level_to_icon, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -109,9 +109,12 @@ impl KDEConnectConfig {
 impl ConfigBlock for KDEConnect {
     type Config = KDEConnectConfig;
 
-    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(
+        id: u64,
+        block_config: Self::Config,
+        config: Config,
+        send: Sender<Task>,
+    ) -> Result<Self> {
         let send2 = send.clone();
         let send3 = send.clone();
         let send4 = send.clone();
@@ -562,7 +565,7 @@ impl ConfigBlock for KDEConnect {
             bat_critical: block_config.bat_critical,
             format: FormatTemplate::from_string(&block_config.format)?,
             format_disconnected: FormatTemplate::from_string(&block_config.format_disconnected)?,
-            output: ButtonWidget::new(config.clone(), hash("kdeconnect")).with_icon("phone"),
+            output: ButtonWidget::new(config.clone(), id).with_icon("phone"),
             config,
         })
     }

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -19,7 +19,7 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct KDEConnect {
-    id: u64,
+    id: usize,
     device_id: String,
     device_name: Arc<Mutex<String>>,
     battery_charge: Arc<Mutex<i32>>,
@@ -110,7 +110,7 @@ impl ConfigBlock for KDEConnect {
     type Config = KDEConnectConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         send: Sender<Task>,
@@ -572,7 +572,7 @@ impl ConfigBlock for KDEConnect {
 }
 
 impl Block for KDEConnect {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -52,7 +52,7 @@ pub trait KeyboardLayoutMonitor {
 
     /// Monitor layout changes and send updates via the `update_request`
     /// channel. By default, this method does nothing.
-    fn monitor(&self, _id: u64, _update_request: Sender<Task>) {}
+    fn monitor(&self, _id: usize, _update_request: Sender<Task>) {}
 }
 
 pub struct SetXkbMap;
@@ -146,7 +146,7 @@ impl KeyboardLayoutMonitor for LocaleBus {
     /// Monitor Locale property changes in a separate thread and send updates
     /// via the `update_request` channel.
     // TODO: pull the new value from the PropertiesChanged message instead of making another method call
-    fn monitor(&self, id: u64, update_request: Sender<Task>) {
+    fn monitor(&self, id: usize, update_request: Sender<Task>) {
         thread::Builder::new()
             .name("keyboard_layout".into())
             .spawn(move || {
@@ -262,7 +262,7 @@ impl KeyboardLayoutMonitor for KbdDaemonBus {
 
     // Monitor KbdDaemon 'layoutChanged' property in a separate thread and send updates
     // via the `update_request` channel.
-    fn monitor(&self, id: u64, update_request: Sender<Task>) {
+    fn monitor(&self, id: usize, update_request: Sender<Task>) {
         let arc = Arc::clone(&self.kbdd_layout_id);
         thread::Builder::new()
             .name("keyboard_layout".into())
@@ -375,7 +375,7 @@ impl KeyboardLayoutMonitor for Sway {
 
     /// Monitor layout changes in a separate thread and send updates
     /// via the `update_request` channel.
-    fn monitor(&self, id: u64, update_request: Sender<Task>) {
+    fn monitor(&self, id: usize, update_request: Sender<Task>) {
         let arc = Arc::clone(&self.sway_kb_layout);
         thread::Builder::new()
             .name("keyboard_layout".into())
@@ -455,7 +455,7 @@ impl KeyboardLayoutConfig {
 }
 
 pub struct KeyboardLayout {
-    id: u64,
+    id: usize,
     output: TextWidget,
     monitor: Box<dyn KeyboardLayoutMonitor>,
     update_interval: Option<Duration>,
@@ -466,7 +466,7 @@ impl ConfigBlock for KeyboardLayout {
     type Config = KeyboardLayoutConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         send: Sender<Task>,
@@ -509,7 +509,7 @@ impl ConfigBlock for KeyboardLayout {
 }
 
 impl Block for KeyboardLayout {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -406,7 +406,7 @@ impl KeyboardLayoutMonitor for Sway {
                                 }
                                 update_request
                                     .send(Task {
-                                        id: id.clone(),
+                                        id,
                                         update_time: Instant::now(),
                                     })
                                     .unwrap();

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -20,7 +20,7 @@ use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
@@ -465,8 +465,12 @@ pub struct KeyboardLayout {
 impl ConfigBlock for KeyboardLayout {
     type Config = KeyboardLayoutConfig;
 
-    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
+    fn new(
+        id: u64,
+        block_config: Self::Config,
+        config: Config,
+        send: Sender<Task>,
+    ) -> Result<Self> {
         let monitor: Box<dyn KeyboardLayoutMonitor> = match block_config.driver {
             KeyboardLayoutDriver::SetXkbMap => Box::new(SetXkbMap::new()?),
             KeyboardLayoutDriver::LocaleBus => {

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -11,7 +11,7 @@ use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
 
@@ -83,12 +83,11 @@ impl ConfigBlock for Load {
     type Config = LoadConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let text = TextWidget::new(config, id)
             .with_icon("cogs")
             .with_state(State::Info);

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -16,10 +16,10 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
 
 pub struct Load {
+    id: u64,
     text: TextWidget,
     logical_cores: u32,
     format: FormatTemplate,
-    id: String,
     update_interval: Duration,
     minimum_info: f32,
     minimum_warning: f32,
@@ -88,7 +88,8 @@ impl ConfigBlock for Load {
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         let id = pseudo_uuid();
-        let text = TextWidget::new(config, &id)
+
+        let text = TextWidget::new(config, id)
             .with_icon("cogs")
             .with_state(State::Info);
 
@@ -154,7 +155,7 @@ impl Block for Load {
         vec![&self.text]
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -16,7 +16,7 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
 
 pub struct Load {
-    id: u64,
+    id: usize,
     text: TextWidget,
     logical_cores: u32,
     format: FormatTemplate,
@@ -83,7 +83,7 @@ impl ConfigBlock for Load {
     type Config = LoadConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -154,7 +154,7 @@ impl Block for Load {
         vec![&self.text]
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -11,7 +11,6 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::pseudo_uuid;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
 
@@ -93,12 +92,11 @@ impl ConfigBlock for Maildir {
     type Config = MaildirConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let widget = TextWidget::new(config, id).with_text("");
         Ok(Maildir {
             id,

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -40,8 +40,8 @@ impl Default for MailType {
 }
 
 pub struct Maildir {
+    id: u64,
     text: TextWidget,
-    id: String,
     update_interval: Duration,
     inboxes: Vec<String>,
     threshold_warning: usize,
@@ -98,7 +98,8 @@ impl ConfigBlock for Maildir {
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         let id = pseudo_uuid();
-        let widget = TextWidget::new(config, &id).with_text("");
+
+        let widget = TextWidget::new(config, id).with_text("");
         Ok(Maildir {
             id,
             update_interval: block_config.interval,
@@ -142,7 +143,7 @@ impl Block for Maildir {
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -39,7 +39,7 @@ impl Default for MailType {
 }
 
 pub struct Maildir {
-    id: u64,
+    id: usize,
     text: TextWidget,
     update_interval: Duration,
     inboxes: Vec<String>,
@@ -92,7 +92,7 @@ impl ConfigBlock for Maildir {
     type Config = MaildirConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -141,7 +141,7 @@ impl Block for Maildir {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -156,7 +156,7 @@ impl Memstate {
 
 #[derive(Clone, Debug)]
 pub struct Memory {
-    id: u64,
+    id: usize,
     memtype: Memtype,
     output: (ButtonWidget, ButtonWidget),
     clickable: bool,
@@ -355,7 +355,12 @@ impl Memory {
 impl ConfigBlock for Memory {
     type Config = MemoryConfig;
 
-    fn new(id: u64, block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
+    fn new(
+        id: usize,
+        block_config: Self::Config,
+        config: Config,
+        tx: Sender<Task>,
+    ) -> Result<Self> {
         let icons: bool = block_config.icons;
         let widget = ButtonWidget::new(config, id).with_text("");
         Ok(Memory {
@@ -383,7 +388,7 @@ impl ConfigBlock for Memory {
 }
 
 impl Block for Memory {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -492,7 +492,7 @@ impl Block for Memory {
                 self.switch();
                 self.update()?;
                 self.tx_update_request.send(Task {
-                    id: self.id.clone(),
+                    id: self.id,
                     update_time: Instant::now(),
                 })?;
             }

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -156,7 +156,7 @@ impl Memstate {
 
 #[derive(Clone, Debug)]
 pub struct Memory {
-    id: String,
+    id: u64,
     memtype: Memtype,
     output: (ButtonWidget, ButtonWidget),
     clickable: bool,
@@ -357,8 +357,9 @@ impl ConfigBlock for Memory {
 
     fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
         let id = pseudo_uuid();
+
         let icons: bool = block_config.icons;
-        let widget = ButtonWidget::new(config, &id).with_text("");
+        let widget = ButtonWidget::new(config, id).with_text("");
         Ok(Memory {
             id,
             memtype: block_config.display_type,
@@ -384,8 +385,8 @@ impl ConfigBlock for Memory {
 }
 
 impl Block for Memory {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 
     fn update(&mut self) -> Result<Option<Update>> {
@@ -486,8 +487,8 @@ impl Block for Memory {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if let Some(ref s) = event.name {
-            if self.clickable && event.button == MouseButton::Left && *s == self.id {
+        if event.matches_id(self.id) {
+            if let MouseButton::Left = event.button {
                 self.switch();
                 self.update()?;
                 self.tx_update_request.send(Task {

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -355,9 +355,7 @@ impl Memory {
 impl ConfigBlock for Memory {
     type Config = MemoryConfig;
 
-    fn new(block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(id: u64, block_config: Self::Config, config: Config, tx: Sender<Task>) -> Result<Self> {
         let icons: bool = block_config.icons;
         let widget = ButtonWidget::new(config, id).with_text("");
         Ok(Memory {

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -431,7 +431,7 @@ impl ConfigBlock for Music {
                             };
                             if updated {
                                 send.send(Task {
-                                    id: id.clone(),
+                                    id,
                                     update_time: Instant::now(),
                                 })
                                 .unwrap();
@@ -705,7 +705,7 @@ impl Block for Music {
                     if (event_id == self.id || event_id == self.collapsed_id) && players.len() > 0 {
                         players.rotate_left(1);
                         self.send.send(Task {
-                            id: self.id.clone(),
+                            id: self.id,
                             update_time: Instant::now(),
                         })?;
                     }

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -23,7 +23,7 @@ use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::{hash, pseudo_uuid, FormatTemplate};
 use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::rotatingtext::RotatingTextWidget;
@@ -54,7 +54,12 @@ impl Default for PlaybackStatus {
 }
 
 pub struct Music {
-    id: String,
+    id: u64,
+    play_id: u64,
+    next_id: u64,
+    prev_id: u64,
+    collapsed_id: u64,
+
     current_song_widget: RotatingTextWidget,
     prev: Option<ButtonWidget>,
     play: Option<ButtonWidget>,
@@ -281,10 +286,12 @@ impl ConfigBlock for Music {
     type Config = MusicConfig;
 
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id: String = pseudo_uuid();
-        let id_copy = id.clone();
-        let id_copy2 = id.clone();
-        let id_copy3 = id.clone();
+        let id = pseudo_uuid();
+        let play_id = hash("PLAY") + id;
+        let prev_id = hash("PREV") + id;
+        let next_id = hash("NEXT") + id;
+        let collapsed_id = hash("COLLAPSED") + id;
+
         let send2 = send.clone();
         let send3 = send.clone();
 
@@ -453,7 +460,7 @@ impl ConfigBlock for Music {
                              if let Some(pos) = players.iter().position(|p| p.bus_name == old_owner) {
                                  players.remove(pos);
                                  send2.send(Task {
-                                     id: id_copy3.clone(),
+                                     id,
                                      update_time: Instant::now(),
                                  })
                                  .unwrap();
@@ -467,7 +474,7 @@ impl ConfigBlock for Music {
                              title: None,
                          });
                          send2.send(Task {
-                             id: id_copy3.clone(),
+                             id,
                              update_time: Instant::now(),
                          })
                          .unwrap();
@@ -483,27 +490,24 @@ impl ConfigBlock for Music {
         for button in block_config.buttons {
             match &*button {
                 "play" => {
-                    let button_id = format!("{}_PLAY", id_copy);
                     play = Some(
-                        ButtonWidget::new(config.clone(), &button_id)
+                        ButtonWidget::new(config.clone(), play_id)
                             .with_icon("music_play")
                             .with_state(State::Info)
                             .with_spacing(Spacing::Inline),
                     )
                 }
                 "next" => {
-                    let button_id = format!("{}_NEXT", id_copy);
                     next = Some(
-                        ButtonWidget::new(config.clone(), &button_id)
+                        ButtonWidget::new(config.clone(), next_id)
                             .with_icon("music_next")
                             .with_state(State::Info)
                             .with_spacing(Spacing::Inline),
                     )
                 }
                 "prev" => {
-                    let button_id = format!("{}_PREV", id_copy);
                     prev = Some(
-                        ButtonWidget::new(config.clone(), &button_id)
+                        ButtonWidget::new(config.clone(), prev_id)
                             .with_icon("music_prev")
                             .with_state(State::Info)
                             .with_spacing(Spacing::Inline),
@@ -522,16 +526,19 @@ impl ConfigBlock for Music {
             patterns.iter().map(|p| Regex::new(&p)).collect()
         }
 
-        let id_collapsed = format!("{}_COLLAPSED", id_copy);
         Ok(Music {
-            id: id_copy,
+            id,
+            play_id,
+            prev_id,
+            next_id,
+            collapsed_id,
             current_song_widget: RotatingTextWidget::new(
                 Duration::new(block_config.marquee_interval.as_secs(), 0),
                 Duration::new(0, block_config.marquee_speed.subsec_nanos()),
                 block_config.max_width,
                 block_config.dynamic_width,
                 config.clone(),
-                &id_copy2,
+                id,
             )
             .with_icon("music")
             .with_state(State::Info),
@@ -539,7 +546,7 @@ impl ConfigBlock for Music {
             play,
             next,
             on_click: None,
-            on_collapsed_click_widget: ButtonWidget::new(config.clone(), &id_collapsed)
+            on_collapsed_click_widget: ButtonWidget::new(config.clone(), collapsed_id)
                 .with_icon("music")
                 .with_state(State::Info)
                 .with_spacing(Spacing::Hidden),
@@ -566,8 +573,8 @@ impl ConfigBlock for Music {
 }
 
 impl Block for Music {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 
     fn update(&mut self) -> Result<Option<Update>> {
@@ -647,16 +654,13 @@ impl Block for Music {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if let Some(ref name) = event.name {
-            let play_id = format!("{}_PLAY", self.id);
-            let prev_id = format!("{}_PREV", self.id);
-            let next_id = format!("{}_NEXT", self.id);
-            let collapsed_id = format!("{}_COLLAPSED", self.id);
-            let action = match name as &str {
-                id if id == play_id => "PlayPause",
-                id if id == next_id => "Next",
-                id if id == prev_id => "Previous",
-                _ => "",
+        if let Some(event_id) = event.id {
+            let action = match event_id {
+                id if id == self.play_id => "PlayPause",
+                id if id == self.next_id => "Next",
+                id if id == self.prev_id => "Previous",
+                id if id == self.id => "",
+                _ => return Ok(()),
             };
 
             let mut players = self
@@ -678,11 +682,11 @@ impl Block for Music {
                         self.dbus_conn
                             .send(m)
                             .block_error("music", "failed to call method via D-Bus")?;
-                    } else if name == &collapsed_id && self.on_collapsed_click.is_some() {
+                    } else if event_id == self.collapsed_id && self.on_collapsed_click.is_some() {
                         let cmd = self.on_collapsed_click.as_ref().unwrap();
                         spawn_child_async("sh", &["-c", cmd])
                             .block_error("music", "could not spawn child")?;
-                    } else if event.matches_name(self.id()) {
+                    } else if event_id == self.id {
                         if let Some(ref cmd) = self.on_click {
                             spawn_child_async("sh", &["-c", cmd])
                                 .block_error("music", "could not spawn child")?;
@@ -698,7 +702,7 @@ impl Block for Music {
                 //                    com.github.altdesktop.playerctld \
                 //                    Shift
                 MouseButton::Right => {
-                    if (name.as_str() == self.id || name == &collapsed_id) && players.len() > 0 {
+                    if (event_id == self.id || event_id == self.collapsed_id) && players.len() > 0 {
                         players.rotate_left(1);
                         self.send.send(Task {
                             id: self.id.clone(),
@@ -707,7 +711,7 @@ impl Block for Music {
                     }
                 }
                 _ => {
-                    if name.as_str() == self.id && players.len() > 0 {
+                    if event_id == self.id && players.len() > 0 {
                         let metadata = players.first().unwrap();
                         let m = Message::new_method_call(
                             metadata.interface_name.clone(),

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -54,11 +54,11 @@ impl Default for PlaybackStatus {
 }
 
 pub struct Music {
-    id: u64,
-    play_id: u64,
-    next_id: u64,
-    prev_id: u64,
-    collapsed_id: u64,
+    id: usize,
+    play_id: usize,
+    next_id: usize,
+    prev_id: usize,
+    collapsed_id: usize,
 
     current_song_widget: RotatingTextWidget,
     prev: Option<ButtonWidget>,
@@ -286,7 +286,7 @@ impl ConfigBlock for Music {
     type Config = MusicConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         send: Sender<Task>,
@@ -577,7 +577,7 @@ impl ConfigBlock for Music {
 }
 
 impl Block for Music {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -23,7 +23,7 @@ use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
-use crate::util::{hash, pseudo_uuid, FormatTemplate};
+use crate::util::{pseudo_uuid, FormatTemplate};
 use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::rotatingtext::RotatingTextWidget;
@@ -285,12 +285,16 @@ impl MusicConfig {
 impl ConfigBlock for Music {
     type Config = MusicConfig;
 
-    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-        let play_id = hash("PLAY") + id;
-        let prev_id = hash("PREV") + id;
-        let next_id = hash("NEXT") + id;
-        let collapsed_id = hash("COLLAPSED") + id;
+    fn new(
+        id: u64,
+        block_config: Self::Config,
+        config: Config,
+        send: Sender<Task>,
+    ) -> Result<Self> {
+        let play_id = pseudo_uuid();
+        let prev_id = pseudo_uuid();
+        let next_id = pseudo_uuid();
+        let collapsed_id = pseudo_uuid();
 
         let send2 = send.clone();
         let send3 = send.clone();

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -18,8 +18,7 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::scheduler::Task;
 use crate::util::{
-    escape_pango_text, format_number, format_percent_bar, format_vec_to_bar_graph, pseudo_uuid,
-    FormatTemplate,
+    escape_pango_text, format_number, format_percent_bar, format_vec_to_bar_graph, FormatTemplate,
 };
 use crate::widget::{I3BarWidget, Spacing};
 use crate::widgets::button::ButtonWidget;
@@ -577,12 +576,11 @@ impl ConfigBlock for Net {
     type Config = NetConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let default_device = match NetworkDevice::default_device() {
             Some(ref s) if !s.is_empty() => s.to_string(),
             _ => "lo".to_string(),

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -356,7 +356,7 @@ impl NetworkDevice {
 }
 
 pub struct Net {
-    id: u64,
+    id: usize,
     format: FormatTemplate,
     output: ButtonWidget,
     config: Config,
@@ -576,7 +576,7 @@ impl ConfigBlock for Net {
     type Config = NetConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -978,7 +978,7 @@ impl Block for Net {
         }
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -357,6 +357,7 @@ impl NetworkDevice {
 }
 
 pub struct Net {
+    id: u64,
     format: FormatTemplate,
     output: ButtonWidget,
     config: Config,
@@ -372,7 +373,6 @@ pub struct Net {
     graph_tx: Option<String>,
     output_rx: Option<String>,
     graph_rx: Option<String>,
-    id: String,
     update_interval: Duration,
     device: NetworkDevice,
     auto_device: bool,
@@ -581,6 +581,8 @@ impl ConfigBlock for Net {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
+        let id = pseudo_uuid();
+
         let default_device = match NetworkDevice::default_device() {
             Some(ref s) if !s.is_empty() => s.to_string(),
             _ => "lo".to_string(),
@@ -593,7 +595,6 @@ impl ConfigBlock for Net {
         let init_tx_bytes = device.tx_bytes().unwrap_or(0);
         let wireless = device.is_wireless();
         let vpn = device.is_vpn();
-        let id = pseudo_uuid();
 
         let (_, net_config) = config
             .blocks
@@ -613,18 +614,18 @@ impl ConfigBlock for Net {
         };
 
         Ok(Net {
-            id: id.clone(),
+            id,
             update_interval: block_config.interval,
             format: FormatTemplate::from_string(&format)
                 .block_error("net", "Invalid format specified")?,
-            output: ButtonWidget::new(config.clone(), "")
+            output: ButtonWidget::new(config.clone(), 0)
                 .with_text("")
                 .with_spacing(Spacing::Inline),
             config: config.clone(),
             use_bits: block_config.use_bits,
             speed_min_unit: block_config.speed_min_unit,
             speed_digits: block_config.speed_digits,
-            network: ButtonWidget::new(config, &id).with_icon(if wireless {
+            network: ButtonWidget::new(config, id).with_icon(if wireless {
                 "net_wireless"
             } else if vpn {
                 "net_vpn"
@@ -979,8 +980,8 @@ impl Block for Net {
         }
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }
 

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -442,7 +442,7 @@ impl<'a> NmIp4Config<'a> {
 }
 
 pub struct NetworkManager {
-    id: String,
+    id: u64,
     indicator: ButtonWidget,
     output: Vec<ButtonWidget>,
     dbus_conn: Connection,
@@ -530,8 +530,8 @@ impl ConfigBlock for NetworkManager {
     type Config = NetworkManagerConfig;
 
     fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id: String = pseudo_uuid();
-        let id_copy = id.clone();
+        let id = pseudo_uuid();
+
         let dbus_conn = Connection::get_private(BusType::System)
             .block_error("networkmanager", "failed to establish D-Bus connection")?;
         let manager = ConnectionManager::new();
@@ -555,7 +555,7 @@ impl ConfigBlock for NetworkManager {
                             ConnectionItem::Nothing => (),
                             _ => send
                                 .send(Task {
-                                    id: id_copy.clone(),
+                                    id,
                                     update_time: Instant::now(),
                                 })
                                 .unwrap(),
@@ -570,9 +570,9 @@ impl ConfigBlock for NetworkManager {
         }
 
         Ok(NetworkManager {
-            id: id.clone(),
+            id,
             config: config.clone(),
-            indicator: ButtonWidget::new(config, &id),
+            indicator: ButtonWidget::new(config, id),
             output: Vec::new(),
             dbus_conn,
             manager,
@@ -590,8 +590,8 @@ impl ConfigBlock for NetworkManager {
 }
 
 impl Block for NetworkManager {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 
     fn update(&mut self) -> Result<Option<Update>> {
@@ -649,7 +649,7 @@ impl Block for NetworkManager {
                     .into_iter()
                     .filter_map(|conn| {
                         // inline spacing for no leading space, because the icon is set in the string
-                        let mut widget = ButtonWidget::new(self.config.clone(), &self.id)
+                        let mut widget = ButtonWidget::new(self.config.clone(), self.id)
                             .with_spacing(Spacing::Inline);
 
                         // Set the state for this connection

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -442,7 +442,7 @@ impl<'a> NmIp4Config<'a> {
 }
 
 pub struct NetworkManager {
-    id: u64,
+    id: usize,
     indicator: ButtonWidget,
     output: Vec<ButtonWidget>,
     dbus_conn: Connection,
@@ -530,7 +530,7 @@ impl ConfigBlock for NetworkManager {
     type Config = NetworkManagerConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         send: Sender<Task>,
@@ -593,7 +593,7 @@ impl ConfigBlock for NetworkManager {
 }
 
 impl Block for NetworkManager {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -19,7 +19,7 @@ use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::Config;
 use crate::errors::*;
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -529,9 +529,12 @@ impl NetworkManagerConfig {
 impl ConfigBlock for NetworkManager {
     type Config = NetworkManagerConfig;
 
-    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(
+        id: u64,
+        block_config: Self::Config,
+        config: Config,
+        send: Sender<Task>,
+    ) -> Result<Self> {
         let dbus_conn = Connection::get_private(BusType::System)
             .block_error("networkmanager", "failed to establish D-Bus connection")?;
         let manager = ConnectionManager::new();

--- a/src/blocks/notify.rs
+++ b/src/blocks/notify.rs
@@ -14,7 +14,7 @@ use crate::config::Config;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::{hash, pseudo_uuid, FormatTemplate};
+use crate::util::{pseudo_uuid, FormatTemplate};
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 
@@ -54,9 +54,13 @@ impl NotifyConfig {
 impl ConfigBlock for Notify {
     type Config = NotifyConfig;
 
-    fn new(block_config: Self::Config, config: Config, send: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-        let notify_id = hash("notify") + id;
+    fn new(
+        id: u64,
+        block_config: Self::Config,
+        config: Config,
+        send: Sender<Task>,
+    ) -> Result<Self> {
+        let notify_id = pseudo_uuid();
 
         let c = Connection::get_private(BusType::Session).block_error(
             "notify",

--- a/src/blocks/notify.rs
+++ b/src/blocks/notify.rs
@@ -22,8 +22,8 @@ use crate::widgets::button::ButtonWidget;
 // Add driver option so can choose between dunst, mako, etc.
 
 pub struct Notify {
-    id: u64,
-    notify_id: u64,
+    id: usize,
+    notify_id: usize,
     paused: Arc<Mutex<i64>>,
     format: FormatTemplate,
     output: ButtonWidget,
@@ -55,7 +55,7 @@ impl ConfigBlock for Notify {
     type Config = NotifyConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         send: Sender<Task>,
@@ -126,7 +126,7 @@ impl ConfigBlock for Notify {
 }
 
 impl Block for Notify {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -11,7 +11,6 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::pseudo_uuid;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
 
@@ -116,12 +115,11 @@ impl ConfigBlock for Notmuch {
     type Config = NotmuchConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let mut widget = TextWidget::new(config, id);
         if !block_config.no_icon {
             widget.set_icon("mail");

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -16,8 +16,8 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
 
 pub struct Notmuch {
+    id: u64,
     text: TextWidget,
-    id: String,
     update_interval: Duration,
     query: String,
     db: String,
@@ -121,7 +121,8 @@ impl ConfigBlock for Notmuch {
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         let id = pseudo_uuid();
-        let mut widget = TextWidget::new(config, &id);
+
+        let mut widget = TextWidget::new(config, id);
         if !block_config.no_icon {
             widget.set_icon("mail");
         }
@@ -181,16 +182,14 @@ impl Block for Notmuch {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.name.as_ref().map(|s| s == &self.id).unwrap_or(false)
-            && event.button == MouseButton::Left
-        {
+        if event.matches_id(self.id) && event.button == MouseButton::Left {
             self.update()?;
         }
 
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -15,7 +15,7 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
 
 pub struct Notmuch {
-    id: u64,
+    id: usize,
     text: TextWidget,
     update_interval: Duration,
     query: String,
@@ -115,7 +115,7 @@ impl ConfigBlock for Notmuch {
     type Config = NotmuchConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -187,7 +187,7 @@ impl Block for Notmuch {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -11,15 +11,15 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::pseudo_uuid;
+use crate::util::{hash, pseudo_uuid};
 use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::text::TextWidget;
 
 pub struct NvidiaGpu {
-    id: String,
-    id_fans: String,
-    id_memory: String,
+    id: u64,
+    id_fans: u64,
+    id_memory: u64,
     update_interval: Duration,
 
     gpu_enabled: bool,
@@ -178,18 +178,19 @@ impl ConfigBlock for NvidiaGpu {
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         let id = pseudo_uuid();
-        let id_memory = pseudo_uuid();
-        let id_fans = pseudo_uuid();
+
+        let id_memory = hash("memory") + id;
+        let id_fans = hash("fans") + id;
 
         Ok(NvidiaGpu {
-            id: id.clone(),
-            id_fans: id_fans.clone(),
-            id_memory: id_memory.clone(),
+            id,
+            id_fans,
+            id_memory,
             update_interval: block_config.interval,
             gpu_enabled: false,
             gpu_id: block_config.gpu_id,
 
-            name_widget: ButtonWidget::new(config.clone(), &id)
+            name_widget: ButtonWidget::new(config.clone(), id)
                 .with_icon("gpu")
                 .with_spacing(Spacing::Inline),
             name_widget_mode: if block_config.label.is_some() {
@@ -204,26 +205,26 @@ impl ConfigBlock for NvidiaGpu {
             },
 
             show_memory: if block_config.show_memory {
-                Some(ButtonWidget::new(config.clone(), &id_memory).with_spacing(Spacing::Inline))
+                Some(ButtonWidget::new(config.clone(), id_memory).with_spacing(Spacing::Inline))
             } else {
                 None
             },
             memory_widget_mode: MemoryWidgetMode::ShowUsedMemory,
 
             show_utilization: if block_config.show_utilization {
-                Some(TextWidget::new(config.clone(), &id).with_spacing(Spacing::Inline))
+                Some(TextWidget::new(config.clone(), id).with_spacing(Spacing::Inline))
             } else {
                 None
             },
 
             show_temperature: if block_config.show_temperature {
-                Some(TextWidget::new(config.clone(), &id).with_spacing(Spacing::Inline))
+                Some(TextWidget::new(config.clone(), id).with_spacing(Spacing::Inline))
             } else {
                 None
             },
 
             show_fan: if block_config.show_fan_speed {
-                Some(ButtonWidget::new(config.clone(), &id_fans).with_spacing(Spacing::Inline))
+                Some(ButtonWidget::new(config.clone(), id_fans).with_spacing(Spacing::Inline))
             } else {
                 None
             },
@@ -232,7 +233,7 @@ impl ConfigBlock for NvidiaGpu {
             scrolling: config.scrolling,
 
             show_clocks: if block_config.show_clocks {
-                Some(TextWidget::new(config, &id).with_spacing(Spacing::Inline))
+                Some(TextWidget::new(config, id).with_spacing(Spacing::Inline))
             } else {
                 None
             },
@@ -384,10 +385,8 @@ impl Block for NvidiaGpu {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if let Some(ref name) = e.name {
-            let event_name = name.as_str();
-
-            if event_name == self.id {
+        if let Some(event_id) = e.id {
+            if event_id == self.id {
                 if let MouseButton::Left = e.button {
                     match self.name_widget_mode {
                         NameWidgetMode::ShowDefaultName => {
@@ -401,7 +400,7 @@ impl Block for NvidiaGpu {
                 }
             }
 
-            if event_name == self.id_memory {
+            if event_id == self.id_memory {
                 if let MouseButton::Left = e.button {
                     match self.memory_widget_mode {
                         MemoryWidgetMode::ShowUsedMemory => {
@@ -415,7 +414,7 @@ impl Block for NvidiaGpu {
                 }
             }
 
-            if event_name == self.id_fans {
+            if event_id == self.id_fans {
                 let mut controlled_changed = false;
                 let mut new_fan_speed = self.fan_speed;
                 match e.button {
@@ -489,7 +488,7 @@ impl Block for NvidiaGpu {
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -11,7 +11,7 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::{hash, pseudo_uuid};
+use crate::util::pseudo_uuid;
 use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 use crate::widgets::text::TextWidget;
@@ -173,14 +173,13 @@ impl ConfigBlock for NvidiaGpu {
     type Config = NvidiaGpuConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
-        let id_memory = hash("memory") + id;
-        let id_fans = hash("fans") + id;
+        let id_memory = pseudo_uuid();
+        let id_fans = pseudo_uuid();
 
         Ok(NvidiaGpu {
             id,

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -17,9 +17,9 @@ use crate::widgets::button::ButtonWidget;
 use crate::widgets::text::TextWidget;
 
 pub struct NvidiaGpu {
-    id: u64,
-    id_fans: u64,
-    id_memory: u64,
+    id: usize,
+    id_fans: usize,
+    id_memory: usize,
     update_interval: Duration,
 
     gpu_enabled: bool,
@@ -173,7 +173,7 @@ impl ConfigBlock for NvidiaGpu {
     type Config = NvidiaGpuConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -487,7 +487,7 @@ impl Block for NvidiaGpu {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -22,7 +22,7 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct Pacman {
-    id: u64,
+    id: usize,
     output: ButtonWidget,
     update_interval: Duration,
     format: FormatTemplate,
@@ -160,7 +160,7 @@ impl ConfigBlock for Pacman {
     type Config = PacmanConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -340,7 +340,7 @@ fn has_critical_update(updates: &str, regex: &Regex) -> bool {
 }
 
 impl Block for Pacman {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -22,8 +22,8 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct Pacman {
+    id: u64,
     output: ButtonWidget,
-    id: String,
     update_interval: Duration,
     format: FormatTemplate,
     format_singular: FormatTemplate,
@@ -165,7 +165,8 @@ impl ConfigBlock for Pacman {
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         let id = pseudo_uuid();
-        let output = ButtonWidget::new(config, &id).with_icon("update");
+
+        let output = ButtonWidget::new(config, id).with_icon("update");
 
         Ok(Pacman {
             id,
@@ -340,8 +341,8 @@ fn has_critical_update(updates: &str, regex: &Regex) -> bool {
 }
 
 impl Block for Pacman {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {
@@ -425,10 +426,10 @@ impl Block for Pacman {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.name.as_ref().map(|s| s == &self.id).unwrap_or(false)
-            && event.button == MouseButton::Left
-        {
-            self.update()?;
+        if event.matches_id(self.id) {
+            if let MouseButton::Left = event.button {
+                self.update()?;
+            }
         }
 
         Ok(())

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -17,7 +17,7 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::{has_command, pseudo_uuid, FormatTemplate};
+use crate::util::{has_command, FormatTemplate};
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -160,12 +160,11 @@ impl ConfigBlock for Pacman {
     type Config = PacmanConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let output = ButtonWidget::new(config, id).with_icon("update");
 
         Ok(Pacman {

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -11,7 +11,6 @@ use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
-use crate::util::pseudo_uuid;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 
@@ -140,9 +139,12 @@ impl PomodoroConfig {
 impl ConfigBlock for Pomodoro {
     type Config = PomodoroConfig;
 
-    fn new(block_config: Self::Config, config: Config, _send: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(
+        id: u64,
+        block_config: Self::Config,
+        config: Config,
+        _send: Sender<Task>,
+    ) -> Result<Self> {
         Ok(Pomodoro {
             id,
             time: ButtonWidget::new(config, id).with_icon("pomodoro"),

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -59,7 +59,7 @@ impl fmt::Display for State {
 }
 
 pub struct Pomodoro {
-    id: u64,
+    id: usize,
     time: ButtonWidget,
     state: State,
     length: Duration,
@@ -140,7 +140,7 @@ impl ConfigBlock for Pomodoro {
     type Config = PomodoroConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _send: Sender<Task>,
@@ -162,7 +162,7 @@ impl ConfigBlock for Pomodoro {
 }
 
 impl Block for Pomodoro {
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -48,7 +48,7 @@ trait SoundDevice {
     fn get_info(&mut self) -> Result<()>;
     fn set_volume(&mut self, step: i32, max_vol: Option<u32>) -> Result<()>;
     fn toggle(&mut self) -> Result<()>;
-    fn monitor(&mut self, id: u64, tx_update_request: Sender<Task>) -> Result<()>;
+    fn monitor(&mut self, id: usize, tx_update_request: Sender<Task>) -> Result<()>;
 }
 
 struct AlsaSoundDevice {
@@ -161,7 +161,7 @@ impl SoundDevice for AlsaSoundDevice {
         Ok(())
     }
 
-    fn monitor(&mut self, id: u64, tx_update_request: Sender<Task>) -> Result<()> {
+    fn monitor(&mut self, id: usize, tx_update_request: Sender<Task>) -> Result<()> {
         // Monitor volume changes in a separate thread.
         thread::Builder::new()
             .name("sound_alsa".into())
@@ -272,7 +272,7 @@ enum PulseAudioClientRequest {
 #[cfg(feature = "pulseaudio")]
 lazy_static! {
     static ref PULSEAUDIO_CLIENT: Result<PulseAudioClient> = PulseAudioClient::new();
-    static ref PULSEAUDIO_EVENT_LISTENER: Mutex<HashMap<u64, Sender<Task>>> =
+    static ref PULSEAUDIO_EVENT_LISTENER: Mutex<HashMap<usize, Sender<Task>>> =
         Mutex::new(HashMap::new());
 
     // Default device names
@@ -666,7 +666,7 @@ impl SoundDevice for PulseAudioSoundDevice {
         Ok(())
     }
 
-    fn monitor(&mut self, id: u64, tx_update_request: Sender<Task>) -> Result<()> {
+    fn monitor(&mut self, id: usize, tx_update_request: Sender<Task>) -> Result<()> {
         PULSEAUDIO_EVENT_LISTENER
             .lock()
             .unwrap()
@@ -678,7 +678,7 @@ impl SoundDevice for PulseAudioSoundDevice {
 // TODO: Use the alsa control bindings to implement push updates
 pub struct Sound {
     text: ButtonWidget,
-    id: u64,
+    id: usize,
     device: Box<dyn SoundDevice>,
     device_kind: DeviceKind,
     step_width: u32,
@@ -889,7 +889,7 @@ impl ConfigBlock for Sound {
     type Config = SoundConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
@@ -995,7 +995,7 @@ impl Block for Sound {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -554,7 +554,7 @@ impl PulseAudioClient {
         for (id, tx_update_request) in &*PULSEAUDIO_EVENT_LISTENER.lock().unwrap() {
             tx_update_request
                 .send(Task {
-                    id: id.clone(),
+                    id: *id,
                     update_time: Instant::now(),
                 })
                 .unwrap();

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -36,7 +36,7 @@ use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
-use crate::util::{format_percent_bar, pseudo_uuid, FormatTemplate};
+use crate::util::{format_percent_bar, FormatTemplate};
 use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -889,11 +889,11 @@ impl ConfigBlock for Sound {
     type Config = SoundConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
         let mut step_width = block_config.step_width;
         if step_width > 50 {
             step_width = 50;

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -14,7 +14,7 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::{format_number, pseudo_uuid};
+use crate::util::format_number;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -163,9 +163,12 @@ fn make_thread(
 impl ConfigBlock for SpeedTest {
     type Config = SpeedTestConfig;
 
-    fn new(block_config: Self::Config, config: Config, done: Sender<Task>) -> Result<Self> {
-        let id = pseudo_uuid();
-
+    fn new(
+        id: u64,
+        block_config: Self::Config,
+        config: Config,
+        done: Sender<Task>,
+    ) -> Result<Self> {
         // Create all the things we are going to send and take for ourselves.
         let (send, recv): (Sender<()>, Receiver<()>) = unbounded();
         let vals = Arc::new(Mutex::new((false, vec![])));

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -171,7 +171,7 @@ impl ConfigBlock for SpeedTest {
         let vals = Arc::new(Mutex::new((false, vec![])));
 
         // Make the update thread
-        make_thread(recv, done, vals.clone(), block_config.clone(), id.clone());
+        make_thread(recv, done, vals.clone(), block_config.clone(), id);
 
         let ty = if block_config.bytes { "MB/s" } else { "Mb/s" };
         Ok(SpeedTest {

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -19,7 +19,7 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct SpeedTest {
-    id: u64,
+    id: usize,
     vals: Arc<Mutex<(bool, Vec<f32>)>>,
     text: Vec<ButtonWidget>,
     config: SpeedTestConfig,
@@ -131,7 +131,7 @@ fn make_thread(
     done: Sender<Task>,
     values: Arc<Mutex<(bool, Vec<f32>)>>,
     config: SpeedTestConfig,
-    id: u64,
+    id: usize,
 ) {
     thread::Builder::new()
         .name("speedtest".into())
@@ -164,7 +164,7 @@ impl ConfigBlock for SpeedTest {
     type Config = SpeedTestConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         done: Sender<Task>,
@@ -258,7 +258,7 @@ impl Block for SpeedTest {
         new
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -16,8 +16,8 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct Taskwarrior {
+    id: u64,
     output: ButtonWidget,
-    id: String,
     update_interval: Duration,
     warning_threshold: u32,
     critical_threshold: u32,
@@ -143,7 +143,8 @@ impl ConfigBlock for Taskwarrior {
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         let id = pseudo_uuid();
-        let output = ButtonWidget::new(config.clone(), &id)
+
+        let output = ButtonWidget::new(config.clone(), id)
             .with_icon("tasks")
             .with_text("-");
         // If the deprecated `filter_tags` option has been set,
@@ -158,7 +159,7 @@ impl ConfigBlock for Taskwarrior {
         };
 
         Ok(Taskwarrior {
-            id: pseudo_uuid(),
+            id,
             update_interval: block_config.interval,
             warning_threshold: block_config.warning_threshold,
             critical_threshold: block_config.critical_threshold,
@@ -260,7 +261,7 @@ impl Block for Taskwarrior {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.name.as_ref().map(|s| s == &self.id).unwrap_or(false) {
+        if event.matches_id(self.id) {
             match event.button {
                 MouseButton::Left => {
                     self.update()?;
@@ -277,7 +278,7 @@ impl Block for Taskwarrior {
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -16,7 +16,7 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct Taskwarrior {
-    id: u64,
+    id: usize,
     output: ButtonWidget,
     update_interval: Duration,
     warning_threshold: u32,
@@ -138,7 +138,7 @@ impl ConfigBlock for Taskwarrior {
     type Config = TaskwarriorConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
@@ -277,7 +277,7 @@ impl Block for Taskwarrior {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -11,7 +11,7 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -138,12 +138,11 @@ impl ConfigBlock for Taskwarrior {
     type Config = TaskwarriorConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let output = ButtonWidget::new(config.clone(), id)
             .with_icon("tasks")
             .with_text("-");

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -29,7 +29,7 @@ impl Default for TemperatureScale {
 }
 
 pub struct Temperature {
-    id: u64,
+    id: usize,
     text: ButtonWidget,
     output: String,
     collapsed: bool,
@@ -124,7 +124,7 @@ impl ConfigBlock for Temperature {
     type Config = TemperatureConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -278,7 +278,7 @@ impl Block for Temperature {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -29,10 +29,10 @@ impl Default for TemperatureScale {
 }
 
 pub struct Temperature {
+    id: u64,
     text: ButtonWidget,
     output: String,
     collapsed: bool,
-    id: String,
     update_interval: Duration,
     scale: TemperatureScale,
     maximum_good: i64,
@@ -130,8 +130,9 @@ impl ConfigBlock for Temperature {
     ) -> Result<Self> {
         let id = pseudo_uuid();
         Ok(Temperature {
+            id,
             update_interval: block_config.interval,
-            text: ButtonWidget::new(config, &id)
+            text: ButtonWidget::new(config, id)
                 .with_icon("thermometer")
                 .with_spacing(if block_config.collapsed {
                     Spacing::Hidden
@@ -140,7 +141,6 @@ impl ConfigBlock for Temperature {
                 }),
             output: String::new(),
             collapsed: block_config.collapsed,
-            id,
             scale: block_config.scale,
             maximum_good: block_config
                 .good
@@ -264,8 +264,8 @@ impl Block for Temperature {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if let Some(ref name) = e.name {
-            if name.as_str() == self.id && e.button == MouseButton::Left {
+        if e.matches_id(self.id) {
+            if e.button == MouseButton::Left {
                 self.collapsed = !self.collapsed;
                 if self.collapsed {
                     self.text.set_text(String::new());
@@ -280,7 +280,7 @@ impl Block for Temperature {
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -264,16 +264,14 @@ impl Block for Temperature {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if e.matches_id(self.id) {
-            if e.button == MouseButton::Left {
-                self.collapsed = !self.collapsed;
-                if self.collapsed {
-                    self.text.set_text(String::new());
-                    self.text.set_spacing(Spacing::Hidden);
-                } else {
-                    self.text.set_text(self.output.clone());
-                    self.text.set_spacing(Spacing::Normal);
-                }
+        if e.matches_id(self.id) && e.button == MouseButton::Left {
+            self.collapsed = !self.collapsed;
+            if self.collapsed {
+                self.text.set_text(String::new());
+                self.text.set_spacing(Spacing::Hidden);
+            } else {
+                self.text.set_text(self.output.clone());
+                self.text.set_spacing(Spacing::Normal);
             }
         }
 

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -11,7 +11,7 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, Spacing, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -124,11 +124,11 @@ impl ConfigBlock for Temperature {
     type Config = TemperatureConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
         Ok(Temperature {
             id,
             update_interval: block_config.interval,

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -15,8 +15,8 @@ use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
 pub struct Template {
+    id: u64,
     text: TextWidget,
-    id: String,
     update_interval: Duration,
 
     //useful, but optional
@@ -59,7 +59,8 @@ impl ConfigBlock for Template {
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         let id = pseudo_uuid();
-        let text = TextWidget::new(config.clone(), &id).with_text("Template");
+
+        let text = TextWidget::new(config.clone(), id).with_text("Template");
 
         Ok(Template {
             id,
@@ -84,7 +85,7 @@ impl Block for Template {
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -10,7 +10,6 @@ use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::pseudo_uuid;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
@@ -54,12 +53,11 @@ impl ConfigBlock for Template {
     type Config = TemplateConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let text = TextWidget::new(config.clone(), id).with_text("Template");
 
         Ok(Template {

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -14,7 +14,7 @@ use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
 pub struct Template {
-    id: u64,
+    id: usize,
     text: TextWidget,
     update_interval: Duration,
 
@@ -53,7 +53,7 @@ impl ConfigBlock for Template {
     type Config = TemplateConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
@@ -83,7 +83,7 @@ impl Block for Template {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -20,7 +20,7 @@ use crate::widgets::button::ButtonWidget;
 
 pub struct Time {
     time: ButtonWidget,
-    id: u64,
+    id: usize,
     update_interval: Duration,
     format: String,
     timezone: Option<Tz>,
@@ -77,7 +77,7 @@ impl ConfigBlock for Time {
     type Config = TimeConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -123,7 +123,7 @@ impl Block for Time {
         vec![&self.time]
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -15,7 +15,6 @@ use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::scheduler::Task;
-use crate::util::pseudo_uuid;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 
@@ -78,11 +77,11 @@ impl ConfigBlock for Time {
     type Config = TimeConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
         Ok(Time {
             id,
             format: block_config.format,

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -21,7 +21,7 @@ use crate::widgets::button::ButtonWidget;
 
 pub struct Time {
     time: ButtonWidget,
-    id: String,
+    id: u64,
     update_interval: Duration,
     format: String,
     timezone: Option<Tz>,
@@ -82,11 +82,11 @@ impl ConfigBlock for Time {
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let i = pseudo_uuid();
+        let id = pseudo_uuid();
         Ok(Time {
-            id: i.clone(),
+            id,
             format: block_config.format,
-            time: ButtonWidget::new(config, i.as_str())
+            time: ButtonWidget::new(config, id)
                 .with_text("")
                 .with_icon("time"),
             update_interval: block_config.interval,
@@ -124,7 +124,7 @@ impl Block for Time {
         vec![&self.time]
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -16,7 +16,7 @@ use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
 pub struct Toggle {
-    id: u64,
+    id: usize,
     text: ButtonWidget,
     command_on: String,
     command_off: String,
@@ -74,7 +74,7 @@ impl ConfigBlock for Toggle {
     type Config = ToggleConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -150,7 +150,7 @@ impl Block for Toggle {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -12,7 +12,6 @@ use crate::de::deserialize_opt_duration;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::pseudo_uuid;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -75,12 +74,11 @@ impl ConfigBlock for Toggle {
     type Config = ToggleConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         Ok(Toggle {
             id,
             text: ButtonWidget::new(config, id).with_content(block_config.text),

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -15,15 +15,9 @@ use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
 pub struct Uptime {
+    id: u64,
     text: TextWidget,
-    id: String,
     update_interval: Duration,
-
-    //useful, but optional
-    #[allow(dead_code)]
-    config: Config,
-    #[allow(dead_code)]
-    tx_update_request: Sender<Task>,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -54,17 +48,16 @@ impl ConfigBlock for Uptime {
     fn new(
         block_config: Self::Config,
         config: Config,
-        tx_update_request: Sender<Task>,
+        _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         let id = pseudo_uuid();
-        let text = TextWidget::new(config.clone(), &id).with_icon("uptime");
+
+        let text = TextWidget::new(config.clone(), id).with_icon("uptime");
 
         Ok(Uptime {
             id,
             update_interval: block_config.interval,
             text,
-            tx_update_request,
-            config,
         })
     }
 }
@@ -120,7 +113,7 @@ impl Block for Uptime {
         vec![&self.text]
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -15,7 +15,7 @@ use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
 pub struct Uptime {
-    id: u64,
+    id: usize,
     text: TextWidget,
     update_interval: Duration,
 }
@@ -46,7 +46,7 @@ impl ConfigBlock for Uptime {
     type Config = UptimeConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -112,7 +112,7 @@ impl Block for Uptime {
         vec![&self.text]
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -52,7 +52,7 @@ impl ConfigBlock for Uptime {
     ) -> Result<Self> {
         let id = pseudo_uuid();
 
-        let text = TextWidget::new(config.clone(), id).with_icon("uptime");
+        let text = TextWidget::new(config, id).with_icon("uptime");
 
         Ok(Uptime {
             id,

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -10,7 +10,7 @@ use crate::config::Config;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, read_file};
+use crate::util::read_file;
 use crate::widget::I3BarWidget;
 use crate::widgets::text::TextWidget;
 
@@ -46,12 +46,11 @@ impl ConfigBlock for Uptime {
     type Config = UptimeConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let text = TextWidget::new(config, id).with_icon("uptime");
 
         Ok(Uptime {

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -22,7 +22,7 @@ use inotify::{EventMask, Inotify, WatchMask};
 use serde_derive::Deserialize;
 
 pub struct Watson {
-    id: String,
+    id: u64,
     text: ButtonWidget,
     state_path: PathBuf,
     show_time: bool,
@@ -78,8 +78,8 @@ impl ConfigBlock for Watson {
         let id = pseudo_uuid();
 
         let watson = Watson {
-            id: id.clone(),
-            text: ButtonWidget::new(config, &id),
+            id,
+            text: ButtonWidget::new(config, id),
             state_path: block_config.state_path.clone(),
             show_time: block_config.show_time,
             update_interval: block_config.interval,
@@ -196,11 +196,9 @@ impl Block for Watson {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if let Some(ref name) = e.name {
-            if name.as_str() == self.id {
-                self.show_time = !self.show_time;
-                self.update()?;
-            }
+        if e.matches_id(self.id) {
+            self.show_time = !self.show_time;
+            self.update()?;
         }
         Ok(())
     }
@@ -209,8 +207,8 @@ impl Block for Watson {
         vec![&self.text]
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }
 

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -12,7 +12,7 @@ use crate::de::deserialize_local_timestamp;
 use crate::errors::*;
 use crate::input::I3BarEvent;
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, xdg_config_home};
+use crate::util::xdg_config_home;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 use chrono::offset::Local;
@@ -71,12 +71,11 @@ impl ConfigBlock for Watson {
     type Config = WatsonConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let watson = Watson {
             id,
             text: ButtonWidget::new(config, id),

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -22,7 +22,7 @@ use inotify::{EventMask, Inotify, WatchMask};
 use serde_derive::Deserialize;
 
 pub struct Watson {
-    id: u64,
+    id: usize,
     text: ButtonWidget,
     state_path: PathBuf,
     show_time: bool,
@@ -71,7 +71,7 @@ impl ConfigBlock for Watson {
     type Config = WatsonConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         tx_update_request: Sender<Task>,
@@ -206,7 +206,7 @@ impl Block for Watson {
         vec![&self.text]
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -122,7 +122,7 @@ impl ConfigBlock for Watson {
                         EventMask::CREATE if event.name == Some(&file_name) => {
                             tx_update_request
                                 .send(Task {
-                                    id: id.clone(),
+                                    id,
                                     update_time: Instant::now(),
                                 })
                                 .expect("unable to send task from watson watcher");

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -55,7 +55,7 @@ pub enum OpenWeatherMapUnits {
 }
 
 pub struct Weather {
-    id: String,
+    id: u64,
     weather: ButtonWidget,
     format: String,
     weather_keys: HashMap<String, String>,
@@ -329,9 +329,10 @@ impl ConfigBlock for Weather {
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         let id = pseudo_uuid();
+
         Ok(Weather {
-            id: id.clone(),
-            weather: ButtonWidget::new(config, &id),
+            id,
+            weather: ButtonWidget::new(config, id),
             format: block_config.format,
             weather_keys: HashMap::new(),
             service: block_config.service,
@@ -369,7 +370,7 @@ impl Block for Weather {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_name(self.id()) {
+        if event.matches_id(self.id()) {
             if let MouseButton::Left = event.button {
                 self.update()?;
             }
@@ -377,7 +378,7 @@ impl Block for Weather {
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -12,7 +12,7 @@ use crate::errors::*;
 use crate::http;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::FormatTemplate;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::button::ButtonWidget;
 
@@ -324,12 +324,11 @@ impl ConfigBlock for Weather {
     type Config = WeatherConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         Ok(Weather {
             id,
             weather: ButtonWidget::new(config, id),

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -55,7 +55,7 @@ pub enum OpenWeatherMapUnits {
 }
 
 pub struct Weather {
-    id: u64,
+    id: usize,
     weather: ButtonWidget,
     format: String,
     weather_keys: HashMap<String, String>,
@@ -324,7 +324,7 @@ impl ConfigBlock for Weather {
     type Config = WeatherConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -377,7 +377,7 @@ impl Block for Weather {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -49,8 +49,8 @@ impl Monitor {
 }
 
 pub struct Xrandr {
+    id: u64,
     text: ButtonWidget,
-    id: String,
     update_interval: Duration,
     monitors: Vec<Monitor>,
     icons: bool,
@@ -241,12 +241,13 @@ impl ConfigBlock for Xrandr {
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
         let id = pseudo_uuid();
+
         let mut step_width = block_config.step_width;
         if step_width > 50 {
             step_width = 50;
         }
         Ok(Xrandr {
-            text: ButtonWidget::new(config.clone(), &id).with_icon("xrandr"),
+            text: ButtonWidget::new(config.clone(), id).with_icon("xrandr"),
             id,
             update_interval: block_config.interval,
             current_idx: 0,
@@ -276,45 +277,43 @@ impl Block for Xrandr {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if let Some(ref name) = e.name {
-            if name.as_str() == self.id {
-                match e.button {
-                    MouseButton::Left => {
-                        if self.current_idx < self.monitors.len() - 1 {
-                            self.current_idx += 1;
-                        } else {
-                            self.current_idx = 0;
-                        }
-                    }
-                    mb => {
-                        use LogicalDirection::*;
-                        match self.config.scrolling.to_logical_direction(mb) {
-                            Some(Up) => {
-                                if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
-                                    if monitor.brightness <= (100 - self.step_width) {
-                                        monitor.set_brightness(self.step_width as i32);
-                                    }
-                                }
-                            }
-                            Some(Down) => {
-                                if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
-                                    if monitor.brightness >= self.step_width {
-                                        monitor.set_brightness(-(self.step_width as i32));
-                                    }
-                                }
-                            }
-                            None => {}
-                        }
+        if e.matches_id(self.id) {
+            match e.button {
+                MouseButton::Left => {
+                    if self.current_idx < self.monitors.len() - 1 {
+                        self.current_idx += 1;
+                    } else {
+                        self.current_idx = 0;
                     }
                 }
-                self.display()?;
+                mb => {
+                    use LogicalDirection::*;
+                    match self.config.scrolling.to_logical_direction(mb) {
+                        Some(Up) => {
+                            if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
+                                if monitor.brightness <= (100 - self.step_width) {
+                                    monitor.set_brightness(self.step_width as i32);
+                                }
+                            }
+                        }
+                        Some(Down) => {
+                            if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
+                                if monitor.brightness >= self.step_width {
+                                    monitor.set_brightness(-(self.step_width as i32));
+                                }
+                            }
+                        }
+                        None => {}
+                    }
+                }
             }
+            self.display()?;
         }
 
         Ok(())
     }
 
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> u64 {
+        self.id
     }
 }

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -49,7 +49,7 @@ impl Monitor {
 }
 
 pub struct Xrandr {
-    id: u64,
+    id: usize,
     text: ButtonWidget,
     update_interval: Duration,
     monitors: Vec<Monitor>,
@@ -236,7 +236,7 @@ impl ConfigBlock for Xrandr {
     type Config = XrandrConfig;
 
     fn new(
-        id: u64,
+        id: usize,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
@@ -312,7 +312,7 @@ impl Block for Xrandr {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -14,7 +14,7 @@ use crate::errors::*;
 use crate::input::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
-use crate::util::{pseudo_uuid, FormatTemplate};
+use crate::util::FormatTemplate;
 use crate::widget::I3BarWidget;
 use crate::widgets::button::ButtonWidget;
 
@@ -236,12 +236,11 @@ impl ConfigBlock for Xrandr {
     type Config = XrandrConfig;
 
     fn new(
+        id: u64,
         block_config: Self::Config,
         config: Config,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let id = pseudo_uuid();
-
         let mut step_width = block_config.step_width;
         if step_width > 50 {
             step_width = 50;

--- a/src/input.rs
+++ b/src/input.rs
@@ -33,12 +33,12 @@ struct I3BarEventInternal {
 
 #[derive(Debug, Clone)]
 pub struct I3BarEvent {
-    pub id: Option<u64>,
+    pub id: Option<usize>,
     pub button: MouseButton,
 }
 
 impl I3BarEvent {
-    pub fn matches_id(&self, other: u64) -> bool {
+    pub fn matches_id(&self, other: usize) -> bool {
         match self.id {
             Some(id) => id == other,
             _ => false,
@@ -61,7 +61,7 @@ pub fn process_events(sender: Sender<I3BarEvent>) {
                 let e: I3BarEventInternal = serde_json::from_str(slice).unwrap();
                 sender
                     .send(I3BarEvent {
-                        id: e.name.map(|x| x.parse::<u64>().unwrap()),
+                        id: e.name.map(|x| x.parse::<usize>().unwrap()),
                         button: e.button,
                     })
                     .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,9 @@ mod widgets;
 
 #[cfg(feature = "profiling")]
 use cpuprofiler::PROFILER;
-
+#[cfg(feature = "profiling")]
 use std::ops::DerefMut;
+
 use std::time::Duration;
 
 use clap::{crate_authors, crate_description, App, Arg, ArgMatches};

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod widgets;
 #[cfg(feature = "profiling")]
 use cpuprofiler::PROFILER;
 
+use std::ops::DerefMut;
 use std::time::Duration;
 
 use clap::{crate_authors, crate_description, App, Arg, ArgMatches};

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
             ::std::process::exit(1);
         }
 
-        let error_widget = TextWidget::new(Default::default(), "error")
+        let error_widget = TextWidget::new(Default::default(), 9999999999)
             .with_state(State::Critical)
             .with_text(&format!("{:?}", error));
         let error_rendered = error_widget.get_rendered();
@@ -195,7 +195,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
             // Receive async update requests
             recv(rx_update_requests) -> request => if let Ok(req) = request {
                 // Process immediately and forget
-                blocks.get_mut(req.id.parse::<usize>().unwrap())
+                blocks.get_mut(req.id as usize)
                     .internal_error("scheduler", "could not get required block")?
                     .update()?;
                 util::print_blocks(&blocks, &config)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
     let mut blocks: Vec<Box<dyn Block>> = Vec::new();
     for &(ref block_name, ref block_config) in &config.blocks {
         blocks.push(create_block(
+            blocks.len() as u64,
             block_name,
             block_config.clone(),
             config.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
     let mut blocks: Vec<Box<dyn Block>> = Vec::new();
     for &(ref block_name, ref block_config) in &config.blocks {
         blocks.push(create_block(
-            blocks.len() as u64,
+            blocks.len(),
             block_name,
             block_config.clone(),
             config.clone(),
@@ -198,7 +198,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
             // Receive async update requests
             recv(rx_update_requests) -> request => if let Ok(req) = request {
                 // Process immediately and forget
-                blocks.get_mut(req.id as usize)
+                blocks.get_mut(req.id)
                     .internal_error("scheduler", "could not get required block")?
                     .update()?;
                 util::print_blocks(&blocks, &config)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,7 +278,7 @@ fn profile_config(name: &str, runs: &str, config: &Config, update: Sender<Task>)
     for &(ref block_name, ref block_config) in &config.blocks {
         if block_name == name {
             let mut block =
-                create_block(&block_name, block_config.clone(), config.clone(), update)?;
+                create_block(0, &block_name, block_config.clone(), config.clone(), update)?;
             profile(profile_runs, &block_name, block.deref_mut());
             break;
         }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,6 +1,6 @@
 use crate::blocks::Update;
 use std::cmp;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
 use std::fmt;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -74,10 +74,7 @@ impl UpdateScheduler {
         }
     }
 
-    pub fn do_scheduled_updates(
-        &mut self,
-        block_map: &mut HashMap<String, &mut dyn Block>,
-    ) -> Result<()> {
+    pub fn do_scheduled_updates(&mut self, blocks: &mut Vec<Box<dyn Block>>) -> Result<()> {
         let t = self
             .schedule
             .pop()
@@ -107,8 +104,8 @@ impl UpdateScheduler {
         let now = Instant::now();
 
         for task in tasks_next {
-            if let Some(dur) = block_map
-                .get_mut(&task.id)
+            if let Some(dur) = blocks
+                .get_mut(task.id.parse::<usize>().unwrap())
                 .internal_error("scheduler", "could not get required block")?
                 .update()?
             {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -10,7 +10,7 @@ use crate::errors::*;
 
 #[derive(Debug, Clone)]
 pub struct Task {
-    pub id: String,
+    pub id: u64,
     pub update_time: Instant,
 }
 
@@ -51,7 +51,7 @@ impl UpdateScheduler {
         let now = Instant::now();
         for block in blocks.iter() {
             schedule.push(Task {
-                id: String::from(block.id()),
+                id: block.id(),
                 update_time: now,
             });
         }
@@ -105,7 +105,7 @@ impl UpdateScheduler {
 
         for task in tasks_next {
             if let Some(dur) = blocks
-                .get_mut(task.id.parse::<usize>().unwrap())
+                .get_mut(task.id as usize)
                 .internal_error("scheduler", "could not get required block")?
                 .update()?
             {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -10,7 +10,7 @@ use crate::errors::*;
 
 #[derive(Debug, Clone)]
 pub struct Task {
-    pub id: u64,
+    pub id: usize,
     pub update_time: Instant,
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,10 +18,13 @@ use crate::errors::*;
 pub const USR_SHARE_PATH: &str = "/usr/share/i3status-rust";
 
 pub fn pseudo_uuid() -> String {
-    let mut bytes = [0u8; 16];
-    getrandom::getrandom(&mut bytes).unwrap();
-    let uuid: String = bytes.iter().map(|&x| format!("{:02x?}", x)).collect();
-    uuid
+    static mut ID: usize = 0;
+    unsafe {
+        let r = ID;
+        ID += 1;
+        r
+    }
+    .to_string()
 }
 
 pub fn escape_pango_text(text: String) -> String {
@@ -179,11 +182,7 @@ macro_rules! map_to_owned (
      };
 );
 
-pub fn print_blocks(
-    order: &[String],
-    block_map: &HashMap<String, &mut dyn Block>,
-    config: &Config,
-) -> Result<()> {
+pub fn print_blocks(blocks: &Vec<Box<dyn Block>>, config: &Config) -> Result<()> {
     let mut last_bg: Option<String> = None;
 
     let mut rendered_blocks = vec![];
@@ -193,20 +192,14 @@ pub fn print_blocks(
      * flip the starting tint if an even number of blocks is visible. This way,
      * the last block should always be untinted.
      */
-    let visible_count = order
+    let visible_count = blocks
         .iter()
-        .filter(|block_id| {
-            let block = block_map.get(block_id.as_str()).unwrap();
-            !block.view().is_empty()
-        })
+        .filter(|block| !block.view().is_empty())
         .count();
 
     let mut alternator = visible_count % 2 == 0;
 
-    for block_id in order {
-        let block = &(*(block_map
-            .get(block_id)
-            .internal_error("util", "couldn't get block by id")?));
+    for block in blocks.iter() {
         let widgets = block.view();
         if widgets.is_empty() {
             continue;

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::prelude::v1::String;
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use regex::Regex;
 use serde::de::DeserializeOwned;
@@ -19,8 +19,8 @@ use crate::errors::*;
 
 pub const USR_SHARE_PATH: &str = "/usr/share/i3status-rust";
 
-pub fn pseudo_uuid() -> u64 {
-    static ID: AtomicU64 = AtomicU64::new(u64::MAX);
+pub fn pseudo_uuid() -> usize {
+    static ID: AtomicUsize = AtomicUsize::new(usize::MAX);
     ID.fetch_sub(1, Ordering::SeqCst)
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,12 +1,15 @@
 use num_traits::{clamp, ToPrimitive};
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs::{File, OpenOptions};
+use std::hash::{Hash, Hasher};
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::prelude::v1::String;
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use regex::Regex;
 use serde::de::DeserializeOwned;
@@ -17,14 +20,15 @@ use crate::errors::*;
 
 pub const USR_SHARE_PATH: &str = "/usr/share/i3status-rust";
 
-pub fn pseudo_uuid() -> String {
-    static mut ID: usize = 0;
-    unsafe {
-        let r = ID;
-        ID += 1;
-        r
-    }
-    .to_string()
+pub fn hash(string: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    string.hash(&mut hasher);
+    hasher.finish()
+}
+
+pub fn pseudo_uuid() -> u64 {
+    static ID: AtomicU64 = AtomicU64::new(0);
+    ID.fetch_add(1, Ordering::SeqCst)
 }
 
 pub fn escape_pango_text(text: String) -> String {

--- a/src/util.rs
+++ b/src/util.rs
@@ -186,7 +186,7 @@ macro_rules! map_to_owned (
      };
 );
 
-pub fn print_blocks(blocks: &Vec<Box<dyn Block>>, config: &Config) -> Result<()> {
+pub fn print_blocks(blocks: &[Box<dyn Block>], config: &Config) -> Result<()> {
     let mut last_bg: Option<String> = None;
 
     let mut rendered_blocks = vec![];

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,8 @@
 // TODO: Replace with clamp() once the feature is stable? Ideally, remove num_traits altogether.
 use num_traits::{clamp, ToPrimitive};
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs::{File, OpenOptions};
-use std::hash::{Hash, Hasher};
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
@@ -21,15 +19,9 @@ use crate::errors::*;
 
 pub const USR_SHARE_PATH: &str = "/usr/share/i3status-rust";
 
-pub fn hash(string: &str) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    string.hash(&mut hasher);
-    hasher.finish()
-}
-
 pub fn pseudo_uuid() -> u64 {
-    static ID: AtomicU64 = AtomicU64::new(0);
-    ID.fetch_add(1, Ordering::SeqCst)
+    static ID: AtomicU64 = AtomicU64::new(u64::MAX);
+    ID.fetch_sub(1, Ordering::SeqCst)
 }
 
 pub fn escape_pango_text(text: String) -> String {

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -11,20 +11,20 @@ pub struct ButtonWidget {
     icon: Option<String>,
     state: State,
     spacing: Spacing,
-    id: String,
+    id: u64,
     rendered: Value,
     cached_output: Option<String>,
     config: Config,
 }
 
 impl ButtonWidget {
-    pub fn new(config: Config, id: &str) -> Self {
+    pub fn new(config: Config, id: u64) -> Self {
         ButtonWidget {
             content: None,
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
-            id: String::from(id),
+            id,
             rendered: json!({
                 "full_text": "",
                 "separator": false,

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -7,18 +7,18 @@ use crate::widget::State;
 
 #[derive(Clone, Debug)]
 pub struct ButtonWidget {
+    id: usize,
     content: Option<String>,
     icon: Option<String>,
     state: State,
     spacing: Spacing,
-    id: u64,
     rendered: Value,
     cached_output: Option<String>,
     config: Config,
 }
 
 impl ButtonWidget {
-    pub fn new(config: Config, id: u64) -> Self {
+    pub fn new(config: Config, id: usize) -> Self {
         ButtonWidget {
             content: None,
             icon: None,

--- a/src/widgets/graph.rs
+++ b/src/widgets/graph.rs
@@ -8,24 +8,24 @@ use crate::widget::State;
 
 #[derive(Clone, Debug)]
 pub struct GraphWidget {
+    id: usize,
     content: Option<String>,
     icon: Option<String>,
     state: State,
     spacing: Spacing,
-    id: String,
     rendered: Value,
     cached_output: Option<String>,
     config: Config,
 }
 #[allow(dead_code)]
 impl GraphWidget {
-    pub fn new(config: Config, id: &str) -> Self {
+    pub fn new(config: Config, id: usize) -> Self {
         GraphWidget {
+            id,
             content: None,
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
-            id: id.to_string(),
             rendered: json!({
                 "full_text": "",
                 "separator": false,

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -18,7 +18,7 @@ pub struct RotatingTextWidget {
     icon: Option<String>,
     state: State,
     spacing: Spacing,
-    id: String,
+    id: u64,
     rendered: Value,
     cached_output: Option<String>,
     config: Config,
@@ -33,7 +33,7 @@ impl RotatingTextWidget {
         max_width: usize,
         dynamic_width: bool,
         config: Config,
-        id: &str,
+        id: u64,
     ) -> RotatingTextWidget {
         RotatingTextWidget {
             rotation_pos: 0,
@@ -46,7 +46,7 @@ impl RotatingTextWidget {
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
-            id: String::from(id),
+            id,
             rendered: json!({
                 "full_text": "",
                 "separator": false,
@@ -161,7 +161,7 @@ impl RotatingTextWidget {
                                 }),
             "separator": false,
             "separator_block_width": 0,
-            "name" : self.id,
+            "name" : self.id.to_string(),
             "min_width":
                 if self.content.is_empty() {
                     "".to_string()
@@ -176,7 +176,6 @@ impl RotatingTextWidget {
                 },
             "align": "left",
             "background": key_bg,
-            "name": self.id.clone(),
             "color": key_fg
         });
 

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -8,6 +8,7 @@ use crate::widget::{I3BarWidget, Spacing, State};
 
 #[derive(Clone, Debug)]
 pub struct RotatingTextWidget {
+    id: usize,
     rotation_pos: usize,
     max_width: usize,
     dynamic_width: bool,
@@ -18,7 +19,6 @@ pub struct RotatingTextWidget {
     icon: Option<String>,
     state: State,
     spacing: Spacing,
-    id: u64,
     rendered: Value,
     cached_output: Option<String>,
     config: Config,
@@ -33,9 +33,10 @@ impl RotatingTextWidget {
         max_width: usize,
         dynamic_width: bool,
         config: Config,
-        id: u64,
+        id: usize,
     ) -> RotatingTextWidget {
         RotatingTextWidget {
+            id,
             rotation_pos: 0,
             max_width,
             dynamic_width,
@@ -46,7 +47,6 @@ impl RotatingTextWidget {
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
-            id,
             rendered: json!({
                 "full_text": "",
                 "separator": false,

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -7,24 +7,24 @@ use crate::widget::State;
 
 #[derive(Clone, Debug)]
 pub struct TextWidget {
+    id: usize,
     content: Option<String>,
     icon: Option<String>,
     state: State,
     spacing: Spacing,
-    id: u64,
     rendered: Value,
     cached_output: Option<String>,
     config: Config,
 }
 
 impl TextWidget {
-    pub fn new(config: Config, id: u64) -> Self {
+    pub fn new(config: Config, id: usize) -> Self {
         TextWidget {
+            id,
             content: None,
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
-            id,
             rendered: json!({
                 "full_text": "",
                 "separator": false,

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -11,20 +11,20 @@ pub struct TextWidget {
     icon: Option<String>,
     state: State,
     spacing: Spacing,
-    id: String,
+    id: u64,
     rendered: Value,
     cached_output: Option<String>,
     config: Config,
 }
 
 impl TextWidget {
-    pub fn new(config: Config, id: &str) -> Self {
+    pub fn new(config: Config, id: u64) -> Self {
         TextWidget {
             content: None,
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
-            id: id.to_string(),
+            id,
             rendered: json!({
                 "full_text": "",
                 "separator": false,


### PR DESCRIPTION
### Why?
This change may make some performance improvements, since it removes [order vector](https://github.com/greshake/i3status-rust/blob/f4ee3e7ac97cead50f17b247feb9be7198bed507/src/main.rs#L174) and [hash map](https://github.com/greshake/i3status-rust/blob/f4ee3e7ac97cead50f17b247feb9be7198bed507/src/main.rs#L183). Also, it removes code like [this](https://github.com/greshake/i3status-rust/blob/f4ee3e7ac97cead50f17b247feb9be7198bed507/src/blocks/kdeconnect.rs#L115) and thus it decreases heap allocation.

Also, it removes `getrandom` dependency.

### How?
~~`pseudo_uuid` have been repurposed to generate IDs starting from zero, so those IDs can be used to actually index blocks' vector. This has one major issue - each block *must* use `pseudo_uuid` one and *only* once.~~

When the block is created it is now explicitly given an ID. `pseudo_uuid` instead if randomly generating a sting now generates `usize` counting from `usize::MAX`.
### TODOs
- [x] Confirm that all blocks that rely on IDs are working
- - [x] Music
- - [x] Notify
- - [x] Nvidia GPU
- [x] Don't use `pseudo_uuid` to create IDs
- [x] Once preveous is done, use `pseudo_uuid` instead of [this](https://github.com/MaxVerevkin/i3status-rust/blob/5675d2eea8ae8b027c0e546f1a283b6056d7f35a/src/blocks/music.rs#L290)
- [x] Use `usize` instead of `u64` (previously used because of hash function)