### PR TITLE
sound: Don't 0-pad volume

### DIFF
--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -843,7 +843,7 @@ impl Sound {
         } else {
             output_name
         };
-        let values = map!("{volume}" => format!("{:02}", volume),
+        let values = map!("{volume}" => format!("{:>3}", volume),
                           "{output_name}" => mapped_output_name
         );
         let text = self.format.render_static_str(&values)?;


### PR DESCRIPTION
The current string format for volume prepends an additional '0' to single digit values. For example, when the volume is set to 0 it would display `00%`.

This patch replaces the zero-padding format with right-alignment, as shown in the example below.

Before:
```
    00%
    10%
   100%
```

After:
```
    0%
   10%
  100%
```