### PR TITLE
Refactor icons deserialization and add ability to load icons from file

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1,14 +1,9 @@
-use std::collections::{BTreeMap, HashMap as Map};
 use std::fmt;
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::str::FromStr;
 use std::time::Duration;
 
 use crate::blocks::Update;
 use chrono::{DateTime, Local};
-use serde::de::{self, Deserialize, DeserializeSeed, Deserializer};
-use toml::{self, value};
+use serde::de::{self, Deserialize, Deserializer};
 
 pub fn deserialize_update<'de, D>(deserializer: D) -> Result<Update, D::Error>
 where
@@ -95,145 +90,6 @@ where
     D: Deserializer<'de>,
 {
     deserialize_duration(deserializer).map(Some)
-}
-
-pub struct MapType<T, V>(pub PhantomData<T>, pub PhantomData<V>);
-
-macro_rules! map_type {
-    ( $name:ident, $value:ty; $fromstr_ident:ident => $fromstr_expr:expr ) => {
-        #[derive(Deserialize, Debug, Default)]
-        struct $name(::std::collections::HashMap<String, $value>);
-
-        impl Deref for $name {
-            type Target = ::std::collections::HashMap<String, $value>;
-
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        impl From<::std::collections::HashMap<String, $value>> for $name {
-            fn from(m: ::std::collections::HashMap<String, $value>) -> Self {
-                $name(m)
-            }
-        }
-
-        impl FromStr for $name {
-            type Err = String;
-
-            fn from_str($fromstr_ident: &str) -> Result<Self, Self::Err> {
-                $fromstr_expr
-            }
-        }
-    };
-}
-
-impl<'de, T, V> DeserializeSeed<'de> for MapType<T, V>
-where
-    T: Deserialize<'de>
-        + Default
-        + FromStr<Err = String>
-        + From<Map<String, V>>
-        + Deref<Target = Map<String, V>>,
-    V: Deserialize<'de> + Clone,
-{
-    type Value = Map<String, V>;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_any(self)
-    }
-}
-
-impl<'de, T, V> de::Visitor<'de> for MapType<T, V>
-where
-    T: Deserialize<'de>
-        + Default
-        + FromStr<Err = String>
-        + From<Map<String, V>>
-        + Deref<Target = Map<String, V>>,
-    V: Deserialize<'de> + Clone,
-{
-    type Value = Map<String, V>;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("string, seq or map")
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        let t: T = FromStr::from_str(value).map_err(de::Error::custom)?;
-        Ok(t.clone())
-    }
-
-    fn visit_seq<A>(self, mut visitor: A) -> Result<Self::Value, A::Error>
-    where
-        A: de::SeqAccess<'de>,
-    {
-        let mut vec: Vec<Self::Value> = Vec::new();
-        while let Some(element) =
-            visitor.next_element_seed(MapType::<T, V>(PhantomData, PhantomData))?
-        {
-            vec.push(element);
-        }
-
-        if vec.is_empty() {
-            Err(de::Error::custom("seq is empty"))
-        } else {
-            let mut combined = vec.remove(0);
-            for other in vec {
-                combined.extend(other);
-            }
-            Ok(combined)
-        }
-    }
-
-    /// If the TOML fragment is a map (table), it has to look something like this:
-    ///
-    /// ```toml
-    /// [mytype]
-    /// name = "predefined-type"
-    /// [mytype.overrides]
-    /// field1 = "override field 1"
-    /// field2 = "override field 2"
-    /// ```
-    ///
-    /// The `name` field will be recursively deserialized using `visit_str` or `visit_seq`. The
-    /// overrides field will be deserialized into a `Map<String, V>` and then combined with what
-    /// the deserialization of `name` delivered.
-    fn visit_map<A>(self, visitor: A) -> Result<Self::Value, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut map: BTreeMap<String, value::Value> =
-            Deserialize::deserialize(de::value::MapAccessDeserializer::new(visitor))?;
-        let mut combined: Map<String, V> = Map::new();
-
-        if let Some(raw_names) = map.remove("name") {
-            combined.extend(
-                raw_names
-                    .deserialize_any(MapType::<T, V>(PhantomData, PhantomData))
-                    .map_err(|e: toml::de::Error| de::Error::custom(e.to_string()))?,
-            );
-        }
-        if let Some(raw_overrides) = map.remove("overrides") {
-            let overrides: Map<String, V> = Map::<String, V>::deserialize(raw_overrides)
-                .map_err(|e: toml::de::Error| de::Error::custom(e.to_string()))?;
-            combined.extend(overrides);
-        }
-
-        if combined.is_empty() {
-            Err(de::Error::custom(
-                "missing all fields (`name`, `overrides`)",
-            ))
-        } else {
-            Ok(combined)
-        }
-    }
 }
 
 pub fn deserialize_local_timestamp<'de, D>(deserializer: D) -> Result<DateTime<Local>, D::Error>

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,9 +1,15 @@
-use std::collections::HashMap as Map;
+use std::collections::HashMap;
+use std::fmt;
 
 use lazy_static::lazy_static;
 
