### PR TITLE
`impl Default` for blocks' configs

### DIFF
--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -31,55 +31,42 @@ pub struct Apt {
     config_path: String,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct AptConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "AptConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Format override
-    #[serde(default = "AptConfig::default_format")]
     pub format: String,
 
     /// Alternative format override for when exactly 1 update is available
-    #[serde(default = "AptConfig::default_format")]
     pub format_singular: String,
 
     /// Alternative format override for when no updates are available
-    #[serde(default = "AptConfig::default_format")]
     pub format_up_to_date: String,
 
     /// Indicate a `warning` state for the block if any pending update match the
     /// following regex. Default behaviour is that no package updates are deemed
     /// warning
-    #[serde(default = "AptConfig::default_warning_updates_regex")]
     pub warning_updates_regex: Option<String>,
 
     /// Indicate a `critical` state for the block if any pending update match the following regex.
     /// Default behaviour is that no package updates are deemed critical
-    #[serde(default = "AptConfig::default_critical_updates_regex")]
     pub critical_updates_regex: Option<String>,
 }
 
-impl AptConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(60 * 10)
-    }
-
-    fn default_format() -> String {
-        "{count:1}".to_owned()
-    }
-
-    fn default_warning_updates_regex() -> Option<String> {
-        None
-    }
-
-    fn default_critical_updates_regex() -> Option<String> {
-        None
+impl Default for AptConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(600),
+            format: "{count:1}".to_string(),
+            format_singular: "{count:1}".to_string(),
+            format_up_to_date: "{count:1}".to_string(),
+            warning_updates_regex: None,
+            critical_updates_regex: None,
+        }
     }
 }
 

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -189,15 +189,13 @@ pub struct Backlight {
 }
 
 /// Configuration for the [`Backlight`](./struct.Backlight.html) block.
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct BacklightConfig {
     /// The backlight device in `/sys/class/backlight/` to read brightness from.
-    #[serde(default = "BacklightConfig::default_device")]
     pub device: Option<String>,
 
     /// The steps brightness is in/decreased for the selected screen (When greater than 50 it gets limited to 50)
-    #[serde(default = "BacklightConfig::default_step_width")]
     pub step_width: u64,
 
     /// Scaling exponent reciprocal (ie. root). Some devices expose raw values
@@ -207,28 +205,19 @@ pub struct BacklightConfig {
     /// More information: <https://en.wikipedia.org/wiki/Lightness>
     ///
     /// For devices with few discrete steps this should be 1.0 (linear).
-    #[serde(default = "BacklightConfig::default_root_scaling")]
     pub root_scaling: f64,
 
-    #[serde(default = "BacklightConfig::default_invert_icons")]
     pub invert_icons: bool,
 }
 
-impl BacklightConfig {
-    fn default_device() -> Option<String> {
-        None
-    }
-
-    fn default_step_width() -> u64 {
-        5
-    }
-
-    fn default_root_scaling() -> f64 {
-        1f64
-    }
-
-    fn default_invert_icons() -> bool {
-        false
+impl Default for BacklightConfig {
+    fn default() -> Self {
+        Self {
+            device: None,
+            step_width: 5,
+            root_scaling: 1f64,
+            invert_icons: false,
+        }
     }
 }
 

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -510,110 +510,65 @@ impl Default for BatteryDriver {
 
 /// Configuration for the [`Battery`](./struct.Battery.html) block.
 #[derive(Deserialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, default)]
 pub struct BatteryConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "BatteryConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// The internal power supply device in `/sys/class/power_supply/` to read from.
-    #[serde(default = "BatteryConfig::default_device")]
     pub device: String,
 
     /// Format string for displaying battery information.
     /// placeholders: {percentage}, {bar}, {time} and {power}
-    #[serde(default = "BatteryConfig::default_format")]
     pub format: String,
 
     /// Format string for displaying battery information when battery is full.
     /// placeholders: {percentage}, {bar}, {time} and {power}
-    #[serde(default = "BatteryConfig::default_full_format")]
     pub full_format: String,
 
     /// Format string that's displayed if a battery is missing.
     /// placeholders: {percentage}, {bar}, {time} and {power}
-    #[serde(default = "BatteryConfig::default_missing_format")]
     pub missing_format: String,
 
     /// The "driver" to use for powering the block. One of "sysfs" or "upower".
-    #[serde(default = "BatteryConfig::default_driver")]
     pub driver: BatteryDriver,
 
     /// The threshold above which the remaining capacity is shown as good
-    #[serde(default = "BatteryConfig::default_good")]
     pub good: u64,
 
     /// The threshold below which the remaining capacity is shown as info
-    #[serde(default = "BatteryConfig::default_info")]
     pub info: u64,
 
     /// The threshold below which the remaining capacity is shown as warning
-    #[serde(default = "BatteryConfig::default_warning")]
     pub warning: u64,
 
     /// The threshold below which the remaining capacity is shown as critical
-    #[serde(default = "BatteryConfig::default_critical")]
     pub critical: u64,
 
     /// If the battery device cannot be found, do not fail and show the block anyway (sysfs only).
-    #[serde(default = "BatteryConfig::default_allow_missing")]
     pub allow_missing: bool,
 
     /// If the battery device cannot be found, completely hide this block.
-    #[serde(default = "BatteryConfig::default_hide_missing")]
     pub hide_missing: bool,
 }
 
-impl BatteryConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(10)
-    }
-
-    fn default_device() -> String {
-        "BAT0".to_string()
-    }
-
-    fn default_format() -> String {
-        "{percentage}".into()
-    }
-
-    fn default_full_format() -> String {
-        "".into()
-    }
-
-    fn default_missing_format() -> String {
-        "{percentage}".into()
-    }
-
-    fn default_driver() -> BatteryDriver {
-        BatteryDriver::Sysfs
-    }
-
-    fn default_critical() -> u64 {
-        15
-    }
-
-    fn default_warning() -> u64 {
-        30
-    }
-
-    fn default_info() -> u64 {
-        60
-    }
-
-    fn default_good() -> u64 {
-        60
-    }
-
-    fn default_allow_missing() -> bool {
-        false
-    }
-
-    fn default_hide_missing() -> bool {
-        false
+impl Default for BatteryConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(10),
+            device: "BAT0".to_string(),
+            format: "{percentage}".to_string(),
+            full_format: "".to_string(),
+            missing_format: "{percentage}".to_string(),
+            driver: BatteryDriver::Sysfs,
+            good: 60,
+            info: 60,
+            warning: 30,
+            critical: 15,
+            allow_missing: false,
+            hide_missing: false,
+        }
     }
 }
 

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -27,52 +27,35 @@ pub struct Cpu {
     format: FormatTemplate,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct CpuConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "CpuConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Minimum usage, where state is set to info
-    #[serde(default = "CpuConfig::default_info")]
     pub info: u64,
 
     /// Minimum usage, where state is set to warning
-    #[serde(default = "CpuConfig::default_warning")]
     pub warning: u64,
 
     /// Minimum usage, where state is set to critical
-    #[serde(default = "CpuConfig::default_critical")]
     pub critical: u64,
 
     /// Format override
-    #[serde(default = "CpuConfig::default_format")]
     pub format: String,
 }
 
