### PR TITLE
remove redundant ConfigLegacy structure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,12 @@ use crossbeam_channel::{select, Receiver, Sender};
 
 use crate::blocks::create_block;
 use crate::blocks::Block;
-use crate::config::{load_config, Config};
+use crate::config::Config;
 use crate::errors::*;
 use crate::input::{process_events, I3BarEvent};
 use crate::scheduler::{Task, UpdateScheduler};
 use crate::signals::process_signals;
+use crate::util::deserialize_file;
 use crate::widget::{I3BarWidget, State};
 use crate::widgets::text::TextWidget;
 
@@ -140,7 +141,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
         Some(config_path) => std::path::PathBuf::from(config_path),
         None => util::xdg_config_home().join("i3status-rust/config.toml"),
     };
-    let config = load_config(&config_path)?;
+    let config = deserialize_file(&config_path)?;
 
     // Update request channel
     let (tx_update_requests, rx_update_requests): (Sender<Task>, Receiver<Task>) =

--- a/src/util.rs
+++ b/src/util.rs
@@ -101,10 +101,11 @@ pub fn xdg_config_home() -> PathBuf {
     PathBuf::from(&config_path)
 }
 
-pub fn deserialize_file<T>(file: &str) -> Result<T>
+pub fn deserialize_file<T>(path: &Path) -> Result<T>
 where
     T: DeserializeOwned,
 {
+    let file = path.to_str().unwrap();
     let mut contents = String::new();
     let mut file = BufReader::new(
         File::open(file).internal_error("util", &format!("failed to open file: {}", file))?,


### PR DESCRIPTION
Manually `impl<'de> Deserialize<'de> for Theme` which gives more flexibility than having two `Config` structs and trying to deserialize one and then another. This solution is similar to what `icons` has.

 Full compatibility is preserved.

Future thoughts: don't copy the entire config to every block. Instead, give each block something like `Rc<Icons>` and `Rc<Theme>` (maybe create struct "appearance"?), and clone the theme only if block has theme overrides. As far as I know, blocks need global config only for theme and icons, please correct me if I'm wrong.