### PR TITLE
Typo in themes.md: `color_overrides` -> `theme_overrides`

### DIFF
--- a/themes.md
+++ b/themes.md
@@ -87,7 +87,7 @@ bat_discharging = " |v| "
 
 Example configurations can be found as `example_theme.toml` and `example_icon.toml`.
 
-Besides global overrides you may also use per-block overrides using the `color_overrides` and `icons_format` options available for all blocks.
+Besides global overrides you may also use per-block overrides using the `theme_overrides` and `icons_format` options available for all blocks.
 For example:
 ```toml
 [[block]]


### PR DESCRIPTION
By the way, `theme_overrides` doesn't work in [`v0.14.7`](03d4fdfcc043e0c61b268bc295fe554f42d602b3). I guess the reason is 3030efebe7a1f3e73eedb697919829910026b737 (#1042) is not in there.