-impl CpuConfig {
-    fn default_format() -> String {
-        "{utilization}".to_owned()
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(1)
-    }
-
-    fn default_info() -> u64 {
-        30
-    }
-
-    fn default_warning() -> u64 {
-        60
-    }
-
-    fn default_critical() -> u64 {
-        90
+impl Default for CpuConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(1),
+            info: 30,
+            warning: 60,
+            critical: 90,
+            format: "{utilization}".to_string(),
+        }
     }
 }
 

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -29,7 +29,7 @@ pub struct CustomDBus {
     status: Arc<Mutex<CustomDBusStatus>>,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct CustomDBusConfig {
     pub name: String,

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -42,87 +42,54 @@ pub struct DiskSpace {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, default)]
 pub struct DiskSpaceConfig {
     /// Path to collect information from
-    #[serde(default = "DiskSpaceConfig::default_path")]
     pub path: String,
 
     /// Currently supported options are available, free, total and used
     /// Sets value used for {percentage} calculation
     /// total is the same as used, use format to set format string for output
-    #[serde(default = "DiskSpaceConfig::default_info_type")]
     pub info_type: InfoType,
 
     /// Format string for output
-    #[serde(default = "DiskSpaceConfig::default_format")]
     pub format: String,
 
     /// Unit that is used to display disk space. Options are B, KB, MB, GB and TB
-    #[serde(default = "DiskSpaceConfig::default_unit")]
     pub unit: String,
 
     /// Update interval in seconds
-    #[serde(
-        default = "DiskSpaceConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
-    /// Diskspace warning in GiB (yellow)
-    #[serde(default = "DiskSpaceConfig::default_warning")]
+    /// Diskspace warning (yellow)
     pub warning: f64,
 
-    /// Diskspace alert in GiB (red)
-    #[serde(default = "DiskSpaceConfig::default_alert")]
+    /// Diskspace alert (red)
     pub alert: f64,
 
     /// use absolute (unit) values for disk space alerts
-    #[serde(default = "DiskSpaceConfig::default_alert_absolute")]
     pub alert_absolute: bool,
 
     /// Alias that is displayed for path
     // DEPRECATED
     // TODO remove
-    #[serde(default = "DiskSpaceConfig::default_alias")]
     pub alias: String,
 }
 
-impl DiskSpaceConfig {
-    fn default_path() -> String {
-        "/".to_owned()
-    }
-
-    fn default_info_type() -> InfoType {
-        InfoType::Available
-    }
-
-    fn default_format() -> String {
-        "{alias} {available}".to_string()
-    }
-
-    fn default_unit() -> String {
-        "GB".to_string()
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(20)
-    }
-
-    fn default_warning() -> f64 {
-        20.
-    }
-
-    fn default_alert() -> f64 {
-        10.
-    }
-
-    fn default_alert_absolute() -> bool {
-        false
-    }
-
-    fn default_alias() -> String {
-        "/".to_string()
+impl Default for DiskSpaceConfig {
+    fn default() -> Self {
+        Self {
+            path: "/".to_string(),
+            info_type: InfoType::Available,
+            format: "{available}".to_string(),
+            unit: "GB".to_string(),
+            interval: Duration::from_secs(20),
+            warning: 20.,
+            alert: 10.,
+            alert_absolute: false,
+            alias: "/".to_string(),
+        }
     }
 }
 

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -39,28 +39,23 @@ struct Status {
     images: i64,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct DockerConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "DockerConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Format override
-    #[serde(default = "DockerConfig::default_format")]
     pub format: String,
 }
 
-impl DockerConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(5)
-    }
-
-    fn default_format() -> String {
-        "{running}".to_owned()
+impl Default for DockerConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(5),
+            format: "{running}".to_string(),
+        }
     }
 }
 

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -32,24 +32,21 @@ pub struct FocusedWindow {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, default)]
 pub struct FocusedWindowConfig {
     /// Truncates titles if longer than max-width
-    #[serde(default = "FocusedWindowConfig::default_max_width")]
     pub max_width: usize,
 
     /// Show marks in place of title (if exist)
-    #[serde(default = "FocusedWindowConfig::default_show_marks")]
     pub show_marks: MarksType,
 }
 
-impl FocusedWindowConfig {
-    fn default_max_width() -> usize {
-        21
-    }
-
-    fn default_show_marks() -> MarksType {
-        MarksType::None
+impl Default for FocusedWindowConfig {
+    fn default() -> Self {
+        Self {
+            max_width: 21,
+            show_marks: MarksType::None,
+        }
     }
 }
 

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -30,42 +30,29 @@ pub struct Github {
     hide_if_total_is_zero: bool,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct GithubConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "GithubConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
-    #[serde(default = "GithubConfig::default_api_server")]
     pub api_server: String,
 
     /// Format override
-    #[serde(default = "GithubConfig::default_format")]
     pub format: String,
 
-    #[serde(default = "GithubConfig::default_hide_if_total_is_zero")]
     pub hide_if_total_is_zero: bool,
 }
 
-impl GithubConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(30)
-    }
-
-    fn default_api_server() -> String {
-        "https://api.github.com".to_owned()
-    }
-
-    fn default_format() -> String {
-        "{total}".to_owned()
-    }
-
-    fn default_hide_if_total_is_zero() -> bool {
-        false
+impl Default for GithubConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(30),
+            api_server: "https://api.github.com".to_string(),
+            format: "{total}".to_string(),
+            hide_if_total_is_zero: false,
+        }
     }
 }
 

--- a/src/blocks/hueshift.rs
+++ b/src/blocks/hueshift.rs
@@ -111,74 +111,46 @@ pub enum HueShifter {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, default)]
 pub struct HueshiftConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "HueshiftConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
