### PR TITLE
Add additional match rule for active connections

### DIFF
--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -550,12 +550,21 @@ impl ConfigBlock for NetworkManager {
             .name("networkmanager".into())
             .spawn(move || {
                 let c = Connection::get_private(BusType::System).unwrap();
-                let rule = "type='signal',\
-                        path='/org/freedesktop/NetworkManager',\
-                        interface='org.freedesktop.NetworkManager',\
-                        member='PropertiesChanged'";
 
-                c.add_match(&rule).unwrap();
+                c.add_match(
+                    "type='signal',\
+                    path='/org/freedesktop/NetworkManager',\
+                    interface='org.freedesktop.NetworkManager',\
+                    member='PropertiesChanged'",
+                )
+                .unwrap();
+                c.add_match(
+                    "type='signal',\
+                    path_namespace='/org/freedesktop/NetworkManager/ActiveConnection',\
+                    interface='org.freedesktop.NetworkManager.Connection.Active',\
+                    member='PropertiesChanged'",
+                )
+                .unwrap();
 
                 loop {
                     let timeout = 300_000;


### PR DESCRIPTION
This fixes #1117 and #991. (For explanation see #1117)
Also as a nice side effect the wifi signal strength now updates.

**But** I was debugging a bit and noticed that the block now updates 14 times when a connection is disabled and 19 times when a new wifi connection is added that seams a _bit_ excessive (most of the time nothing changes between updates, because we listen for properties we don't display). Removing the rule for `/org/freedesktop/NetworkManager` helps, but it's still not great (7-10 updates) and we could miss events (again).
I have looked a bit into the dbus crate, but didn't manage to deconstruct or filter an event (jet)...