### PR TITLE
widgets/rotatingtext: never provide `min_width` for dynamic width

### DIFF
--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -163,11 +163,8 @@ impl RotatingTextWidget {
                 _ => String::from(" "),
             }
         );
-        self.inner.min_width = if self.content.is_empty() {
-            None
-        } else {
-            let text_width = self.get_rotated_content().chars().count();
-            if self.dynamic_width && text_width < self.max_width {
+        self.inner.min_width = {
+            if self.dynamic_width || self.content.is_empty() {
                 None
             } else {
                 icon.push_str(&"0".repeat(self.max_width + 1));


### PR DESCRIPTION
This field was only filled when not necessary (ie. when `text_width >= max_width`) with `dynamic_width` set to `true` but would potentially add a padding when not using a fixed sized font.

I personally encountered this issue while using the music block.