### PR TITLE
Block update changed to right click

### DIFF
--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -223,7 +223,7 @@ impl Block for Apt {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.button == MouseButton::Left {
+        if event.button == MouseButton::Right {
             self.update()?;
         }
         Ok(())

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -634,7 +634,7 @@ impl Block for Net {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.button == MouseButton::Left {
+        if event.button == MouseButton::Right {
             if let Some(ref mut format) = self.format_alt {
                 std::mem::swap(format, &mut self.format);
             }

--- a/src/blocks/notify.rs
+++ b/src/blocks/notify.rs
@@ -144,7 +144,7 @@ impl Block for Notify {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if let MouseButton::Left = e.button {
+        if let MouseButton::Right = e.button {
             let c = Connection::get_private(BusType::Session).block_error(
                 "notify",
                 &"Failed to establish D-Bus connection".to_string(),

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -140,7 +140,7 @@ impl Block for Notmuch {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if event.button == MouseButton::Left {
+        if event.button == MouseButton::Right {
             self.update()?;
         }
 

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -359,7 +359,7 @@ impl Block for NvidiaGpu {
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
         if let Some(event_id) = e.instance {
             if event_id == self.id {
-                if let MouseButton::Left = e.button {
+                if let MouseButton::Right = e.button {
                     match self.name_widget_mode {
                         NameWidgetMode::ShowDefaultName => {
                             self.name_widget_mode = NameWidgetMode::ShowLabel
@@ -373,7 +373,7 @@ impl Block for NvidiaGpu {
             }
 
             if event_id == self.id_memory {
-                if let MouseButton::Left = e.button {
+                if let MouseButton::Right = e.button {
                     match self.memory_widget_mode {
                         MemoryWidgetMode::ShowUsedMemory => {
                             self.memory_widget_mode = MemoryWidgetMode::ShowTotalMemory

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -402,7 +402,7 @@ impl Block for Pacman {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if let MouseButton::Left = event.button {
+        if let MouseButton::Right = event.button {
             self.update()?;
         }
 

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -194,7 +194,7 @@ impl Block for SpeedTest {
     }
 
     fn click(&mut self, e: &I3BarEvent) -> Result<()> {
-        if let MouseButton::Left = e.button {
+        if let MouseButton::Right = e.button {
             self.send.send(())?;
         }
         Ok(())

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -379,7 +379,7 @@ impl Block for Weather {
     }
 
     fn click(&mut self, event: &I3BarEvent) -> Result<()> {
-        if let MouseButton::Left = event.button {
+        if let MouseButton::Right = event.button {
             self.update()?;
         }
         Ok(())


### PR DESCRIPTION
Initially, I just wanted to change the apt block to use right click to update instead of left because left click is used for the `on_click` property. However, I realised there are a few blocks that also have some sort of update function when left click is clicked, so I updated them accordingly.

In a nutshell, I just wanted to be able to have an extra bind (left click), whilst retaining the block's existing update functionality. This is particularly useful for blocks that tend to have long intervals like the apt block.