### PR TITLE
Include "Power Draw" option for Nvidia GPU block

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -1182,6 +1182,7 @@ Key | Values | Required | Default
 `show_temperature` | Display GPU temperature. | No | `true`
 `show_fan_speed` | Display fan speed. | No | `false`
 `show_clocks` | Display gpu clocks. | No | `false`
+`show_power_draw` | Display GPU power draw in watts. | No | `false`
 
 ###### [↥ back to top](#list-of-available-blocks)
 


### PR DESCRIPTION
I am interesting in monitoring my GPU's power usage at a glance
so I added this quick feature.

I had initially added this to the `v0.14.7` branch/tag but decided on
master as it seemed like that was where other efforts were being
focused.

If you're not interested in this change, or would like to see more
(I know I didn't add any tests, let me know if that is a dealbreaker)
let me know. Thanks! (I'm not sure if the manual pages are
auto-generated from the comments/code; that is another area
where I could have very easily missed something necessary)

Screenshot of this working on my branch with the no theme nor
icons specified:

![2021-04-03-16-13-28_448x29](https://user-images.githubusercontent.com/1027952/113490934-439aeb00-949b-11eb-80a8-63dfc00a7155.png)

This fits in with the existing `nvidia-smi` invocation.

I fit this at end of the Nvidia block, as it seemed visually appealing
there (this did mean some `count++` and `.clone()` lines in the
previously-trailing option, hopefully it makes sense and is easy to
follow).

I was not able to find the exact name `power.draw` from the `nvidia-smi`
manual page, but from this site:

https://briot-jerome.developpez.com/fichiers/blog/nvidia-smi/list.txt

I found the following line that the author has documented as:

```
"power.draw"
The last measured power draw for the entire board, in watts. Only available if power management is supported. This reading is accurate to within +/- 5 watts.
```

I was able to run with this query option on my machine, as seen here:

```
 $ nvidia-smi -i 0 --query-gpu="name,memory.used,memory.total,utilization.gpu,temperature.gpu,fan.speed,clocks.current.graphics,power.draw" --format=csv,noheader
GeForce GTX 980 Ti, 836 MiB, 6080 MiB, 21 %, 62, 7 %, 683 MHz, 40.47 W
```

or more simplified:

```
 $ nvidia-smi -i 0 --query-gpu="power.draw" --format=csv,noheader
40.47 W
```

```
 $ nvidia-smi -i 0 --query-gpu="power.draw" --format=csv,noheader,nounits
40.67
```