-    #[serde(default = "HueshiftConfig::default_max_temp")]
     pub max_temp: u16,
-    #[serde(default = "HueshiftConfig::default_min_temp")]
     pub min_temp: u16,
 
     // TODO: Detect currently defined temperature
     /// Currently defined temperature default to 6500K.
-    #[serde(default = "HueshiftConfig::default_current_temp")]
     pub current_temp: u16,
 
     /// Can be set by user as an option.
-    #[serde(default = "HueshiftConfig::default_hue_shifter")]
     pub hue_shifter: Option<HueShifter>,
 
     /// Default to 100K, cannot go over 500K.
-    #[serde(default = "HueshiftConfig::default_step")]
     pub step: u16,
-    #[serde(default = "HueshiftConfig::default_click_temp")]
     pub click_temp: u16,
 }
 
-impl HueshiftConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(5)
-    }
-
-    /// Default current temp for any screens
-    fn default_current_temp() -> u16 {
-        6500
-    }
-    /// Max/Min hue temperature (min 1000K, max 10_000K)
-    // TODO: Try to detect if we're using redshift or not
-    // to set default max_temp either to 10_000K to 25_000K
-    fn default_min_temp() -> u16 {
-        1000
-    }
-    fn default_max_temp() -> u16 {
-        10_000
-    }
-
-    fn default_step() -> u16 {
-        100
-    }
-
-    /// Prefer any installed shifter, redshift is preferred though.
-    fn default_hue_shifter() -> Option<HueShifter> {
-        if has_command("hueshift", "redshift").unwrap_or(false) {
-            Some(HueShifter::Redshift)
-        } else if has_command("hueshift", "sct").unwrap_or(false) {
-            Some(HueShifter::Sct)
-        } else if has_command("hueshift", "gammastep").unwrap_or(false) {
-            Some(HueShifter::Gammastep)
-        } else {
-            None
+impl Default for HueshiftConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(5),
+            max_temp: 10_000,
+            min_temp: 1_000,
+            current_temp: 6_500,
+            hue_shifter: if has_command("hueshift", "redshift").unwrap_or(false) {
+                Some(HueShifter::Redshift)
+            } else if has_command("hueshift", "sct").unwrap_or(false) {
+                Some(HueShifter::Sct)
+            } else if has_command("hueshift", "gammastep").unwrap_or(false) {
+                Some(HueShifter::Gammastep)
+            } else {
+                None
+            },
+            step: 100,
+            click_temp: 6_500,
         }
-    }
-
-    fn default_click_temp() -> u16 {
-        6500
     }
 }
 

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -37,23 +37,19 @@ pub struct IBus {
     format: FormatTemplate,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct IBusConfig {
-    #[serde(default = "IBusConfig::default_mappings")]
     pub mappings: Option<BTreeMap<String, String>>,
-
-    #[serde(default = "IBusConfig::default_format")]
     pub format: String,
 }
 
-impl IBusConfig {
-    fn default_mappings() -> Option<BTreeMap<String, String>> {
-        None
-    }
-
-    fn default_format() -> String {
-        "{engine}".into()
+impl Default for IBusConfig {
+    fn default() -> Self {
+        Self {
+            mappings: None,
+            format: "{engine}".to_string(),
+        }
     }
 }
 

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -39,64 +39,41 @@ pub struct KDEConnect {
     shared_config: SharedConfig,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct KDEConnectConfig {
-    #[serde(default = "KDEConnectConfig::default_device_id")]
     pub device_id: Option<String>,
 
     /// The threshold above which the remaining capacity is shown as good
-    #[serde(default = "KDEConnectConfig::default_bat_good")]
     pub bat_good: i32,
 
     /// The threshold below which the remaining capacity is shown as info
-    #[serde(default = "KDEConnectConfig::default_bat_info")]
     pub bat_info: i32,
 
     /// The threshold below which the remaining capacity is shown as warning
-    #[serde(default = "KDEConnectConfig::default_bat_warning")]
     pub bat_warning: i32,
 
     /// The threshold below which the remaining capacity is shown as critical
-    #[serde(default = "KDEConnectConfig::default_bat_critical")]
     pub bat_critical: i32,
 
     /// Format string for displaying phone information.
-    #[serde(default = "KDEConnectConfig::default_format")]
     pub format: String,
 
     /// Format string for displaying phone information when it is disconnected.
-    #[serde(default = "KDEConnectConfig::default_format_disconnected")]
     pub format_disconnected: String,
 }
 
-impl KDEConnectConfig {
-    fn default_device_id() -> Option<String> {
-        None
-    }
-
-    fn default_bat_critical() -> i32 {
-        15
-    }
-
-    fn default_bat_warning() -> i32 {
-        30
-    }
-
-    fn default_bat_info() -> i32 {
-        60
-    }
-
-    fn default_bat_good() -> i32 {
-        60
-    }
-
-    fn default_format() -> String {
-        "{name} {bat_icon}{bat_charge} {notif_icon}{notif_count}".into()
-    }
-
-    fn default_format_disconnected() -> String {
-        "{name}".into()
+impl Default for KDEConnectConfig {
+    fn default() -> Self {
+        Self {
+            device_id: None,
+            bat_good: 60,
+            bat_info: 60,
+            bat_warning: 30,
+            bat_critical: 15,
+            format: "{name} {bat_icon}{bat_charge} {notif_icon}{notif_count}".to_string(),
+            format_disconnected: "{name}".to_string(),
+        }
     }
 }
 

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -26,49 +26,32 @@ pub struct Load {
     minimum_critical: f64,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct LoadConfig {
-    #[serde(default = "LoadConfig::default_format")]
     pub format: String,
-    #[serde(
-        default = "LoadConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Minimum load, where state is set to info
-    #[serde(default = "LoadConfig::default_info")]
     pub info: f64,
 
     /// Minimum load, where state is set to warning
-    #[serde(default = "LoadConfig::default_warning")]
     pub warning: f64,
 
     /// Minimum load, where state is set to critical
-    #[serde(default = "LoadConfig::default_critical")]
     pub critical: f64,
 }
 
-impl LoadConfig {
-    fn default_format() -> String {
-        "{1m}".to_owned()
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(5)
-    }
-
-    fn default_info() -> f64 {
-        0.3
-    }
-
-    fn default_warning() -> f64 {
-        0.6
-    }
-
-    fn default_critical() -> f64 {
-        0.9
+impl Default for LoadConfig {
+    fn default() -> Self {
+        Self {
+            format: "{1m}".to_string(),
+            interval: Duration::from_secs(5),
+            info: 0.3,
+            warning: 0.6,
+            critical: 0.9,
+        }
     }
 }
 

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -30,12 +30,6 @@ impl MailType {
     }
 }
 
-impl Default for MailType {
-    fn default() -> MailType {
-        MailType::New
-    }
-}
-
 pub struct Maildir {
     id: usize,
     text: TextWidget,
@@ -46,38 +40,30 @@ pub struct Maildir {
     display_type: MailType,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+//TODO add `format`
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct MaildirConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "MaildirConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
     pub inboxes: Vec<String>,
-    #[serde(default = "MaildirConfig::default_threshold_warning")]
     pub threshold_warning: usize,
-    #[serde(default = "MaildirConfig::default_threshold_critical")]
     pub threshold_critical: usize,
-    #[serde(default)]
     pub display_type: MailType,
-    #[serde(default = "MaildirConfig::default_icon")]
     pub icon: bool,
 }
 
-impl MaildirConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(5)
-    }
-    fn default_threshold_warning() -> usize {
-        1
-    }
-    fn default_threshold_critical() -> usize {
-        10
-    }
-    fn default_icon() -> bool {
-        true
+impl Default for MaildirConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(5),
+            inboxes: Vec::new(),
+            threshold_warning: 1,
+            threshold_critical: 10,
+            display_type: MailType::New,
+            icon: true,
+        }
     }
 }
 

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -109,90 +109,54 @@ pub struct Memory {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct MemoryConfig {
     /// Format string for Memory view. All format values are described below.
-    #[serde(default = "MemoryConfig::default_format_mem")]
     pub format_mem: String,
 
     /// Format string for Swap view.
-    #[serde(default = "MemoryConfig::default_format_swap")]
     pub format_swap: String,
 
     /// Default view displayed on startup. Options are <br/> memory, swap
-    #[serde(default = "MemoryConfig::default_display_type")]
     pub display_type: Memtype,
 
     /// Whether the format string should be prepended with Icons. Options are <br/> true, false
-    #[serde(default = "MemoryConfig::default_icons")]
     pub icons: bool,
 
     /// Whether the view should switch between memory and swap on click. Options are <br/> true, false
-    #[serde(default = "MemoryConfig::default_clickable")]
     pub clickable: bool,
 
     /// The delay in seconds between an update. If `clickable`, an update is triggered on click. Integer values only.
-    #[serde(
-        default = "MemoryConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Percentage of memory usage, where state is set to warning
-    #[serde(default = "MemoryConfig::default_warning_mem")]
     pub warning_mem: f64,
 
     /// Percentage of swap usage, where state is set to warning
-    #[serde(default = "MemoryConfig::default_warning_swap")]
     pub warning_swap: f64,
 
     /// Percentage of memory usage, where state is set to critical
-    #[serde(default = "MemoryConfig::default_critical_mem")]
     pub critical_mem: f64,
 
     /// Percentage of swap usage, where state is set to critical
-    #[serde(default = "MemoryConfig::default_critical_swap")]
     pub critical_swap: f64,
 }
 
-impl MemoryConfig {
-    fn default_format_mem() -> String {
-        "{mem_free;M}/{mem_total;M}({mem_total_used_percents})".to_owned()
-    }
-
-    fn default_format_swap() -> String {
-        "{swap_free;M}/{swap_total;M}({swap_used_percents})".to_owned()
-    }
-
-    fn default_display_type() -> Memtype {
-        Memtype::Memory
-    }
-
-    fn default_icons() -> bool {
-        true
-    }
-
-    fn default_clickable() -> bool {
-        true
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(5)
-    }
-
-    fn default_warning_mem() -> f64 {
-        80.0
-    }
-
-    fn default_warning_swap() -> f64 {
-        80.0
-    }
-
-    fn default_critical_mem() -> f64 {
-        95.0
-    }
-
-    fn default_critical_swap() -> f64 {
-        95.0
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            format_mem: "{mem_free;M}/{mem_total;M}({mem_total_used_percents})".to_string(),
+            format_swap: "{swap_free;M}/{swap_total;M}({swap_used_percents})".to_string(),
+            display_type: Memtype::Memory,
+            icons: true,
+            clickable: true,
+            interval: Duration::from_secs(5),
+            warning_mem: 80.,
+            warning_swap: 80.,
+            critical_mem: 95.,
+            critical_swap: 95.,
+        }
     }
 }
 

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -151,8 +151,8 @@ impl Music {
     }
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct MusicConfig {
     /// Name of the music player. Must be the same name the player is
     /// registered with the MediaPlayer2 Interface. If not specified then
@@ -160,119 +160,69 @@ pub struct MusicConfig {
     pub player: Option<String>,
 
     /// Max width of the block in characters, not including the buttons.
-    #[serde(default = "MusicConfig::default_max_width")]
     pub max_width: usize,
 
     /// Bool to specify whether the block will change width depending on the
     /// text content or remain static always (= max_width)
-    #[serde(default = "MusicConfig::default_dynamic_width")]
     pub dynamic_width: bool,
 
     /// Bool to specify if a marquee style rotation should be used if the
     /// title + artist is longer than max-width
-    #[serde(default = "MusicConfig::default_marquee")]
     pub marquee: bool,
 
     /// Marquee interval in seconds. This is the delay between each rotation.
-    #[serde(
-        default = "MusicConfig::default_marquee_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub marquee_interval: Duration,
 
     /// Marquee speed in seconds. This is the scrolling time used per character.
-    #[serde(
-        default = "MusicConfig::default_marquee_speed",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub marquee_speed: Duration,
 
     /// Bool to specify whether smart trimming should be used when marquee
     /// rotation is disabled and the title + artist is longer than
     /// max-width. It will trim from both the artist and the title in proportion
     /// to their lengths, to try and show the most information possible.
-    #[serde(default = "MusicConfig::default_smart_trim")]
     pub smart_trim: bool,
 
     /// Separator to use between artist and title.
-    #[serde(default = "MusicConfig::default_separator")]
     pub separator: String,
 
     /// Array of control buttons to be displayed. Options are prev (previous title),
     /// play (play/pause) and next (next title).
-    #[serde(default = "MusicConfig::default_buttons")]
     pub buttons: Vec<String>,
 
-    #[serde(default = "MusicConfig::default_on_collapsed_click")]
     pub on_collapsed_click: Option<String>,
 
     // Number of microseconds to seek forward/backward when scrolling on the bar.
-    #[serde(default = "MusicConfig::default_seek_step")]
     pub seek_step: i64,
 
     /// MPRIS interface name regex patterns to ignore.
-    #[serde(default = "MusicConfig::default_interface_name_exclude_patterns")]
     pub interface_name_exclude: Vec<String>,
 
-    #[serde(default = "MusicConfig::default_hide_when_empty")]
     pub hide_when_empty: bool,
 
     /// Format string for displaying music player info.
-    #[serde(default = "MusicConfig::default_format")]
     pub format: String,
 }
 
-impl MusicConfig {
-    fn default_max_width() -> usize {
-        21
-    }
-
-    fn default_dynamic_width() -> bool {
-        false
-    }
-
-    fn default_marquee() -> bool {
-        true
-    }
-
-    fn default_marquee_interval() -> Duration {
-        Duration::from_secs(10)
-    }
-
-    fn default_marquee_speed() -> Duration {
-        Duration::from_millis(500)
-    }
-
-    fn default_smart_trim() -> bool {
-        false
-    }
-
-    fn default_separator() -> String {
-        " - ".to_string()
-    }
-
-    fn default_buttons() -> Vec<String> {
-        vec![]
-    }
-
-    fn default_on_collapsed_click() -> Option<String> {
-        None
-    }
-
-    fn default_seek_step() -> i64 {
-        1000
-    }
-
-    fn default_interface_name_exclude_patterns() -> Vec<String> {
-        vec![]
-    }
-
-    fn default_hide_when_empty() -> bool {
-        false
-    }
-
-    fn default_format() -> String {
-        "{combo}".to_string()
+impl Default for MusicConfig {
+    fn default() -> Self {
+        Self {
+            player: None,
+            max_width: 21,
+            dynamic_width: false,
+            marquee: true,
+            marquee_interval: Duration::from_secs(10),
+            marquee_speed: Duration::from_millis(500),
+            smart_trim: false,
+            separator: " - ".to_string(),
+            buttons: Vec::new(),
+            on_collapsed_click: None,
+            seek_step: 1000,
+            interface_name_exclude: Vec::new(),
+            hide_when_empty: false,
+            format: "{combo}".to_string(),
+        }
     }
 }
 

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -385,53 +385,37 @@ impl fmt::Display for Unit {
     }
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct NetConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "NetConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
-    #[serde(default = "NetConfig::default_format")]
     pub format: String,
 
-    #[serde(default = "NetConfig::default_format_alt")]
     pub format_alt: Option<String>,
 
     /// Which interface in /sys/class/net/ to read from.
     pub device: Option<String>,
 
     /// Whether to hide networks that are down/inactive completely.
-    #[serde(default = "NetConfig::default_hide_inactive")]
     pub hide_inactive: bool,
 
     /// Whether to hide networks that are missing.
-    #[serde(default = "NetConfig::default_hide_missing")]
     pub hide_missing: bool,
 }
 
-impl NetConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(1)
-    }
-
-    fn default_format() -> String {
-        "{speed_up;K} {speed_down;K}".to_owned()
-    }
-
-    fn default_format_alt() -> Option<String> {
-        None
-    }
-
-    fn default_hide_inactive() -> bool {
-        false
-    }
-
-    fn default_hide_missing() -> bool {
-        false
+impl Default for NetConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(1),
+            format: "{speed_up;K} {speed_down;K}".to_string(),
+            format_alt: None,
+            device: None,
+            hide_inactive: false,
+            hide_missing: false,
+        }
     }
 }
 

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -471,57 +471,38 @@ pub struct NetworkManager {
     shared_config: SharedConfig,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct NetworkManagerConfig {
     /// Whether to only show the primary connection, or all active connections.
-    #[serde(default = "NetworkManagerConfig::default_primary_only")]
     pub primary_only: bool,
 
     /// AP formatter
-    #[serde(default = "NetworkManagerConfig::default_ap_format")]
     pub ap_format: String,
 
     /// Device formatter.
-    #[serde(default = "NetworkManagerConfig::default_device_format")]
     pub device_format: String,
 
     /// Connection formatter.
-    #[serde(default = "NetworkManagerConfig::default_connection_format")]
     pub connection_format: String,
 
     /// Interface name regex patterns to include.
-    #[serde(default = "NetworkManagerConfig::default_interface_name_include_patterns")]
     pub interface_name_exclude: Vec<String>,
 
     /// Interface name regex patterns to ignore.
-    #[serde(default = "NetworkManagerConfig::default_interface_name_exclude_patterns")]
     pub interface_name_include: Vec<String>,
 }
 
-impl NetworkManagerConfig {
-    fn default_primary_only() -> bool {
-        false
-    }
-
-    fn default_ap_format() -> String {
-        "{ssid}".to_string()
-    }
-
-    fn default_device_format() -> String {
-        "{icon}{ap} {ips}".to_string()
-    }
-
-    fn default_connection_format() -> String {
-        "{devices}".to_string()
-    }
-
-    fn default_interface_name_include_patterns() -> Vec<String> {
-        vec![]
-    }
-
-    fn default_interface_name_exclude_patterns() -> Vec<String> {
-        vec![]
+impl Default for NetworkManagerConfig {
+    fn default() -> Self {
+        Self {
+            primary_only: false,
+            ap_format: "{ssid}".to_string(),
+            device_format: "{icon}{ap} {ips}".to_string(),
+            connection_format: "{devices}".to_string(),
+            interface_name_exclude: Vec::new(),
+            interface_name_include: Vec::new(),
+        }
     }
 }
 

--- a/src/blocks/notify.rs
+++ b/src/blocks/notify.rs
@@ -29,18 +29,19 @@ pub struct Notify {
     output: TextWidget,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct NotifyConfig {
     /// Format string which describes the output of this block.
-    #[serde(default = "NotifyConfig::default_format")]
     pub format: String,
 }
 
-impl NotifyConfig {
-    fn default_format() -> String {
-        // display just the bell icon
-        "".into()
+impl Default for NotifyConfig {
+    fn default() -> Self {
+        Self {
+            // display just the bell icon
+            format: "".into(),
+        }
     }
 }
 

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -26,74 +26,42 @@ pub struct Notmuch {
     name: Option<String>,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct NotmuchConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "NotmuchConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
-    #[serde(default = "NotmuchConfig::default_maildir")]
     pub maildir: String,
-    #[serde(default = "NotmuchConfig::default_query")]
     pub query: String,
-    #[serde(default = "NotmuchConfig::default_threshold_warning")]
     pub threshold_warning: u32,
-    #[serde(default = "NotmuchConfig::default_threshold_critical")]
     pub threshold_critical: u32,
-    #[serde(default = "NotmuchConfig::default_threshold_info")]
     pub threshold_info: u32,
-    #[serde(default = "NotmuchConfig::default_threshold_good")]
     pub threshold_good: u32,
-    #[serde(default = "NotmuchConfig::default_name")]
     pub name: Option<String>,
-    #[serde(default = "NotmuchConfig::default_no_icon")]
     pub no_icon: bool,
 }
 
-impl NotmuchConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(10)
-    }
-
-    fn default_maildir() -> String {
+impl Default for NotmuchConfig {
+    fn default() -> Self {
         #[allow(deprecated)]
         let home_dir = match env::home_dir() {
             Some(path) => path.into_os_string().into_string().unwrap(),
             None => "".to_owned(),
         };
+        let maildir = format!("{}/.mail", home_dir);
 
-        format!("{}/.mail", home_dir)
-    }
-
-    fn default_query() -> String {
-        "".to_owned()
-    }
-
-    fn default_threshold_info() -> u32 {
-        <u32>::max_value()
-    }
-
-    fn default_threshold_good() -> u32 {
-        <u32>::max_value()
-    }
-
-    fn default_threshold_warning() -> u32 {
-        <u32>::max_value()
-    }
-
-    fn default_threshold_critical() -> u32 {
-        <u32>::max_value()
-    }
-
-    fn default_name() -> Option<String> {
-        None
-    }
-
-    fn default_no_icon() -> bool {
-        false
+        Self {
+            interval: Duration::from_secs(10),
+            maildir,
+            query: "".to_string(),
+            threshold_warning: std::u32::MAX,
+            threshold_critical: std::u32::MAX,
+            threshold_info: std::u32::MAX,
+            threshold_good: std::u32::MAX,
+            name: None,
+            no_icon: false,
+        }
     }
 }
 

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -56,108 +56,64 @@ enum NameWidgetMode {
     ShowLabel,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+// TODO add `format` option
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct NvidiaGpuConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "NvidiaGpuConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Label to show instead of the default GPU name from `nvidia-smi`
-    #[serde(default = "NvidiaGpuConfig::default_label")]
     pub label: Option<String>,
 
     /// GPU id in system
-    #[serde(default = "NvidiaGpuConfig::default_gpu_id")]
     pub gpu_id: u64,
 
     /// GPU utilization. In percent.
-    #[serde(default = "NvidiaGpuConfig::default_show_utilization")]
     pub show_utilization: bool,
 
     /// VRAM utilization.
-    #[serde(default = "NvidiaGpuConfig::default_show_memory")]
     pub show_memory: bool,
 
     /// Core GPU temperature. In degrees C.
-    #[serde(default = "NvidiaGpuConfig::default_show_temperature")]
     pub show_temperature: bool,
 
     /// Fan speed. In percents.
-    #[serde(default = "NvidiaGpuConfig::default_show_fan_speed")]
     pub show_fan_speed: bool,
 
     /// GPU clocks. In percents.
-    #[serde(default = "NvidiaGpuConfig::default_show_clocks")]
     pub show_clocks: bool,
 
     /// Maximum temperature, below which state is set to idle
-    #[serde(default = "NvidiaGpuConfig::default_idle")]
     pub idle: u64,
 
     /// Maximum temperature, below which state is set to good
-    #[serde(default = "NvidiaGpuConfig::default_good")]
     pub good: u64,
 
     /// Maximum temperature, below which state is set to info
-    #[serde(default = "NvidiaGpuConfig::default_info")]
     pub info: u64,
 
     /// Maximum temperature, below which state is set to warning
-    #[serde(default = "NvidiaGpuConfig::default_warning")]
     pub warning: u64,
 }
 
-impl NvidiaGpuConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(3)
-    }
-
-    fn default_label() -> Option<String> {
-        None
-    }
-
-    fn default_gpu_id() -> u64 {
-        0
-    }
-
-    fn default_show_utilization() -> bool {
-        true
-    }
-
-    fn default_show_memory() -> bool {
-        true
-    }
-
-    fn default_show_temperature() -> bool {
-        true
-    }
-
-    fn default_show_fan_speed() -> bool {
-        false
-    }
-
-    fn default_show_clocks() -> bool {
-        false
-    }
-
-    fn default_idle() -> u64 {
-        50
-    }
-
-    fn default_good() -> u64 {
-        70
-    }
-
-    fn default_info() -> u64 {
-        75
-    }
-
-    fn default_warning() -> u64 {
-        80
+impl Default for NvidiaGpuConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(3),
+            label: None,
+            gpu_id: 0,
+            show_utilization: true,
+            show_memory: true,
+            show_temperature: true,
+            show_fan_speed: false,
+            show_clocks: false,
+            idle: 50,
+            good: 70,
+            info: 75,
+            warning: 80,
+        }
     }
 }
 

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -46,64 +46,53 @@ pub enum Watched {
     Both(String),
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct PacmanConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "PacmanConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Format override
-    #[serde(default = "PacmanConfig::default_format")]
     pub format: String,
 
     /// Alternative format override for when exactly 1 update is available
-    #[serde(default = "PacmanConfig::default_format")]
     pub format_singular: String,
 
     /// Alternative format override for when no updates are available
-    #[serde(default = "PacmanConfig::default_format")]
     pub format_up_to_date: String,
 
     /// Indicate a `warning` state for the block if any pending update match the
     /// following regex. Default behaviour is that no package updates are deemed
     /// warning
-    #[serde(default = "PacmanConfig::default_warning_updates_regex")]
     pub warning_updates_regex: Option<String>,
 
     /// Indicate a `critical` state for the block if any pending update match the following regex.
     /// Default behaviour is that no package updates are deemed critical
-    #[serde(default = "PacmanConfig::default_critical_updates_regex")]
     pub critical_updates_regex: Option<String>,
 
     /// Optional AUR command, listing available updates
-    #[serde()]
     pub aur_command: Option<String>,
 
-    #[serde(default = "PacmanConfig::default_hide_when_uptodate")]
     pub hide_when_uptodate: bool,
 }
 
+impl Default for PacmanConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(600),
+            format: "{pacman}".to_string(),
+            format_singular: "{pacman}".to_string(),
+            format_up_to_date: "{pacman}".to_string(),
+            warning_updates_regex: None,
+            critical_updates_regex: None,
+            aur_command: None,
+            hide_when_uptodate: false,
+        }
+    }
+}
+
 impl PacmanConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(60 * 10)
-    }
-
-    fn default_format() -> String {
-        "{pacman}".to_owned()
-    }
-
-    fn default_warning_updates_regex() -> Option<String> {
-        None
-    }
-
-    fn default_critical_updates_regex() -> Option<String> {
-        None
-    }
-
     fn watched(
         format: &str,
         format_singular: &str,
@@ -136,10 +125,6 @@ impl PacmanConfig {
         } else {
             Ok(Watched::None)
         }
-    }
-
-    fn default_hide_when_uptodate() -> bool {
-        false
     }
 }
 

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -86,46 +86,27 @@ impl Pomodoro {
     }
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct PomodoroConfig {
-    #[serde(default = "PomodoroConfig::default_length")]
     pub length: u64,
-    #[serde(default = "PomodoroConfig::default_break_length")]
     pub break_length: u64,
-    #[serde(default = "PomodoroConfig::default_message")]
     pub message: String,
-    #[serde(default = "PomodoroConfig::default_break_message")]
     pub break_message: String,
-    #[serde(default = "PomodoroConfig::default_use_nag")]
     pub use_nag: bool,
-    #[serde(default = "PomodoroConfig::default_nag_path")]
     pub nag_path: std::path::PathBuf,
 }
 
-impl PomodoroConfig {
-    fn default_length() -> u64 {
-        25
-    }
-
-    fn default_break_length() -> u64 {
-        5
-    }
-
-    fn default_message() -> String {
-        "Pomodoro over! Take a break!".to_owned()
-    }
-
-    fn default_break_message() -> String {
-        "Break over! Time to work!".to_owned()
-    }
-
-    fn default_use_nag() -> bool {
-        false
-    }
-
-    fn default_nag_path() -> std::path::PathBuf {
-        std::path::PathBuf::from("i3-nagbar")
+impl Default for PomodoroConfig {
+    fn default() -> Self {
+        Self {
+            length: 25,
+            break_length: 5,
+            message: "Pomodoro over! Take a break!".to_string(),
+            break_message: "Break over! Time to work!".to_string(),
+            use_nag: false,
+            nag_path: std::path::PathBuf::from("i3-nagbar"),
+        }
     }
 }
 

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -734,49 +734,6 @@ impl Default for DeviceKind {
     }
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct SoundConfig {
-    /// ALSA / PulseAudio sound device name
-    #[serde(default)]
-    pub driver: SoundDriver,
-
-    /// PulseAudio device name, or
-    /// ALSA control name as listed in the output of `amixer -D yourdevice scontrols` (default is "Master")
-    #[serde(default = "SoundConfig::default_name")]
-    pub name: Option<String>,
-
-    /// ALSA device name, usually in the form "hw:#" where # is the number of the card desired (default is "default")
-    #[serde(default = "SoundConfig::default_device")]
-    pub device: Option<String>,
-
-    /// Type of device: sink or source (default is "sink")
-    #[serde(default)]
-    pub device_kind: DeviceKind,
-
-    /// Use the mapped volume for evaluating the percentage representation like alsamixer, to be more natural for human ear
-    #[serde(default = "SoundConfig::default_natural_mapping")]
-    pub natural_mapping: bool,
-
-    /// The steps volume is in/decreased for the selected audio device (When greater than 50 it gets limited to 50)
-    #[serde(default = "SoundConfig::default_step_width")]
-    pub step_width: u32,
-
-    /// Format string for displaying sound information.
-    /// placeholders: {volume}
-    #[serde(default = "SoundConfig::default_format")]
-    pub format: String,
-
-    #[serde(default = "SoundConfig::default_show_volume_when_muted")]
-    pub show_volume_when_muted: bool,
-
-    #[serde(default = "SoundConfig::default_mappings")]
-    pub mappings: Option<BTreeMap<String, String>>,
-
-    #[serde(default = "SoundConfig::default_max_vol")]
-    pub max_vol: Option<u32>,
-}
-
 #[derive(Deserialize, Copy, Clone, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum SoundDriver {
@@ -792,37 +749,53 @@ impl Default for SoundDriver {
     }
 }
 
-impl SoundConfig {
-    fn default_name() -> Option<String> {
-        None
-    }
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
+pub struct SoundConfig {
+    /// ALSA / PulseAudio sound device name
+    pub driver: SoundDriver,
 
-    fn default_device() -> Option<String> {
-        None
-    }
+    /// PulseAudio device name, or
+    /// ALSA control name as listed in the output of `amixer -D yourdevice scontrols` (default is "Master")
+    pub name: Option<String>,
 
-    fn default_natural_mapping() -> bool {
-        false
-    }
+    /// ALSA device name, usually in the form "hw:#" where # is the number of the card desired (default is "default")
+    pub device: Option<String>,
 
-    fn default_step_width() -> u32 {
-        5
-    }
+    /// Type of device: sink or source (default is "sink")
+    pub device_kind: DeviceKind,
 
-    fn default_format() -> String {
-        "{volume:2}".into()
-    }
+    /// Use the mapped volume for evaluating the percentage representation like alsamixer, to be more natural for human ear
+    pub natural_mapping: bool,
 
-    fn default_show_volume_when_muted() -> bool {
-        false
-    }
+    /// The steps volume is in/decreased for the selected audio device (When greater than 50 it gets limited to 50)
+    pub step_width: u32,
 
-    fn default_mappings() -> Option<BTreeMap<String, String>> {
-        None
-    }
+    /// Format string for displaying sound information.
+    /// placeholders: {volume}
+    pub format: String,
 
-    fn default_max_vol() -> Option<u32> {
-        None
+    pub show_volume_when_muted: bool,
+
+    pub mappings: Option<BTreeMap<String, String>>,
+
+    pub max_vol: Option<u32>,
+}
+
+impl Default for SoundConfig {
+    fn default() -> Self {
+        Self {
+            driver: Default::default(),
+            name: None,
+            device: None,
+            device_kind: Default::default(),
+            natural_mapping: false,
+            step_width: 5,
+            format: "{volume}".to_string(),
+            show_volume_when_muted: false,
+            mappings: None,
+            max_vol: None,
+        }
     }
 }
 

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -30,28 +30,23 @@ pub struct SpeedTest {
     send: Sender<()>,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct SpeedTestConfig {
     /// Format override
-    #[serde(default = "SpeedTestConfig::default_format")]
     pub format: String,
 
     /// Update interval in seconds
-    #[serde(
-        default = "SpeedTestConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 }
 
-impl SpeedTestConfig {
-    fn default_format() -> String {
-        "{ping}{speed_down}{speed_up}".to_string()
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(1800)
+impl Default for SpeedTestConfig {
+    fn default() -> Self {
+        Self {
+            format: "{ping}{speed_down}{speed_up}".to_string(),
+            interval: Duration::from_secs(1800),
+        }
     }
 }
 

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -46,18 +46,14 @@ pub struct Temperature {
     fallback_required: bool,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct TemperatureConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "TemperatureConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Collapsed by default?
-    #[serde(default = "TemperatureConfig::default_collapsed")]
     pub collapsed: bool,
 
     /// The temperature scale to use for display and thresholds
@@ -81,37 +77,29 @@ pub struct TemperatureConfig {
     pub warning: Option<i64>,
 
     /// Format override
-    #[serde(default = "TemperatureConfig::default_format")]
     pub format: String,
 
     /// Chip override
-    #[serde(default = "TemperatureConfig::default_chip")]
     pub chip: Option<String>,
 
     /// Inputs whitelist
-    #[serde(default = "TemperatureConfig::default_inputs")]
     pub inputs: Option<Vec<String>>,
 }
 
-impl TemperatureConfig {
-    fn default_format() -> String {
-        "{average} avg, {max} max".to_owned()
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(5)
-    }
-
-    fn default_collapsed() -> bool {
-        true
-    }
-
-    fn default_chip() -> Option<String> {
-        None
-    }
-
-    fn default_inputs() -> Option<Vec<String>> {
-        None
+impl Default for TemperatureConfig {
+    fn default() -> Self {
+        Self {
+            format: "{average} avg, {max} max".to_string(),
+            interval: Duration::from_secs(5),
+            collapsed: true,
+            scale: TemperatureScale::default(),
+            good: None,
+            idle: None,
+            info: None,
+            warning: None,
+            chip: None,
+            inputs: None,
+        }
     }
 }
 

--- a/src/blocks/template.rs
+++ b/src/blocks/template.rs
@@ -24,20 +24,19 @@ pub struct Template {
     tx_update_request: Sender<Task>,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct TemplateConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "TemplateConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 }
 
-impl TemplateConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(5)
+impl Default for TemplateConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(5),
+        }
     }
 }
 

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -26,42 +26,31 @@ pub struct Time {
     locale: Option<String>,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct TimeConfig {
-    /// Format string.<br/> See [chrono docs](https://docs.rs/chrono/0.3.0/chrono/format/strftime/index.html#specifiers) for all options.
-    #[serde(default = "TimeConfig::default_format")]
+    /// Format string.
+    ///
+    /// See [chrono docs](https://docs.rs/chrono/0.3.0/chrono/format/strftime/index.html#specifiers) for all options.
     pub format: String,
 
     /// Update interval in seconds
-    #[serde(
-        default = "TimeConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
-    #[serde(default = "TimeConfig::default_timezone")]
     pub timezone: Option<Tz>,
 
-    #[serde(default = "TimeConfig::default_locale")]
     pub locale: Option<String>,
 }
 
-impl TimeConfig {
-    fn default_format() -> String {
-        "%a %d/%m %R".to_owned()
-    }
-
-    fn default_interval() -> Duration {
-        Duration::from_secs(5)
-    }
-
-    fn default_timezone() -> Option<Tz> {
-        None
-    }
-
-    fn default_locale() -> Option<String> {
-        None
+impl Default for TimeConfig {
+    fn default() -> Self {
+        Self {
+            format: "%a %d/%m %R".to_string(),
+            interval: Duration::from_secs(5),
+            timezone: None,
+            locale: None,
+        }
     }
 }
 

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -19,20 +19,19 @@ pub struct Uptime {
     update_interval: Duration,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct UptimeConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "UptimeConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 }
 
-impl UptimeConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(60)
+impl Default for UptimeConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(60),
+        }
     }
 }
 

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -29,34 +29,29 @@ pub struct Watson {
     update_interval: Duration,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct WatsonConfig {
     /// Path to state of watson
-    #[serde(default = "WatsonConfig::default_state_path")]
     pub state_path: PathBuf,
+
     /// Update interval in seconds
-    #[serde(
-        default = "WatsonConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
+
     /// Show time spent
-    #[serde(default = "WatsonConfig::default_show_time")]
     pub show_time: bool,
 }
 
-impl WatsonConfig {
-    fn default_state_path() -> PathBuf {
+impl Default for WatsonConfig {
+    fn default() -> Self {
         let mut config_dir = xdg_config_home();
         config_dir.push("watson/state");
-        config_dir
-    }
-    fn default_interval() -> Duration {
-        Duration::from_secs(60)
-    }
-    fn default_show_time() -> bool {
-        false
+        Self {
+            state_path: config_dir,
+            interval: Duration::from_secs(60),
+            show_time: false,
+        }
     }
 }
 

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -60,44 +60,32 @@ pub struct Xrandr {
     shared_config: SharedConfig,
 }
 
-#[derive(Deserialize, Debug, Default, Clone)]
-#[serde(deny_unknown_fields)]
+// TODO add `format`
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
 pub struct XrandrConfig {
     /// Update interval in seconds
-    #[serde(
-        default = "XrandrConfig::default_interval",
-        deserialize_with = "deserialize_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
     /// Show icons for brightness and resolution (needs awesome fonts support)
-    #[serde(default = "XrandrConfig::default_icons")]
     pub icons: bool,
 
     /// Shows the screens resolution
-    #[serde(default = "XrandrConfig::default_resolution")]
     pub resolution: bool,
 
     /// The steps brightness is in/decreased for the selected screen (When greater than 50 it gets limited to 50)
-    #[serde(default = "XrandrConfig::default_step_width")]
     pub step_width: u32,
 }
 
-impl XrandrConfig {
-    fn default_interval() -> Duration {
-        Duration::from_secs(5)
-    }
-
-    fn default_icons() -> bool {
-        true
-    }
-
-    fn default_resolution() -> bool {
-        false
-    }
-
-    fn default_step_width() -> u32 {
-        5
+impl Default for XrandrConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(5),
+            icons: true,
+            resolution: false,
+            step_width: 5,
+        }
     }
 }
 


### PR DESCRIPTION
`impl Default` for blocks' configs instead of setting default value for each field separately.

It is just a little cleaner, behavior should not have been changed.