### PR TITLE
net: add `clickable` option and `format_alt` formating option

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -940,7 +940,9 @@ use_bits = false
 Key | Values | Required | Default
 ----|--------|----------|--------
 `device` | Network interface to monitor (name from /sys/class/net). | No | Automatically chosen from the output of `ip route show default`
-`format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | "{speed_up} {speed_down}" 
+`format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{speed_up} {speed_down}"`
+`clickable` | Whether to allow clicking on the block and swithching between `format` and `format_alt` | No | `false`
+`format_alt` | The same as `format`. Shows when the block is toggled with a mouse click (if `clickable` is `true`). | No | `"{ssid}"`
 `speed_digits` | Number of digits to use when displaying speeds. | No | `3`
 `speed_min_unit` | Smallest unit to use when displaying speeds. Possible choices: `"B"`, `"K"`, `"M"`, `"G"`, `"T"`. | No | `"K"`
 `use_bits` | Display speeds in bits instead of bytes. | No | `false`


### PR DESCRIPTION
Adds an ability to have two different formats and switch between them by just clicking on the block. For example, there is no need to constantly monitor your ssid, but is is nice to be able to click and see what is it.