### PR TITLE
fix clippy warnings; show profiling options only if profiling is enabled

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -672,7 +672,7 @@ impl Net {
 
         // Update the throughput/graph widgets if they are enabled
         let current_tx = self.device.tx_bytes()?;
-        let diff = current_tx.checked_sub(self.tx_bytes).unwrap_or(0);
+        let diff = current_tx.saturating_sub(self.tx_bytes);
         let tx_bytes = (diff as f64 / update_interval) as u64;
         self.tx_bytes = current_tx;
 
@@ -692,7 +692,7 @@ impl Net {
         self.graph_tx = format_vec_to_bar_graph(&self.tx_buff, None, None);
 
         let current_rx = self.device.rx_bytes()?;
-        let diff = current_rx.checked_sub(self.rx_bytes).unwrap_or(0);
+        let diff = current_rx.saturating_sub(self.rx_bytes);
         let rx_bytes = (diff as f64 / update_interval) as u64;
         self.rx_bytes = current_rx;
 

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -855,7 +855,7 @@ impl Sound {
                 self.text.set_text(if self.bar {
                     format_percent_bar(volume as f32)
                 } else {
-                    text.clone()
+                    text
                 });
             } else {
                 self.text.set_text(String::new());
@@ -869,7 +869,7 @@ impl Sound {
             self.text.set_text(if self.bar {
                 format_percent_bar(volume as f32)
             } else {
-                text.clone()
+                text
             });
         }
 

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -195,8 +195,8 @@ impl Block for Temperature {
 
         if self.fallback_required {
             for line in output.lines() {
-                if line.starts_with("  temp") {
-                    let rest = &line[6..]
+                if let Some(rest) = line.strip_prefix("  temp") {
+                    let rest = rest
                         .split('_')
                         .flat_map(|x| x.split(' '))
                         .flat_map(|x| x.split('.'))

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use regex::Regex;
 use serde::de::DeserializeOwned;
+use serde_json::json;
 
 use crate::blocks::Block;
 use crate::config::SharedConfig;
@@ -483,10 +484,6 @@ impl FormatTemplate {
         };
         Ok(rendered)
     }
-}
-
-macro_rules! if_debug {
-    ($x:block) => (if cfg!(debug_assertions) $x)
 }
 
 #[cfg(test)]

--- a/src/widgets/graph.rs
+++ b/src/widgets/graph.rs
@@ -1,4 +1,6 @@
 use num_traits::{clamp, ToPrimitive};
+
+use serde_json::json;
 use serde_json::value::Value;
 
 use super::I3BarWidget;

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, Instant};
 
+use serde_json::json;
 use serde_json::value::Value;
 
 use super::{I3BarWidget, Spacing, State};

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -1,3 +1,4 @@
+use serde_json::json;
 use serde_json::value::Value;
 
 use super::I3BarWidget;


### PR DESCRIPTION
Currently if built in debug mode, even if profiling is disabled, `i3status-rs -h` gives this:
```
--profile <profile>
--profile-runs <profile-runs>
```
which is not correct.

Also fix some clippy warnings and remove
```rust
#[macro_use]
extern crate serde_json;
```
because it isn't necessary since edition 2018