### PR TITLE
Add description and max_width to sound block

### DIFF
--- a/blocks.md
+++ b/blocks.md
@@ -1264,6 +1264,12 @@ step_width = 3
 ```toml
 [[block]]
 block = "sound"
+format = "{output_description} {volume}%"
+```
+
+```toml
+[[block]]
+block = "sound"
 format = "{output_name} {volume}"
 [block.mappings]
 "alsa_output.usb-Harman_Multimedia_JBL_Pebbles_1.0.0-00.analog-stereo" = "🔈"
@@ -1285,7 +1291,7 @@ Key | Values | Required | Default
 `on_click` | Shell command to run when the sound block is clicked. | No | None
 `show_volume_when_muted` | Show the volume even if it is currently muted. | No | `false`
 `max_width` | Max width of output\_name | No | `None`
-`use_description` | Pulseaudio provides some more human friendly names called description, it will replace the value of output\_name (mapping will still use the name) | No | `true`
+
 
 #### Available Format Keys
 
@@ -1293,6 +1299,7 @@ Key | Values | Required | Default
 ---------|-------
 `{volume}` | Current volume in percent
 `{output_name}` | PulseAudio or ALSA device name
+`{output_description}` | PulseAudio device description, will fallback to `output_name` if no description is available and will be overwritten by mappings (mappings will still use `output_name`)
 
 ###### [↥ back to top](#list-of-available-blocks)
 

--- a/blocks.md
+++ b/blocks.md
@@ -1284,6 +1284,8 @@ Key | Values | Required | Default
 `max_vol` | Max volume in percent that can be set via scrolling. Note it can still be set above this value if changed by another application. | No | `None`
 `on_click` | Shell command to run when the sound block is clicked. | No | None
 `show_volume_when_muted` | Show the volume even if it is currently muted. | No | `false`
+`max_width` | Max width of output\_name | No | `None`
+`use_description` | Pulseaudio provides some more human friendly names called description, it will replace the value of output\_name (mapping will still use the name) | No | `true`
 
 #### Available Format Keys
 

--- a/blocks.md
+++ b/blocks.md
@@ -1290,7 +1290,6 @@ Key | Values | Required | Default
 `max_vol` | Max volume in percent that can be set via scrolling. Note it can still be set above this value if changed by another application. | No | `None`
 `on_click` | Shell command to run when the sound block is clicked. | No | None
 `show_volume_when_muted` | Show the volume even if it is currently muted. | No | `false`
-`max_width` | Max width of output\_name | No | `None`
 
 
 #### Available Format Keys

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -249,7 +249,7 @@ impl TryFrom<&SourceInfo<'_>> for PulseAudioVolInfo {
                 description: source_info
                     .description
                     .clone()
-                    .map(|description| description.into_owned().to_string()),
+                    .map(|description| description.into_owned()),
             }),
         }
     }
@@ -269,7 +269,7 @@ impl TryFrom<&SinkInfo<'_>> for PulseAudioVolInfo {
                 description: sink_info
                     .description
                     .clone()
-                    .map(|description| description.into_owned().to_string()),
+                    .map(|description| description.into_owned()),
             }),
         }
     }

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -709,7 +709,6 @@ pub struct Sound {
     mappings: Option<BTreeMap<String, String>>,
     max_vol: Option<u32>,
     scrolling: Scrolling,
-    max_width: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq)]
@@ -780,10 +779,6 @@ pub struct SoundConfig {
 
     #[serde(default = "SoundConfig::default_max_vol")]
     pub max_vol: Option<u32>,
-
-    /// max_width only gets applied to the output names
-    #[serde(default = "SoundConfig::default_max_width")]
-    pub max_width: Option<usize>,
 }
 
 #[derive(Deserialize, Copy, Clone, Debug)]
@@ -837,10 +832,6 @@ impl SoundConfig {
     fn default_max_vol() -> Option<u32> {
         None
     }
-
-    fn default_max_width() -> Option<usize> {
-        None
-    }
 }
 
 impl Sound {
@@ -879,11 +870,6 @@ impl Sound {
             } {
                 output_name = mapped_name.clone();
                 output_description = mapped_name;
-            }
-
-            if let Some(max_width) = self.max_width {
-                output_name.truncate(max_width);
-                output_description.truncate(max_width);
             }
 
             (output_name, output_description)
@@ -980,7 +966,6 @@ impl ConfigBlock for Sound {
             max_vol: block_config.max_vol,
             scrolling: shared_config.scrolling,
             text: TextWidget::new(id, 0, shared_config).with_icon("volume_empty"),
-            max_width: block_config.max_width,
         };
 
         sound.device.monitor(id, tx_update_request)?;


### PR DESCRIPTION
This adds the usage of Pulse device descriptions (more human friendly names) (without breaking mapping).
Also the `output_name` now can have a `max_width`.