### PR TITLE
Fixed wpa_cli BSSID being displayed instead of SSID, see #1100

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -27,7 +27,7 @@ lazy_static! {
     static ref WHITESPACE_REGEX: Regex = Regex::new("\\s+").unwrap();
     static ref ETHTOOL_SPEED_REGEX: Regex = Regex::new("Speed: (\\d+\\w\\w/s)").unwrap();
     static ref IW_SSID_REGEX: Regex = Regex::new("SSID: (.*)").unwrap();
-    static ref WPA_SSID_REGEX: Regex = Regex::new("ssid=([[:alnum:]]+)").unwrap();
+    static ref WPA_SSID_REGEX: Regex = Regex::new("^ssid=(.*)").unwrap();
     static ref IWCTL_SSID_REGEX: Regex = Regex::new("Connected network\\s+([[:alnum:]]+)").unwrap();
     static ref IW_BITRATE_REGEX: Regex =
         Regex::new("tx bitrate: (\\d+(?:\\.?\\d+) [[:alpha:]]+/s)").unwrap();
@@ -880,7 +880,8 @@ fn get_wpa_ssid(dev: &NetworkDevice) -> Result<Option<String>> {
     let result = raw
         .stdout
         .split(|c| *c == b'\n')
-        .filter_map(|x| WPA_SSID_REGEX.find(x))
+        .filter_map(|x| WPA_SSID_REGEX.captures_iter(x).next())
+        .filter_map(|x| x.get(1))
         .next();
 
     maybe_ssid_convert(result.map(|x| x.as_bytes()))


### PR DESCRIPTION
The net block now correctly displays the SSID instead of the BSSID when `wpa_cli` is used and fixes #1100 