+use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
+use serde_derive::Deserialize;
+
+use crate::util;
+
 lazy_static! {
-    pub static ref NONE: Map<String, String> = map_to_owned! {
+    pub static ref NONE: HashMap<String, String> = map_to_owned! {
         "" => "",
         "backlight_empty" => "BRIGHT",
         "backlight_full" => "BRIGHT",
@@ -88,7 +94,7 @@ lazy_static! {
     };
 
     // FontAwesome 4: https://fontawesome.com/v4.7.0/cheatsheet/
-    pub static ref AWESOME: Map<String, String> = map_to_owned! {
+    pub static ref AWESOME: HashMap<String, String> = map_to_owned! {
         "" => "",
         "backlight_empty" => "\u{1f315}",
         "backlight_full" => "\u{1f311}",
@@ -175,7 +181,7 @@ lazy_static! {
     };
 
     // FontAwesome 5: https://fontawesome.com/icons?d=gallery&p=2&m=free
-    pub static ref AWESOME5: Map<String, String> = map_to_owned! {
+    pub static ref AWESOME5: HashMap<String, String> = map_to_owned! {
         "" => "",
         "backlight_empty" => "\u{1f315}",
         "backlight_full" => "\u{1f311}",
@@ -260,7 +266,7 @@ lazy_static! {
         "xrandr" => "\u{f26c}"
     };
 
-    pub static ref MATERIAL: Map<String, String> = map_to_owned! {
+    pub static ref MATERIAL: HashMap<String, String> = map_to_owned! {
         "" => "",
         "bat_charging" => "\u{e1a3}",
         "bat_discharging" => "\u{e19c}",
@@ -313,7 +319,7 @@ lazy_static! {
 
     // Material from NerdFont
     // https://www.nerdfonts.com/cheat-sheet
-    pub static ref MATERIAL_NF: Map<String, String> = map_to_owned! {
+    pub static ref MATERIAL_NF: HashMap<String, String> = map_to_owned! {
         "" => "",
         "backlight_empty" => "\u{e38d}", // nf-weather-moon_new
         "backlight_full" => "\u{e39b}", // nf-weather-moon_full
@@ -399,17 +405,122 @@ lazy_static! {
     };
 }
 
-pub fn get_icons(name: &str) -> Option<Map<String, String>> {
-    match name {
-        "material" => Some(MATERIAL.clone()),
-        "awesome" => Some(AWESOME.clone()),
-        "awesome5" => Some(AWESOME5.clone()),
-        "material-nf" => Some(MATERIAL_NF.clone()),
-        "none" => Some(NONE.clone()),
-        _ => None,
+#[derive(Debug, Clone)]
+pub struct Icons(pub HashMap<String, String>);
+
+impl Default for Icons {
+    fn default() -> Self {
+        Self(NONE.clone())
     }
 }
 
-pub fn default() -> Map<String, String> {
-    NONE.clone()
+impl Icons {
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "material" => Some(Icons(MATERIAL.clone())),
+            "awesome" => Some(Icons(AWESOME.clone())),
+            "awesome5" => Some(Icons(AWESOME5.clone())),
+            "material-nf" => Some(Icons(MATERIAL_NF.clone())),
+            "none" => Some(Icons(NONE.clone())),
+            _ => None,
+        }
+    }
+
+    pub fn from_file(file: &str) -> Option<Self> {
+        let file = util::find_file(file, Some("icons"), Some(".toml"))?;
+        let icons: HashMap<String, String> = util::deserialize_file(&file).ok()?;
+        Some(Icons(icons))
+    }
+}
+
+impl<'de> Deserialize<'de> for Icons {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Name,
+            File,
+            Overrides,
+        }
+
+        struct IconsVisitor;
+
+        impl<'de> Visitor<'de> for IconsVisitor {
+            type Value = Icons;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Icons")
+            }
+
+            /// Handle configs like:
+            ///
+            /// ```toml
+            /// icons = "awesome"
+            /// ```
+            fn visit_str<E>(self, name: &str) -> Result<Icons, E>
+            where
+                E: de::Error,
+            {
+                Icons::from_name(name)
+                    .ok_or_else(|| de::Error::custom(format!("Icon set \"{}\" not found.", name)))
+            }
+
+            /// Handle configs like:
+            ///
+            /// ```toml
+            /// [icons]
+            /// name = "awesome"
+            /// ```
+            fn visit_map<V>(self, mut map: V) -> Result<Icons, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut icons = None;
+                let mut overrides: Option<HashMap<String, String>> = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Name => {
+                            if icons.is_some() {
+                                return Err(de::Error::duplicate_field("name or file"));
+                            }
+                            let name = map.next_value()?;
+                            icons = Some(Icons::from_name(name).ok_or_else(|| {
+                                de::Error::custom(format!("Icon set \"{}\" not found.", name))
+                            })?);
+                        }
+                        Field::File => {
+                            if icons.is_some() {
+                                return Err(de::Error::duplicate_field("name or file"));
+                            }
+                            let file = map.next_value()?;
+                            icons = Some(Icons::from_file(file).ok_or_else(|| {
+                                de::Error::custom(format!(
+                                    "Failed to load icon set from file {}.",
+                                    file
+                                ))
+                            })?);
+                        }
+                        Field::Overrides => {
+                            if overrides.is_some() {
+                                return Err(de::Error::duplicate_field("overrides"));
+                            }
+                            overrides = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let mut icons = icons.unwrap_or_default();
+                if let Some(overrides) = overrides {
+                    for icon in overrides {
+                        icons.0.insert(icon.0, icon.1);
+                    }
+                }
+                Ok(icons)
+            }
+        }
+
+        deserializer.deserialize_any(IconsVisitor)
+    }
 }

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,6 +1,5 @@
 use std::default::Default;
 use std::fmt;
-use std::path::Path;
 
 use lazy_static::lazy_static;
 use serde_derive::Deserialize;
@@ -309,23 +308,9 @@ impl Theme {
     }
 
     pub fn from_file(file: &str) -> Option<Theme> {
-        let full_path = Path::new(file);
-        let xdg_path = util::xdg_config_home()
-            .join("i3status-rust/themes")
-            .join(file);
-        let share_path = Path::new(util::USR_SHARE_PATH).join("themes").join(file);
-
-        let theme: Option<ThemeFromFile> = if full_path.exists() {
-            util::deserialize_file(&full_path).ok()
-        } else if xdg_path.exists() {
-            util::deserialize_file(&xdg_path).ok()
-        } else if share_path.exists() {
-            util::deserialize_file(&share_path).ok()
-        } else {
-            None
-        };
-
-        theme.map(|theme| theme.into())
+        let file = util::find_file(file, Some("themes"), Some(".toml"))?;
+        let theme: ThemeFromFile = util::deserialize_file(&file).ok()?;
+        Some(theme.into())
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,6 +24,40 @@ pub fn pseudo_uuid() -> usize {
     ID.fetch_sub(1, Ordering::SeqCst)
 }
 
+pub fn find_file(file: &str, subdir: Option<&str>, extension: Option<&str>) -> Option<PathBuf> {
+    // Append an extension if `file` does not have it
+    let mut file = String::from(file);
+    if let Some(extension) = extension {
+        if !file.ends_with(extension) {
+            file.push_str(extension);
+        }
+    }
+
+    let full_path = PathBuf::from(&file);
+
+    let mut xdg_path = xdg_config_home().join("i3status-rust");
+    if let Some(subdir) = subdir {
+        xdg_path = xdg_path.join(subdir);
+    }
+    xdg_path = xdg_path.join(&file);
+
+    let mut share_path = PathBuf::from(USR_SHARE_PATH);
+    if let Some(subdir) = subdir {
+        share_path = share_path.join(subdir);
+    }
+    share_path = share_path.join(&file);
+
+    if full_path.exists() {
+        Some(full_path)
+    } else if xdg_path.exists() {
+        Some(xdg_path)
+    } else if share_path.exists() {
+        Some(share_path)
+    } else {
+        None
+    }
+}
+
 pub fn escape_pango_text(text: String) -> String {
     text.chars()
         .map(|x| match x {

--- a/themes.md
+++ b/themes.md
@@ -15,18 +15,20 @@ name = "solarized-dark"
 name = "awesome"
 ```
 
-You can also use your own custom theme:
-
+Both theme and an icon set can be loaded from a separate file using `file` parameter:
 ```toml
 [theme]
 file = "<file>"
+[icons]
+file = "<file_2>
 ```
-
 where `<file>` can be either a filename or a full path and will be checked in this order:
 
 1. If full path given, then use it as is: `/home/foo/custom_theme.toml`
 2. If filename given, e.g. "custom_theme.toml", then first check `XDG_CONFIG_HOME/i3status-rust/themes`
 3. Otherwise look for it in `/usr/share/i3status-rust/themes`
+
+Note: you can omit the `.toml` extension while specifying `file` parameter.
 
 Example theme file can be found in `example/theme/solarized-dark.toml`.
 


### PR DESCRIPTION
### Changes
- With this PR it is now possible to load icons from a separate file, just like themes
- User can omit `.toml` extension when loading a theme or an icon set from a file
- All this takes 27 lines less compared to previous implementation!

### TODO
- [x] Write documentation
- [ ] Probably some testing is necessary
