### PR TITLE
I3BlockData: allow `min_width` in pixels; fix `align` rendering

### DIFF
--- a/src/widgets/i3block_data.rs
+++ b/src/widgets/i3block_data.rs
@@ -11,7 +11,7 @@ pub struct I3BlockData {
     pub border_right: Option<usize>,
     pub border_bottom: Option<usize>,
     pub border_left: Option<usize>,
-    pub min_width: Option<String>,
+    pub min_width: Option<I3BlockMinWidth>,
     pub align: Option<I3BlockAlign>,
     pub name: Option<String>,
     pub instance: Option<String>,
@@ -48,11 +48,15 @@ impl I3BlockData {
         json_add_val!(retval, self.border_right, border_right);
         json_add_val!(retval, self.border_bottom, border_bottom);
         json_add_val!(retval, self.border_left, border_left);
-        json_add_str!(retval, self.min_width, min_width);
+        match self.min_width {
+            Some(I3BlockMinWidth::Pixels(x)) => json_add_val!(retval, Some(x), min_width),
+            Some(I3BlockMinWidth::Text(ref x)) => json_add_str!(retval, Some(x), min_width),
+            None => {}
+        }
         match self.align {
-            Some(I3BlockAlign::Center) => retval.push_str("align:\"center\","),
-            Some(I3BlockAlign::Right) => retval.push_str("align:\"right\","),
-            Some(I3BlockAlign::Left) => retval.push_str("align:\"left\","),
+            Some(I3BlockAlign::Center) => retval.push_str("\"align\":\"center\","),
+            Some(I3BlockAlign::Right) => retval.push_str("\"align\":\"right\","),
+            Some(I3BlockAlign::Left) => retval.push_str("\"align\":\"left\","),
             None => {}
         }
         json_add_str!(retval, self.name, name);
@@ -96,4 +100,10 @@ pub enum I3BlockAlign {
     Center,
     Right,
     Left,
+}
+
+#[derive(Debug, Clone)]
+pub enum I3BlockMinWidth {
+    Pixels(usize),
+    Text(String),
 }

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -1,6 +1,9 @@
 use std::time::{Duration, Instant};
 
-use super::{i3block_data::I3BlockData, I3BarWidget, Spacing, State};
+use super::{
+    i3block_data::{I3BlockData, I3BlockMinWidth},
+    I3BarWidget, Spacing, State,
+};
 use crate::config::SharedConfig;
 use crate::errors::*;
 
@@ -163,14 +166,14 @@ impl RotatingTextWidget {
             }
         );
         self.inner.min_width = Some(if self.content.is_empty() {
-            "".to_string()
+            I3BlockMinWidth::Text("".to_string())
         } else {
             let text_width = self.get_rotated_content().chars().count();
             let icon_width = icon.chars().count();
             if self.dynamic_width && text_width < self.max_width {
-                "0".repeat(text_width + icon_width)
+                I3BlockMinWidth::Text("0".repeat(text_width + icon_width))
             } else {
-                "0".repeat(self.max_width + icon_width + 1)
+                I3BlockMinWidth::Text("0".repeat(self.max_width + icon_width + 1))
             }
         });
         self.inner.background = key_bg.clone();


### PR DESCRIPTION
A small bugfix for #1085:
- fix rendering of "align" option
- allow "min_width" option to be in pixels

Found those while trying to fix some spacing-related issues by moving each icon into it's own widget. Is this a reasonable idea and have someone tried this before? In some fonts each icon occupy two characters and overlaps with the next character. In some fonts this doesn't happen. If each icon had it's own widget, user would be able to set the size of the icon and it's align.