### PR TITLE
Introduce I3BlockData structure, do not call `click()` on every block

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -165,13 +165,13 @@ pub trait Block {
         Ok(())
     }
 
-    /// Sends click events to the block. This function is called on every block for every click.
+    /// Sends click events to the block.
     ///
     /// Here you can react to the user clicking your block. The I3BarEvent instance contains all
     /// fields to describe the click action, including mouse button and location down to the pixel.
     /// You may also update the internal state here.
     ///
-    /// To filter, use the event.id property and event.matches_id() function.
+    /// If block uses more that one widget, use the event.instance property to determine which widget was clicked.
     fn click(&mut self, _event: &I3BarEvent) -> Result<()> {
         Ok(())
     }

--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -111,7 +111,7 @@ impl ConfigBlock for Apt {
             .block_error("apt", "Failed to create config file")?;
         write!(config_file, "{}", apt_conf).block_error("apt", "Failed to write to config file")?;
 
-        let output = TextWidget::new(id, shared_config).with_icon("update");
+        let output = TextWidget::new(id, 0, shared_config).with_icon("update");
 
         Ok(Apt {
             id,
@@ -239,7 +239,7 @@ impl Block for Apt {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id) && event.button == MouseButton::Left {
+        if event.button == MouseButton::Left {
             self.update()?;
         }
         Ok(())

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -245,7 +245,7 @@ impl ConfigBlock for Backlight {
             device,
             step_width: block_config.step_width,
             scrolling: shared_config.scrolling,
-            output: TextWidget::new(id, shared_config),
+            output: TextWidget::new(id, 0, shared_config),
         };
 
         // Spin up a thread to watch for changes to the brightness file for the
@@ -302,22 +302,20 @@ impl Block for Backlight {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id) {
-            let brightness = self.device.brightness()?;
-            use LogicalDirection::*;
-            match self.scrolling.to_logical_direction(event.button) {
-                Some(Up) => {
-                    if brightness < 100 {
-                        self.device.set_brightness(brightness + self.step_width)?;
-                    }
+        let brightness = self.device.brightness()?;
+        use LogicalDirection::*;
+        match self.scrolling.to_logical_direction(event.button) {
+            Some(Up) => {
+                if brightness < 100 {
+                    self.device.set_brightness(brightness + self.step_width)?;
                 }
-                Some(Down) => {
-                    if brightness > self.step_width {
-                        self.device.set_brightness(brightness - self.step_width)?;
-                    }
-                }
-                None => {}
             }
+            Some(Down) => {
+                if brightness > self.step_width {
+                    self.device.set_brightness(brightness - self.step_width)?;
+                }
+            }
+            None => {}
         }
 
         Ok(())

--- a/src/blocks/base_block.rs
+++ b/src/blocks/base_block.rs
@@ -40,11 +40,9 @@ impl<T: Block> Block for BaseBlock<T> {
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
         match &self.on_click {
             Some(cmd) => {
-                if e.matches_id(self.id()) {
-                    if let MouseButton::Left = e.button {
-                        spawn_child_async("sh", &["-c", &cmd])
-                            .block_error(&self.name, "could not spawn child")?;
-                    }
+                if let MouseButton::Left = e.button {
+                    spawn_child_async("sh", &["-c", &cmd])
+                        .block_error(&self.name, "could not spawn child")?;
                 }
                 Ok(())
             }

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -664,11 +664,10 @@ impl ConfigBlock for Battery {
             )?),
         };
 
-        let output = TextWidget::new(id, shared_config);
         Ok(Battery {
             id,
             update_interval: block_config.interval,
-            output,
+            output: TextWidget::new(id, 0, shared_config),
             device,
             format: FormatTemplate::from_string(&format)?,
             full_format: FormatTemplate::from_string(&block_config.full_format)?,

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -258,7 +258,7 @@ impl ConfigBlock for Bluetooth {
 
         Ok(Bluetooth {
             id,
-            output: TextWidget::new(id, shared_config).with_icon(match device.icon {
+            output: TextWidget::new(id, 0, shared_config).with_icon(match device.icon {
                 Some(ref icon) if icon == "audio-card" => "headphones",
                 Some(ref icon) if icon == "input-gaming" => "joystick",
                 Some(ref icon) if icon == "input-keyboard" => "keyboard",
@@ -318,10 +318,8 @@ impl Block for Bluetooth {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id) {
-            if let MouseButton::Right = event.button {
-                self.device.toggle()?;
-            }
+        if let MouseButton::Right = event.button {
+            self.device.toggle()?;
         }
         Ok(())
     }

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -112,7 +112,7 @@ impl ConfigBlock for Cpu {
         Ok(Cpu {
             id,
             update_interval: block_config.interval,
-            output: TextWidget::new(id, shared_config).with_icon("cpu"),
+            output: TextWidget::new(id, 0, shared_config).with_icon("cpu"),
             prev_idles: [0; MAX_CPUS],
             prev_non_idles: [0; MAX_CPUS],
             minimum_info: block_config.info,

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -88,7 +88,7 @@ impl ConfigBlock for Custom {
         let mut custom = Custom {
             id,
             update_interval: block_config.interval,
-            output: TextWidget::new(id, shared_config),
+            output: TextWidget::new(id, 0, shared_config),
             command: None,
             on_click: None,
             cycle: None,
@@ -201,26 +201,24 @@ impl Block for Custom {
         Ok(())
     }
 
-    fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id) {
-            let mut update = false;
+    fn click(&mut self, _e: &I3BarEvent) -> Result<()> {
+        let mut update = false;
 
-            if let Some(ref on_click) = self.on_click {
-                spawn_child_async(&self.shell, &["-c", on_click]).ok();
-                update = true;
-            }
+        if let Some(ref on_click) = self.on_click {
+            spawn_child_async(&self.shell, &["-c", on_click]).ok();
+            update = true;
+        }
 
-            if let Some(ref mut cycle) = self.cycle {
-                cycle.next();
-                update = true;
-            }
+        if let Some(ref mut cycle) = self.cycle {
+            cycle.next();
+            update = true;
+        }
 
-            if update {
-                self.tx_update_request.send(Task {
-                    id: self.id,
-                    update_time: Instant::now(),
-                })?;
-            }
+        if update {
+            self.tx_update_request.send(Task {
+                id: self.id,
+                update_time: Instant::now(),
+            })?;
         }
 
         Ok(())

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -12,7 +12,6 @@ use serde_derive::Deserialize;
 use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::SharedConfig;
 use crate::errors::*;
-use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::widgets::text::TextWidget;
 use crate::widgets::{I3BarWidget, State};
@@ -120,7 +119,7 @@ impl ConfigBlock for CustomDBus {
             })
             .unwrap();
 
-        let text = TextWidget::new(id, shared_config).with_text("CustomDBus");
+        let text = TextWidget::new(id, 0, shared_config).with_text("CustomDBus");
         Ok(CustomDBus { id, text, status })
     }
 }
@@ -146,10 +145,5 @@ impl Block for CustomDBus {
     // Returns the view of the block, comprised of widgets.
     fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
-    }
-
-    // This function is called on every block for every click.
-    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
-        Ok(())
     }
 }

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -209,11 +209,10 @@ impl ConfigBlock for DiskSpace {
     ) -> Result<Self> {
         let icon = shared_config.get_icon("disk_drive").unwrap_or_default();
 
-        let disk_space = TextWidget::new(id, shared_config);
         Ok(DiskSpace {
             id,
             update_interval: block_config.interval,
-            disk_space,
+            disk_space: TextWidget::new(id, 0, shared_config),
             alias: block_config.alias,
             path: block_config.path,
             format: FormatTemplate::from_string(&block_config.format)?,

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -8,7 +8,6 @@ use crate::config::SharedConfig;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::http;
-use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widgets::text::TextWidget;
@@ -73,7 +72,7 @@ impl ConfigBlock for Docker {
         shared_config: SharedConfig,
         _: Sender<Task>,
     ) -> Result<Self> {
-        let text = TextWidget::new(id, shared_config)
+        let text = TextWidget::new(id, 0, shared_config)
             .with_text("N/A")
             .with_icon("docker");
         Ok(Docker {
@@ -114,10 +113,6 @@ impl Block for Docker {
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
-    }
-
-    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
-        Ok(())
     }
 
     fn id(&self) -> usize {

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -179,7 +179,7 @@ impl ConfigBlock for FocusedWindow {
             })
             .expect("failed to start watching thread for `window` block");
 
-        let text = TextWidget::new(id, shared_config);
+        let text = TextWidget::new(id, 0, shared_config);
         Ok(FocusedWindow {
             id,
             text,

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -11,7 +11,6 @@ use crate::config::SharedConfig;
 use crate::de::deserialize_duration;
 use crate::errors::*;
 use crate::http;
-use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::util::FormatTemplate;
 use crate::widgets::text::TextWidget;
@@ -81,7 +80,7 @@ impl ConfigBlock for Github {
         let token = std::env::var(GITHUB_TOKEN_ENV)
             .block_error("github", "missing I3RS_GITHUB_TOKEN environment variable")?;
 
-        let text = TextWidget::new(id, shared_config)
+        let text = TextWidget::new(id, 0, shared_config)
             .with_text("x")
             .with_icon("github");
         Ok(Github {
@@ -149,10 +148,6 @@ impl Block for Github {
         } else {
             vec![&self.text]
         }
-    }
-
-    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
-        Ok(())
     }
 
     fn id(&self) -> usize {

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -209,7 +209,7 @@ impl ConfigBlock for IBus {
             })
             .unwrap();
 
-        let text = TextWidget::new(id, shared_config).with_text("IBus");
+        let text = TextWidget::new(id, 0, shared_config).with_text("IBus");
         Ok(IBus {
             id,
             text,
@@ -254,9 +254,8 @@ impl Block for IBus {
         vec![&self.text]
     }
 
-    // This function is called on every block for every click.
-    // TODO: Filter events by using the event.name property,
-    // and use to switch between input engines?
+    // TODO:
+    // switch between input engines?
     fn click(&mut self, _: &I3BarEvent) -> Result<()> {
         Ok(())
     }

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -11,7 +11,6 @@ use serde_derive::Deserialize;
 use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::SharedConfig;
 use crate::errors::*;
-use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::util::{battery_level_to_icon, FormatTemplate};
 use crate::widgets::text::TextWidget;
@@ -557,7 +556,7 @@ impl ConfigBlock for KDEConnect {
             bat_critical: block_config.bat_critical,
             format: FormatTemplate::from_string(&block_config.format)?,
             format_disconnected: FormatTemplate::from_string(&block_config.format_disconnected)?,
-            output: TextWidget::new(id, shared_config.clone()).with_icon("phone"),
+            output: TextWidget::new(id, 0, shared_config.clone()).with_icon("phone"),
             shared_config,
         })
     }
@@ -671,10 +670,6 @@ impl Block for KDEConnect {
     // Returns the view of the block, comprised of widgets.
     fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.output]
-    }
-
-    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
-        Ok(())
     }
 }
 

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -485,7 +485,7 @@ impl ConfigBlock for KeyboardLayout {
         } else {
             None
         };
-        let output = TextWidget::new(id, shared_config);
+        let output = TextWidget::new(id, 0, shared_config);
         Ok(KeyboardLayout {
             id,
             output,

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -80,7 +80,7 @@ impl ConfigBlock for Load {
         shared_config: SharedConfig,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let text = TextWidget::new(id, shared_config)
+        let text = TextWidget::new(id, 0, shared_config)
             .with_icon("cogs")
             .with_state(State::Info);
 

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -8,7 +8,6 @@ use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::SharedConfig;
 use crate::de::deserialize_duration;
 use crate::errors::*;
-use crate::input::I3BarEvent;
 use crate::scheduler::Task;
 use crate::widgets::text::TextWidget;
 use crate::widgets::{I3BarWidget, State};
@@ -91,7 +90,7 @@ impl ConfigBlock for Maildir {
         shared_config: SharedConfig,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let widget = TextWidget::new(id, shared_config).with_text("");
+        let widget = TextWidget::new(id, 0, shared_config).with_text("");
         Ok(Maildir {
             id,
             update_interval: block_config.interval,
@@ -129,10 +128,6 @@ impl Block for Maildir {
 
     fn view(&self) -> Vec<&dyn I3BarWidget> {
         vec![&self.text]
-    }
-
-    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
-        Ok(())
     }
 
     fn id(&self) -> usize {

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -354,7 +354,7 @@ impl ConfigBlock for Memory {
         tx: Sender<Task>,
     ) -> Result<Self> {
         let icons: bool = block_config.icons;
-        let widget = TextWidget::new(id, shared_config).with_text("");
+        let widget = TextWidget::new(id, 0, shared_config).with_text("");
         Ok(Memory {
             id,
             memtype: block_config.display_type,
@@ -482,15 +482,13 @@ impl Block for Memory {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id) && self.clickable {
-            if let MouseButton::Left = event.button {
-                self.switch();
-                self.update()?;
-                self.tx_update_request.send(Task {
-                    id: self.id,
-                    update_time: Instant::now(),
-                })?;
-            }
+        if let MouseButton::Left = event.button {
+            self.switch();
+            self.update()?;
+            self.tx_update_request.send(Task {
+                id: self.id,
+                update_time: Instant::now(),
+            })?;
         }
 
         Ok(())

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -488,7 +488,7 @@ impl ConfigBlock for Music {
             match &*button {
                 "play" => {
                     play = Some(
-                        TextWidget::new(play_id, shared_config.clone())
+                        TextWidget::new(id, play_id, shared_config.clone())
                             .with_icon("music_play")
                             .with_state(State::Info)
                             .with_spacing(Spacing::Hidden),
@@ -496,7 +496,7 @@ impl ConfigBlock for Music {
                 }
                 "next" => {
                     next = Some(
-                        TextWidget::new(next_id, shared_config.clone())
+                        TextWidget::new(id, next_id, shared_config.clone())
                             .with_icon("music_next")
                             .with_state(State::Info)
                             .with_spacing(Spacing::Hidden),
@@ -504,7 +504,7 @@ impl ConfigBlock for Music {
                 }
                 "prev" => {
                     prev = Some(
-                        TextWidget::new(prev_id, shared_config.clone())
+                        TextWidget::new(id, prev_id, shared_config.clone())
                             .with_icon("music_prev")
                             .with_state(State::Info)
                             .with_spacing(Spacing::Hidden),
@@ -531,6 +531,7 @@ impl ConfigBlock for Music {
             collapsed_id,
             current_song_widget: RotatingTextWidget::new(
                 id,
+                id,
                 Duration::new(block_config.marquee_interval.as_secs(), 0),
                 Duration::new(0, block_config.marquee_speed.subsec_nanos()),
                 block_config.max_width,
@@ -544,7 +545,7 @@ impl ConfigBlock for Music {
             play,
             next,
             on_click: None,
-            on_collapsed_click_widget: TextWidget::new(collapsed_id, shared_config.clone())
+            on_collapsed_click_widget: TextWidget::new(id, collapsed_id, shared_config.clone())
                 .with_icon("music")
                 .with_state(State::Info)
                 .with_spacing(Spacing::Hidden),
@@ -652,7 +653,7 @@ impl Block for Music {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if let Some(event_id) = event.id {
+        if let Some(event_id) = event.instance {
             let action = match event_id {
                 id if id == self.play_id => "PlayPause",
                 id if id == self.next_id => "Next",

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -508,7 +508,7 @@ impl ConfigBlock for Net {
             format: FormatTemplate::from_string(&block_config.format)
                 .block_error("net", "Invalid format specified")?,
             format_alt,
-            output: TextWidget::new(id, shared_config.clone())
+            output: TextWidget::new(id, 0, shared_config.clone())
                 .with_icon(if wireless {
                     "net_wireless"
                 } else if vpn {
@@ -793,7 +793,7 @@ impl Block for Net {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id) && event.button == MouseButton::Left {
+        if event.button == MouseButton::Left {
             if let Some(ref mut format) = self.format_alt {
                 std::mem::swap(format, &mut self.format);
             }

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -566,7 +566,7 @@ impl ConfigBlock for NetworkManager {
 
         Ok(NetworkManager {
             id,
-            indicator: TextWidget::new(id, shared_config.clone()),
+            indicator: TextWidget::new(id, 0, shared_config.clone()),
             output: Vec::new(),
             dbus_conn,
             manager,
@@ -644,7 +644,7 @@ impl Block for NetworkManager {
                     .into_iter()
                     .filter_map(|conn| {
                         // inline spacing for no leading space, because the icon is set in the string
-                        let mut widget = TextWidget::new(self.id, self.shared_config.clone())
+                        let mut widget = TextWidget::new(self.id, 0, self.shared_config.clone())
                             .with_spacing(Spacing::Inline);
 
                         // Set the state for this connection

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -112,7 +112,7 @@ impl ConfigBlock for Notmuch {
         shared_config: SharedConfig,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let mut widget = TextWidget::new(id, shared_config);
+        let mut widget = TextWidget::new(id, 0, shared_config);
         if !block_config.no_icon {
             widget.set_icon("mail");
         }
@@ -172,7 +172,7 @@ impl Block for Notmuch {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id) && event.button == MouseButton::Left {
+        if event.button == MouseButton::Left {
             self.update()?;
         }
 

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -181,7 +181,7 @@ impl ConfigBlock for NvidiaGpu {
             gpu_enabled: false,
             gpu_id: block_config.gpu_id,
 
-            name_widget: TextWidget::new(id, shared_config.clone())
+            name_widget: TextWidget::new(id, id, shared_config.clone())
                 .with_icon("gpu")
                 .with_spacing(Spacing::Inline),
             name_widget_mode: if block_config.label.is_some() {
@@ -193,7 +193,8 @@ impl ConfigBlock for NvidiaGpu {
 
             show_memory: if block_config.show_memory {
                 Some(
-                    TextWidget::new(id_memory, shared_config.clone()).with_spacing(Spacing::Inline),
+                    TextWidget::new(id, id_memory, shared_config.clone())
+                        .with_spacing(Spacing::Inline),
                 )
             } else {
                 None
@@ -201,19 +202,22 @@ impl ConfigBlock for NvidiaGpu {
             memory_widget_mode: MemoryWidgetMode::ShowUsedMemory,
 
             show_utilization: if block_config.show_utilization {
-                Some(TextWidget::new(id, shared_config.clone()).with_spacing(Spacing::Inline))
+                Some(TextWidget::new(id, id, shared_config.clone()).with_spacing(Spacing::Inline))
             } else {
                 None
             },
 
             show_temperature: if block_config.show_temperature {
-                Some(TextWidget::new(id, shared_config.clone()).with_spacing(Spacing::Inline))
+                Some(TextWidget::new(id, id, shared_config.clone()).with_spacing(Spacing::Inline))
             } else {
                 None
             },
 
             show_fan: if block_config.show_fan_speed {
-                Some(TextWidget::new(id_fans, shared_config.clone()).with_spacing(Spacing::Inline))
+                Some(
+                    TextWidget::new(id, id_fans, shared_config.clone())
+                        .with_spacing(Spacing::Inline),
+                )
             } else {
                 None
             },
@@ -222,7 +226,7 @@ impl ConfigBlock for NvidiaGpu {
             scrolling: shared_config.scrolling,
 
             show_clocks: if block_config.show_clocks {
-                Some(TextWidget::new(id, shared_config).with_spacing(Spacing::Inline))
+                Some(TextWidget::new(id, id, shared_config).with_spacing(Spacing::Inline))
             } else {
                 None
             },
@@ -374,7 +378,7 @@ impl Block for NvidiaGpu {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if let Some(event_id) = e.id {
+        if let Some(event_id) = e.instance {
             if event_id == self.id {
                 if let MouseButton::Left = e.button {
                     match self.name_widget_mode {

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -157,7 +157,7 @@ impl ConfigBlock for Pacman {
         shared_config: SharedConfig,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let output = TextWidget::new(id, shared_config).with_icon("update");
+        let output = TextWidget::new(id, 0, shared_config).with_icon("update");
 
         Ok(Pacman {
             id,
@@ -417,10 +417,8 @@ impl Block for Pacman {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id) {
-            if let MouseButton::Left = event.button {
-                self.update()?;
-            }
+        if let MouseButton::Left = event.button {
+            self.update()?;
         }
 
         Ok(())

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -140,7 +140,7 @@ impl ConfigBlock for Pomodoro {
     ) -> Result<Self> {
         Ok(Pomodoro {
             id,
-            time: TextWidget::new(id, shared_config).with_icon("pomodoro"),
+            time: TextWidget::new(id, 0, shared_config).with_icon("pomodoro"),
             state: State::Stopped,
             length: Duration::from_secs(block_config.length * 60), // convert to minutes
             break_length: Duration::from_secs(block_config.break_length * 60), // convert to minutes
@@ -187,31 +187,28 @@ impl Block for Pomodoro {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id) {
-            match event.button {
-                MouseButton::Right => {
-                    self.state = State::Stopped;
-                    self.count = 0;
-                }
-                _ => match &self.state {
-                    State::Stopped => {
-                        self.state = State::Started(Instant::now());
-                    }
-                    State::Started(_) => {
-                        self.state = State::Paused(self.state.elapsed());
-                    }
-                    State::Paused(duration) => {
-                        self.state = State::Started(
-                            Instant::now().checked_sub(duration.to_owned()).unwrap(),
-                        );
-                    }
-                    State::OnBreak(_) => {
-                        self.state = State::Started(Instant::now());
-                    }
-                },
+        match event.button {
+            MouseButton::Right => {
+                self.state = State::Stopped;
+                self.count = 0;
             }
-            self.set_text();
+            _ => match &self.state {
+                State::Stopped => {
+                    self.state = State::Started(Instant::now());
+                }
+                State::Started(_) => {
+                    self.state = State::Paused(self.state.elapsed());
+                }
+                State::Paused(duration) => {
+                    self.state =
+                        State::Started(Instant::now().checked_sub(duration.to_owned()).unwrap());
+                }
+                State::OnBreak(_) => {
+                    self.state = State::Started(Instant::now());
+                }
+            },
         }
+        self.set_text();
 
         Ok(())
     }

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -933,7 +933,7 @@ impl ConfigBlock for Sound {
             mappings: block_config.mappings,
             max_vol: block_config.max_vol,
             scrolling: shared_config.scrolling,
-            text: TextWidget::new(id, shared_config).with_icon("volume_empty"),
+            text: TextWidget::new(id, 0, shared_config).with_icon("volume_empty"),
         };
 
         sound.device.monitor(id, tx_update_request)?;
@@ -960,30 +960,29 @@ impl Block for Sound {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if e.matches_id(self.id) {
-            match e.button {
-                MouseButton::Right => self.device.toggle()?,
-                MouseButton::Left => {
-                    if let Some(ref cmd) = self.on_click {
-                        spawn_child_async("sh", &["-c", cmd])
-                            .block_error("sound", "could not spawn child")?;
-                    }
-                }
-                _ => {
-                    use LogicalDirection::*;
-                    match self.scrolling.to_logical_direction(e.button) {
-                        Some(Up) => self
-                            .device
-                            .set_volume(self.step_width as i32, self.max_vol)?,
-                        Some(Down) => self
-                            .device
-                            .set_volume(-(self.step_width as i32), self.max_vol)?,
-                        None => (),
-                    }
+        match e.button {
+            MouseButton::Right => self.device.toggle()?,
+            MouseButton::Left => {
+                if let Some(ref cmd) = self.on_click {
+                    spawn_child_async("sh", &["-c", cmd])
+                        .block_error("sound", "could not spawn child")?;
                 }
             }
-            self.display()?;
+            _ => {
+                use LogicalDirection::*;
+                match self.scrolling.to_logical_direction(e.button) {
+                    Some(Up) => self
+                        .device
+                        .set_volume(self.step_width as i32, self.max_vol)?,
+                    Some(Down) => self
+                        .device
+                        .set_volume(-(self.step_width as i32), self.max_vol)?,
+                    None => (),
+                }
+            }
         }
+        self.display()?;
+
         Ok(())
     }
 

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -172,13 +172,13 @@ impl ConfigBlock for SpeedTest {
         Ok(SpeedTest {
             vals,
             text: vec![
-                TextWidget::new(id, shared_config.clone())
+                TextWidget::new(id, 0, shared_config.clone())
                     .with_icon("ping")
                     .with_text("0ms"),
-                TextWidget::new(id, shared_config.clone())
+                TextWidget::new(id, 1, shared_config.clone())
                     .with_icon("net_down")
                     .with_text(&format!("0{}", ty)),
-                TextWidget::new(id, shared_config)
+                TextWidget::new(id, 2, shared_config)
                     .with_icon("net_up")
                     .with_text(&format!("0{}", ty)),
             ],
@@ -234,10 +234,8 @@ impl Block for SpeedTest {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if e.matches_id(self.id) {
-            if let MouseButton::Left = e.button {
-                self.send.send(())?;
-            }
+        if let MouseButton::Left = e.button {
+            self.send.send(())?;
         }
         Ok(())
     }

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -129,7 +129,7 @@ impl ConfigBlock for Taskwarrior {
         shared_config: SharedConfig,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let output = TextWidget::new(id, shared_config)
+        let output = TextWidget::new(id, 0, shared_config)
             .with_icon("tasks")
             .with_text("-");
         // If the deprecated `filter_tags` option has been set,
@@ -244,18 +244,16 @@ impl Block for Taskwarrior {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id) {
-            match event.button {
-                MouseButton::Left => {
-                    self.update()?;
-                }
-                MouseButton::Right => {
-                    // Increment the filter_index, rotating at the end
-                    self.filter_index = (self.filter_index + 1) % self.filters.len();
-                    self.update()?;
-                }
-                _ => {}
+        match event.button {
+            MouseButton::Left => {
+                self.update()?;
             }
+            MouseButton::Right => {
+                // Increment the filter_index, rotating at the end
+                self.filter_index = (self.filter_index + 1) % self.filters.len();
+                self.update()?;
+            }
+            _ => {}
         }
 
         Ok(())

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -125,7 +125,7 @@ impl ConfigBlock for Temperature {
         Ok(Temperature {
             id,
             update_interval: block_config.interval,
-            text: TextWidget::new(id, shared_config)
+            text: TextWidget::new(id, 0, shared_config)
                 .with_icon("thermometer")
                 .with_spacing(if block_config.collapsed {
                     Spacing::Hidden
@@ -294,7 +294,7 @@ impl Block for Temperature {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if e.matches_id(self.id) && e.button == MouseButton::Left {
+        if e.button == MouseButton::Left {
             self.collapsed = !self.collapsed;
             if self.collapsed {
                 self.text.set_text(String::new());

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -50,7 +50,7 @@ impl ConfigBlock for Template {
         shared_config: SharedConfig,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let text = TextWidget::new(id, shared_config.clone()).with_text("Template");
+        let text = TextWidget::new(id, 0, shared_config.clone()).with_text("Template");
 
         Ok(Template {
             id,

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -76,7 +76,7 @@ impl ConfigBlock for Time {
     ) -> Result<Self> {
         Ok(Time {
             id,
-            time: TextWidget::new(id, shared_config)
+            time: TextWidget::new(id, 0, shared_config)
                 .with_text("")
                 .with_icon("time"),
             update_interval: block_config.interval,

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -45,7 +45,7 @@ impl ConfigBlock for Uptime {
         shared_config: SharedConfig,
         _tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let text = TextWidget::new(id, shared_config).with_icon("uptime");
+        let text = TextWidget::new(id, 0, shared_config).with_icon("uptime");
 
         Ok(Uptime {
             id,

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -71,7 +71,7 @@ impl ConfigBlock for Watson {
     ) -> Result<Self> {
         let watson = Watson {
             id,
-            text: TextWidget::new(id, shared_config),
+            text: TextWidget::new(id, 0, shared_config),
             state_path: block_config.state_path.clone(),
             show_time: block_config.show_time,
             update_interval: block_config.interval,
@@ -187,11 +187,9 @@ impl Block for Watson {
         }
     }
 
-    fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if e.matches_id(self.id) {
-            self.show_time = !self.show_time;
-            self.update()?;
-        }
+    fn click(&mut self, _e: &I3BarEvent) -> Result<()> {
+        self.show_time = !self.show_time;
+        self.update()?;
         Ok(())
     }
 

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -326,7 +326,7 @@ impl ConfigBlock for Weather {
     ) -> Result<Self> {
         Ok(Weather {
             id,
-            weather: TextWidget::new(id, shared_config),
+            weather: TextWidget::new(id, 0, shared_config),
             format: block_config.format,
             weather_keys: HashMap::new(),
             service: block_config.service,
@@ -364,10 +364,8 @@ impl Block for Weather {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.matches_id(self.id()) {
-            if let MouseButton::Left = event.button {
-                self.update()?;
-            }
+        if let MouseButton::Left = event.button {
+            self.update()?;
         }
         Ok(())
     }

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -236,7 +236,7 @@ impl ConfigBlock for Xrandr {
             step_width = 50;
         }
         Ok(Xrandr {
-            text: TextWidget::new(id, shared_config.clone()).with_icon("xrandr"),
+            text: TextWidget::new(id, 0, shared_config.clone()).with_icon("xrandr"),
             id,
             update_interval: block_config.interval,
             current_idx: 0,
@@ -266,38 +266,36 @@ impl Block for Xrandr {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if e.matches_id(self.id) {
-            match e.button {
-                MouseButton::Left => {
-                    if self.current_idx < self.monitors.len() - 1 {
-                        self.current_idx += 1;
-                    } else {
-                        self.current_idx = 0;
-                    }
-                }
-                mb => {
-                    use LogicalDirection::*;
-                    match self.shared_config.scrolling.to_logical_direction(mb) {
-                        Some(Up) => {
-                            if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
-                                if monitor.brightness <= (100 - self.step_width) {
-                                    monitor.set_brightness(self.step_width as i32);
-                                }
-                            }
-                        }
-                        Some(Down) => {
-                            if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
-                                if monitor.brightness >= self.step_width {
-                                    monitor.set_brightness(-(self.step_width as i32));
-                                }
-                            }
-                        }
-                        None => {}
-                    }
+        match e.button {
+            MouseButton::Left => {
+                if self.current_idx < self.monitors.len() - 1 {
+                    self.current_idx += 1;
+                } else {
+                    self.current_idx = 0;
                 }
             }
-            self.display()?;
+            mb => {
+                use LogicalDirection::*;
+                match self.shared_config.scrolling.to_logical_direction(mb) {
+                    Some(Up) => {
+                        if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
+                            if monitor.brightness <= (100 - self.step_width) {
+                                monitor.set_brightness(self.step_width as i32);
+                            }
+                        }
+                    }
+                    Some(Down) => {
+                        if let Some(monitor) = self.monitors.get_mut(self.current_idx) {
+                            if monitor.brightness >= self.step_width {
+                                monitor.set_brightness(-(self.step_width as i32));
+                            }
+                        }
+                    }
+                    None => {}
+                }
+            }
         }
+        self.display()?;
 
         Ok(())
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -34,6 +34,7 @@ struct I3BarEventInternal {
 #[derive(Debug, Clone)]
 pub struct I3BarEvent {
     pub id: Option<usize>,
+    pub instance: Option<usize>,
     pub button: MouseButton,
 }
 
@@ -62,6 +63,7 @@ pub fn process_events(sender: Sender<I3BarEvent>) {
                 sender
                     .send(I3BarEvent {
                         id: e.name.map(|x| x.parse::<usize>().unwrap()),
+                        instance: e.instance.map(|x| x.parse::<usize>().unwrap()),
                         button: e.button,
                     })
                     .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ fn main() {
             .with_state(State::Critical)
             .with_text(&format!("{:?}", error));
         let error_rendered = error_widget.get_data();
-        println!("{}", error_rendered.to_string());
+        println!("{}", error_rendered.render());
 
         eprintln!("\n\n{:?}", error);
         // Do nothing, so the error message keeps displayed

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,14 +111,11 @@ fn main() {
             ::std::process::exit(1);
         }
 
-        let error_widget = TextWidget::new(0, Default::default())
+        let error_widget = TextWidget::new(0, 0, Default::default())
             .with_state(State::Critical)
             .with_text(&format!("{:?}", error));
-        let error_rendered = error_widget.get_rendered();
-        println!(
-            "{}",
-            serde_json::to_string(&[error_rendered]).expect("failed to serialize error message")
-        );
+        let error_rendered = error_widget.get_data();
+        println!("{}", error_rendered.to_string());
 
         eprintln!("\n\n{:?}", error);
         // Do nothing, so the error message keeps displayed
@@ -197,10 +194,12 @@ fn run(matches: &ArgMatches) -> Result<()> {
         select! {
             // Receive click events
             recv(rx_clicks) -> res => if let Ok(event) = res {
-                    for block in blocks.iter_mut() {
-                        block.click(&event)?;
-                    }
+                if let Some(id) = event.id {
+                        blocks.get_mut(id)
+                    .internal_error("click handler", "could not get required block")?
+                            .click(&event)?;
                     util::print_blocks(&blocks, &shared_config)?;
+                }
             },
             // Receive async update requests
             recv(rx_update_requests) -> request => if let Ok(req) = request {

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use regex::Regex;
 use serde::de::DeserializeOwned;
-use serde_json::json;
 
 use crate::blocks::Block;
 use crate::config::SharedConfig;
@@ -222,7 +221,7 @@ pub fn print_blocks(blocks: &[Box<dyn Block>], config: &SharedConfig) -> Result<
         // Serialize and concatenate widgets
         let block_str = rendered_widgets
             .iter()
-            .map(|w| w.to_string())
+            .map(|w| w.render())
             .collect::<Vec<String>>()
             .join(",");
 
@@ -258,7 +257,7 @@ pub fn print_blocks(blocks: &[Box<dyn Block>], config: &SharedConfig) -> Result<
         separator.background = sep_bg;
         separator.color = sep_fg;
 
-        rendered_blocks.push(format!("{},{}", separator.to_string(), block_str));
+        rendered_blocks.push(format!("{},{}", separator.render(), block_str));
 
         // The last widget's BG is used to get the BG color for the next separator
         last_bg = Some(

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,6 +16,8 @@ use crate::blocks::Block;
 use crate::config::SharedConfig;
 use crate::errors::*;
 
+use crate::widgets::i3block_data::I3BlockData;
+
 pub const USR_SHARE_PATH: &str = "/usr/share/i3status-rust";
 
 pub fn pseudo_uuid() -> usize {
@@ -191,38 +193,30 @@ pub fn print_blocks(blocks: &[Box<dyn Block>], config: &SharedConfig) -> Result<
         let mut rendered_widgets = widgets
             .iter()
             .map(|widget| {
-                let mut w_json: serde_json::Value = widget.get_rendered().to_owned();
+                let mut data = widget.get_data();
                 if alternator {
                     // Apply tint for all widgets of every second block
-                    *w_json.get_mut("background").unwrap() = json!(add_colors(
-                        w_json["background"].as_str(),
-                        config.theme.alternating_tint_bg.as_deref()
+                    data.background = add_colors(
+                        data.background.as_deref(),
+                        config.theme.alternating_tint_bg.as_deref(),
                     )
-                    .unwrap());
-                    *w_json.get_mut("color").unwrap() = json!(add_colors(
-                        w_json["color"].as_str(),
-                        config.theme.alternating_tint_fg.as_deref()
+                    .unwrap();
+                    data.color = add_colors(
+                        data.color.as_deref(),
+                        config.theme.alternating_tint_bg.as_deref(),
                     )
-                    .unwrap());
+                    .unwrap();
                 }
-                w_json
+                data
             })
-            .collect::<Vec<serde_json::Value>>();
+            .collect::<Vec<I3BlockData>>();
 
         alternator = !alternator;
 
         if config.theme.native_separators == Some(true) {
             // Re-add native separator on last widget for native theme
-            *rendered_widgets
-                .last_mut()
-                .unwrap()
-                .get_mut("separator")
-                .unwrap() = json!(null);
-            *rendered_widgets
-                .last_mut()
-                .unwrap()
-                .get_mut("separator_block_width")
-                .unwrap() = json!(null);
+            rendered_widgets.last_mut().unwrap().separator = None;
+            rendered_widgets.last_mut().unwrap().separator_block_width = None;
         }
 
         // Serialize and concatenate widgets
@@ -239,8 +233,11 @@ pub fn print_blocks(blocks: &[Box<dyn Block>], config: &SharedConfig) -> Result<
         }
 
         // The first widget's BG is used to get the FG color for the current separator
-        let first_bg = rendered_widgets.first().unwrap()["background"]
-            .as_str()
+        let first_bg = rendered_widgets
+            .first()
+            .unwrap()
+            .background
+            .clone()
             .internal_error("util", "couldn't get background color")?;
 
         let sep_fg = if config.theme.separator_fg == Some("auto".to_string()) {
@@ -256,23 +253,21 @@ pub fn print_blocks(blocks: &[Box<dyn Block>], config: &SharedConfig) -> Result<
             config.theme.separator_bg.clone()
         };
 
-        let separator = json!({
-            "full_text": config.theme.separator,
-            "separator": false,
-            "separator_block_width": 0,
-            "background": sep_bg,
-            "color": sep_fg,
-            "markup": "pango"
-        });
+        let mut separator = I3BlockData::default();
+        separator.full_text = config.theme.separator.clone();
+        separator.background = sep_bg;
+        separator.color = sep_fg;
 
         rendered_blocks.push(format!("{},{}", separator.to_string(), block_str));
 
         // The last widget's BG is used to get the BG color for the next separator
         last_bg = Some(
-            rendered_widgets.last().unwrap()["background"]
-                .as_str()
-                .internal_error("util", "couldn't get background color")?
-                .to_string(),
+            rendered_widgets
+                .last()
+                .unwrap()
+                .background
+                .clone()
+                .internal_error("util", "couldn't get background color")?,
         );
     }
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -1,3 +1,4 @@
+pub mod i3block_data;
 pub mod rotatingtext;
 pub mod text;
 
@@ -6,9 +7,9 @@ use std::str::FromStr;
 use serde::de::value::{Error, StrDeserializer};
 use serde::de::{Deserialize, IntoDeserializer};
 use serde_derive::Deserialize;
-use serde_json::value::Value;
 
 use crate::themes::Theme;
+use i3block_data::I3BlockData;
 
 #[derive(Debug, Copy, Clone, Deserialize)]
 pub enum Spacing {
@@ -52,6 +53,5 @@ impl FromStr for State {
 }
 
 pub trait I3BarWidget {
-    fn to_string(&self) -> String;
-    fn get_rendered(&self) -> &Value;
+    fn get_data(&self) -> I3BlockData;
 }

--- a/src/widgets/i3block_data.rs
+++ b/src/widgets/i3block_data.rs
@@ -1,0 +1,99 @@
+/// Represent block as described in https://i3wm.org/docs/i3bar-protocol.html
+
+#[derive(Debug, Clone)]
+pub struct I3BlockData {
+    pub full_text: String,
+    pub short_text: Option<String>,
+    pub color: Option<String>,
+    pub background: Option<String>,
+    pub border: Option<String>,
+    pub border_top: Option<usize>,
+    pub border_right: Option<usize>,
+    pub border_bottom: Option<usize>,
+    pub border_left: Option<usize>,
+    pub min_width: Option<String>,
+    pub align: Option<I3BlockAlign>,
+    pub name: Option<String>,
+    pub instance: Option<String>,
+    pub urgent: Option<bool>,
+    pub separator: Option<bool>,
+    pub separator_block_width: Option<usize>,
+    pub markup: Option<String>,
+}
+
+macro_rules! json_add_str {
+    ($retval:ident, $obj:expr, $name:expr) => {
+        if let Some(ref val) = $obj {
+            $retval.push_str(&format!("\"{}\":\"{}\",", stringify!($name), val));
+        }
+    };
+}
+macro_rules! json_add_val {
+    ($retval:ident, $obj:expr, $name:expr) => {
+        if let Some(val) = $obj {
+            $retval.push_str(&format!("\"{}\":{},", stringify!($name), val));
+        }
+    };
+}
+
+impl I3BlockData {
+    pub fn to_string(&self) -> String {
+        let mut retval = format!("{{\"full_text\":\"{}\",", self.full_text);
+
+        json_add_str!(retval, self.short_text, short_text);
+        json_add_str!(retval, self.color, color);
+        json_add_str!(retval, self.background, background);
+        json_add_str!(retval, self.border, border);
+        json_add_val!(retval, self.border_top, border_top);
+        json_add_val!(retval, self.border_right, border_right);
+        json_add_val!(retval, self.border_bottom, border_bottom);
+        json_add_val!(retval, self.border_left, border_left);
+        json_add_str!(retval, self.min_width, min_width);
+        match self.align {
+            Some(I3BlockAlign::Center) => retval.push_str("align:\"center\","),
+            Some(I3BlockAlign::Right) => retval.push_str("align:\"right\","),
+            Some(I3BlockAlign::Left) => retval.push_str("align:\"left\","),
+            None => {}
+        }
+        json_add_str!(retval, self.name, name);
+        json_add_str!(retval, self.instance, instance);
+        json_add_val!(retval, self.urgent, urgent);
+        json_add_val!(retval, self.separator, separator);
+        json_add_val!(retval, self.separator_block_width, separator_block_width);
+        json_add_str!(retval, self.markup, markup);
+
+        retval.push_str("}");
+        retval
+    }
+}
+
+impl Default for I3BlockData {
+    fn default() -> Self {
+        Self {
+            full_text: String::new(),
+            short_text: None,
+            color: None,
+            background: None,
+            border: None,
+            border_top: None,
+            border_right: None,
+            border_bottom: None,
+            border_left: None,
+            min_width: None,
+            align: None,
+            name: None,
+            instance: None,
+            urgent: None,
+            separator: Some(false),
+            separator_block_width: Some(0),
+            markup: Some("pango".to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum I3BlockAlign {
+    Center,
+    Right,
+    Left,
+}

--- a/src/widgets/i3block_data.rs
+++ b/src/widgets/i3block_data.rs
@@ -37,7 +37,7 @@ macro_rules! json_add_val {
 }
 
 impl I3BlockData {
-    pub fn to_string(&self) -> String {
+    pub fn render(&self) -> String {
         let mut retval = format!("{{\"full_text\":\"{}\",", self.full_text);
 
         json_add_str!(retval, self.short_text, short_text);
@@ -62,7 +62,7 @@ impl I3BlockData {
         json_add_val!(retval, self.separator_block_width, separator_block_width);
         json_add_str!(retval, self.markup, markup);
 
-        retval.push_str("}");
+        retval.push('}');
         retval
     }
 }

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -35,9 +35,11 @@ impl RotatingTextWidget {
         dynamic_width: bool,
         shared_config: SharedConfig,
     ) -> RotatingTextWidget {
-        let mut inner = I3BlockData::default();
-        inner.name = Some(id.to_string());
-        inner.instance = Some(instance.to_string());
+        let inner = I3BlockData {
+            name: Some(id.to_string()),
+            instance: Some(instance.to_string()),
+            ..I3BlockData::default()
+        };
 
         RotatingTextWidget {
             id,

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -1,15 +1,13 @@
 use std::time::{Duration, Instant};
 
-use serde_json::json;
-use serde_json::value::Value;
-
-use super::{I3BarWidget, Spacing, State};
+use super::{i3block_data::I3BlockData, I3BarWidget, Spacing, State};
 use crate::config::SharedConfig;
 use crate::errors::*;
 
 #[derive(Clone, Debug)]
 pub struct RotatingTextWidget {
     id: usize,
+    pub instance: usize,
     rotation_pos: usize,
     max_width: usize,
     dynamic_width: bool,
@@ -20,24 +18,30 @@ pub struct RotatingTextWidget {
     icon: Option<String>,
     state: State,
     spacing: Spacing,
-    rendered: Value,
-    cached_output: Option<String>,
     shared_config: SharedConfig,
     pub rotating: bool,
+
+    inner: I3BlockData,
 }
 
 #[allow(dead_code)]
 impl RotatingTextWidget {
     pub fn new(
         id: usize,
+        instance: usize,
         interval: Duration,
         speed: Duration,
         max_width: usize,
         dynamic_width: bool,
         shared_config: SharedConfig,
     ) -> RotatingTextWidget {
+        let mut inner = I3BlockData::default();
+        inner.name = Some(id.to_string());
+        inner.instance = Some(instance.to_string());
+
         RotatingTextWidget {
             id,
+            instance,
             rotation_pos: 0,
             max_width,
             dynamic_width,
@@ -48,16 +52,11 @@ impl RotatingTextWidget {
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
-            rendered: json!({
-                "full_text": "",
-                "separator": false,
-                "separator_block_width": 0,
-                "background": "#000000",
-                "color": "#000000"
-            }),
-            cached_output: None,
+            //cached_output: None,
             shared_config,
             rotating: false,
+
+            inner,
         }
     }
 
@@ -152,35 +151,30 @@ impl RotatingTextWidget {
             _ => String::from(""),
         });
 
-        self.rendered = json!({
-            "full_text": format!("{}{}{}",
-                                icon,
-                                self.get_rotated_content(),
-                                match self.spacing {
-                                    Spacing::Hidden => String::from(""),
-                                    _ => String::from(" ")
-                                }),
-            "separator": false,
-            "separator_block_width": 0,
-            "name" : self.id.to_string(),
-            "min_width":
-                if self.content.is_empty() {
-                    "".to_string()
-                } else {
-                    let text_width = self.get_rotated_content().chars().count();
-                    let icon_width = icon.chars().count();
-                    if self.dynamic_width && text_width < self.max_width {
-                        "0".repeat(text_width + icon_width)
-                    } else {
-                        "0".repeat(self.max_width + icon_width + 1)
-                    }
-                },
-            "align": "left",
-            "background": key_bg,
-            "color": key_fg
+        self.inner.full_text = format!(
+            "{}{}{}",
+            icon,
+            self.get_rotated_content(),
+            match self.spacing {
+                Spacing::Hidden => String::from(""),
+                _ => String::from(" "),
+            }
+        );
+        self.inner.min_width = Some(if self.content.is_empty() {
+            "".to_string()
+        } else {
+            let text_width = self.get_rotated_content().chars().count();
+            let icon_width = icon.chars().count();
+            if self.dynamic_width && text_width < self.max_width {
+                "0".repeat(text_width + icon_width)
+            } else {
+                "0".repeat(self.max_width + icon_width + 1)
+            }
         });
+        self.inner.background = key_bg.clone();
+        self.inner.color = key_fg.clone();
 
-        self.cached_output = Some(self.rendered.to_string());
+        //self.cached_output = Some(self.rendered.to_string());
     }
 
     pub fn next(&mut self) -> Result<(bool, Option<Duration>)> {
@@ -212,13 +206,7 @@ impl RotatingTextWidget {
 }
 
 impl I3BarWidget for RotatingTextWidget {
-    fn to_string(&self) -> String {
-        self.cached_output
-            .clone()
-            .unwrap_or_else(|| self.rendered.to_string())
-    }
-
-    fn get_rendered(&self) -> &Value {
-        &self.rendered
+    fn get_data(&self) -> I3BlockData {
+        self.inner.clone()
     }
 }

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -15,9 +15,11 @@ pub struct TextWidget {
 
 impl TextWidget {
     pub fn new(id: usize, instance: usize, shared_config: SharedConfig) -> Self {
-        let mut inner = I3BlockData::default();
-        inner.name = Some(id.to_string());
-        inner.instance = Some(instance.to_string());
+        let inner = I3BlockData {
+            name: Some(id.to_string()),
+            instance: Some(instance.to_string()),
+            ..I3BlockData::default()
+        };
 
         TextWidget {
             id,

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -1,41 +1,33 @@
-use serde_json::json;
-use serde_json::value::Value;
-
-use super::I3BarWidget;
-use super::Spacing;
-use super::State;
+use super::{i3block_data::I3BlockData, I3BarWidget, Spacing, State};
 use crate::config::SharedConfig;
 
 #[derive(Clone, Debug)]
 pub struct TextWidget {
     id: usize,
+    pub instance: usize,
     content: Option<String>,
     icon: Option<String>,
     state: State,
     spacing: Spacing,
-    rendered: Value,
-    cached_output: Option<String>,
     shared_config: SharedConfig,
+    inner: I3BlockData,
 }
 
 impl TextWidget {
-    pub fn new(id: usize, shared_config: SharedConfig) -> Self {
+    pub fn new(id: usize, instance: usize, shared_config: SharedConfig) -> Self {
+        let mut inner = I3BlockData::default();
+        inner.name = Some(id.to_string());
+        inner.instance = Some(instance.to_string());
+
         TextWidget {
             id,
+            instance,
             content: None,
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
-            rendered: json!({
-                "full_text": "",
-                "separator": false,
-                "separator_block_width": 0,
-                "background": "#000000",
-                "color": "#000000",
-                "markup": "pango"
-            }),
-            cached_output: None,
             shared_config,
+            inner,
         }
     }
 
@@ -90,40 +82,29 @@ impl TextWidget {
         let (key_bg, key_fg) = self.state.theme_keys(&self.shared_config.theme);
 
         // When rendered inline, remove the leading space
-        self.rendered = json!({
-            "full_text": format!("{}{}{}",
-                                self.icon.clone().unwrap_or_else(|| {
-                                    match self.spacing {
-                                        Spacing::Normal => String::from(" "),
-                                        _ => String::from("")
-                                    }
-                                }),
-                                self.content.clone().unwrap_or_default(),
-                                match self.spacing {
-                                    Spacing::Hidden => String::from(""),
-                                    _ => String::from(" ")
-                                }
-                            ),
-            "separator": false,
-            "name": self.id.to_string(),
-            "separator_block_width": 0,
-            "background": key_bg,
-            "color": key_fg,
-            "markup": "pango"
-        });
+        self.inner.full_text = format!(
+            "{}{}{}",
+            self.icon.clone().unwrap_or_else(|| {
+                match self.spacing {
+                    Spacing::Normal => String::from(" "),
+                    _ => String::from(""),
+                }
+            }),
+            self.content.clone().unwrap_or_default(),
+            match self.spacing {
+                Spacing::Hidden => String::from(""),
+                _ => String::from(" "),
+            }
+        );
+        self.inner.background = key_bg.clone();
+        self.inner.color = key_fg.clone();
 
-        self.cached_output = Some(self.rendered.to_string());
+        //self.cached_output = Some(self.inner.to_string());
     }
 }
 
 impl I3BarWidget for TextWidget {
-    fn to_string(&self) -> String {
-        self.cached_output
-            .clone()
-            .unwrap_or_else(|| self.rendered.to_string())
-    }
-
-    fn get_rendered(&self) -> &Value {
-        &self.rendered
+    fn get_data(&self) -> I3BlockData {
+        self.inner.clone()
     }
 }


### PR DESCRIPTION
### Changes
- Introduce `I3BlockData` structure that represents every field described by the protocol here: https://i3wm.org/docs/i3bar-protocol.html
- Use (name, instance) pair to index every widget. Each block has a unique name/id, and inside of that block, each widget has an "instance". Now `click()` is called on the block that was clicked only.