### PR TITLE
Add short_text support

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -1724,6 +1724,18 @@ command = "echo '<b>1 &amp;</b>'"
 
 # Formatting
 
+All blocks that have a `format` field can be reformatted by changing their format strings.
+
+The field can be set as a string (`format = "{my_format}"`) or as a section:
+```toml
+[[block]]
+block = "my_block"
+[block.format]
+full = "{my_full_format}"
+short = "{my_short_format}"
+```
+Your `i3` or `sway` will switch all blocks over to the `short` variant whenever there isn't enough space on your screen for the `full` status bar.
+
 ## Syntax
 
 The syntax for placeholders is

--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -39,13 +39,13 @@ pub struct AptConfig {
     pub interval: Duration,
 
     /// Format override
-    pub format: String,
+    pub format: FormatTemplate,
 
     /// Alternative format override for when exactly 1 update is available
-    pub format_singular: String,
+    pub format_singular: FormatTemplate,
 
     /// Alternative format override for when no updates are available
-    pub format_up_to_date: String,
+    pub format_up_to_date: FormatTemplate,
 
     /// Indicate a `warning` state for the block if any pending update match the
     /// following regex. Default behaviour is that no package updates are deemed
@@ -61,9 +61,9 @@ impl Default for AptConfig {
     fn default() -> Self {
         Self {
             interval: Duration::from_secs(600),
-            format: "{count:1}".to_string(),
-            format_singular: "{count:1}".to_string(),
-            format_up_to_date: "{count:1}".to_string(),
+            format: FormatTemplate::default(),
+            format_singular: FormatTemplate::default(),
+            format_up_to_date: FormatTemplate::default(),
             warning_updates_regex: None,
             critical_updates_regex: None,
         }
@@ -104,12 +104,9 @@ impl ConfigBlock for Apt {
         Ok(Apt {
             id,
             update_interval: block_config.interval,
-            format: FormatTemplate::from_string(&block_config.format)
-                .block_error("apt", "Invalid format specified for apt::format")?,
-            format_singular: FormatTemplate::from_string(&block_config.format_singular)
-                .block_error("apt", "Invalid format specified for apt::format_singular")?,
-            format_up_to_date: FormatTemplate::from_string(&block_config.format_up_to_date)
-                .block_error("apt", "Invalid format specified for apt::format_up_to_date")?,
+            format: block_config.format.with_default("{count:1}")?,
+            format_singular: block_config.format_singular.with_default("{count:1}")?,
+            format_up_to_date: block_config.format_up_to_date.with_default("{count:1}")?,
             output,
             warning_updates_regex: match block_config.warning_updates_regex {
                 None => None, // no regex configured
@@ -202,7 +199,7 @@ impl Block for Apt {
 
             (formatting_map, warning, critical, count)
         };
-        self.output.set_text(match cum_count {
+        self.output.set_texts(match cum_count {
             0 => self.format_up_to_date.render(&formatting_map)?,
             1 => self.format_singular.render(&formatting_map)?,
             _ => self.format.render(&formatting_map)?,

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -44,7 +44,7 @@ pub struct CpuConfig {
     pub critical: u64,
 
     /// Format override
-    pub format: String,
+    pub format: FormatTemplate,
 }
 
 impl Default for CpuConfig {
@@ -54,7 +54,7 @@ impl Default for CpuConfig {
             info: 30,
             warning: 60,
             critical: 90,
-            format: "{utilization}".to_string(),
+            format: FormatTemplate::default(),
         }
     }
 }
@@ -76,8 +76,7 @@ impl ConfigBlock for Cpu {
             minimum_info: block_config.info,
             minimum_warning: block_config.warning,
             minimum_critical: block_config.critical,
-            format: FormatTemplate::from_string(&block_config.format)
-                .block_error("cpu", "Invalid format specified for cpu")?,
+            format: block_config.format.with_default("{utilization}")?,
         })
     }
 }
@@ -193,7 +192,7 @@ impl Block for Cpu {
             );
         }
 
-        self.output.set_text(self.format.render(&values)?);
+        self.output.set_texts(self.format.render(&values)?);
 
         Ok(Some(self.update_interval.into()))
     }

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -53,7 +53,7 @@ pub struct DiskSpaceConfig {
     pub info_type: InfoType,
 
     /// Format string for output
-    pub format: String,
+    pub format: FormatTemplate,
 
     /// Unit that is used to display disk space. Options are B, KB, MB, GB and TB
     pub unit: String,
@@ -82,7 +82,7 @@ impl Default for DiskSpaceConfig {
         Self {
             path: "/".to_string(),
             info_type: InfoType::Available,
-            format: "{available}".to_string(),
+            format: FormatTemplate::default(),
             unit: "GB".to_string(),
             interval: Duration::from_secs(20),
             warning: 20.,
@@ -139,7 +139,7 @@ impl ConfigBlock for DiskSpace {
             update_interval: block_config.interval,
             disk_space: TextWidget::new(id, 0, shared_config),
             path: block_config.path,
-            format: FormatTemplate::from_string(&block_config.format)?,
+            format: block_config.format.with_default("{available}")?,
             info_type: block_config.info_type,
             unit: match block_config.unit.as_str() {
                 "TB" => Prefix::Tera,
@@ -203,7 +203,7 @@ impl Block for DiskSpace {
             //TODO remove
             "alias" => Value::from_string(self.alias.clone()),
         );
-        self.disk_space.set_text(self.format.render(&values)?);
+        self.disk_space.set_texts(self.format.render(&values)?);
 
         // Send percentage to alert check if we don't want absolute alerts
         let alert_val = if self.alert_absolute {

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -47,14 +47,14 @@ pub struct DockerConfig {
     pub interval: Duration,
 
     /// Format override
-    pub format: String,
+    pub format: FormatTemplate,
 }
 
 impl Default for DockerConfig {
     fn default() -> Self {
         Self {
             interval: Duration::from_secs(5),
-            format: "{running}".to_string(),
+            format: FormatTemplate::default(),
         }
     }
 }
@@ -74,8 +74,7 @@ impl ConfigBlock for Docker {
         Ok(Docker {
             id,
             text,
-            format: FormatTemplate::from_string(&block_config.format)
-                .block_error("docker", "Invalid format specified")?,
+            format: block_config.format.with_default("{running}")?,
             update_interval: block_config.interval,
         })
     }
@@ -102,7 +101,7 @@ impl Block for Docker {
             "images" =>  Value::from_integer(status.images),
         );
 
-        self.text.set_text(self.format.render(&values)?);
+        self.text.set_texts(self.format.render(&values)?);
 
         Ok(Some(self.update_interval.into()))
     }

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -40,7 +40,7 @@ pub struct GithubConfig {
     pub api_server: String,
 
     /// Format override
-    pub format: String,
+    pub format: FormatTemplate,
 
     pub hide_if_total_is_zero: bool,
 }
@@ -50,7 +50,7 @@ impl Default for GithubConfig {
         Self {
             interval: Duration::from_secs(30),
             api_server: "https://api.github.com".to_string(),
-            format: "{total}".to_string(),
+            format: FormatTemplate::default(),
             hide_if_total_is_zero: false,
         }
     }
@@ -77,8 +77,7 @@ impl ConfigBlock for Github {
             text,
             api_server: block_config.api_server,
             token,
-            format: FormatTemplate::from_string(&block_config.format)
-                .block_error("github", "Invalid format specified")?,
+            format: block_config.format.with_default("{total:1}")?,
             total_notifications: 0,
             hide_if_total_is_zero: block_config.hide_if_total_is_zero,
         })
@@ -125,7 +124,7 @@ impl Block for Github {
             "team_mention" =>     Value::from_integer(*aggregations.get("team_mention").unwrap_or(&default) as i64),
         );
 
-        self.text.set_text(self.format.render(&values)?);
+        self.text.set_texts(self.format.render(&values)?);
 
         Ok(Some(self.update_interval.into()))
     }

--- a/src/blocks/ibus.rs
+++ b/src/blocks/ibus.rs
@@ -41,14 +41,14 @@ pub struct IBus {
 #[serde(deny_unknown_fields, default)]
 pub struct IBusConfig {
     pub mappings: Option<BTreeMap<String, String>>,
-    pub format: String,
+    pub format: FormatTemplate,
 }
 
 impl Default for IBusConfig {
     fn default() -> Self {
         Self {
             mappings: None,
-            format: "{engine}".to_string(),
+            format: FormatTemplate::default(),
         }
     }
 }
@@ -213,7 +213,7 @@ impl ConfigBlock for IBus {
             text,
             engine: engine_original,
             mappings: block_config.mappings,
-            format: FormatTemplate::from_string(&block_config.format)?,
+            format: block_config.format.with_default("{engine}")?,
         })
     }
 }
@@ -243,7 +243,7 @@ impl Block for IBus {
             "engine" => Value::from_string(display_engine)
         );
 
-        self.text.set_text(self.format.render(&values)?);
+        self.text.set_texts(self.format.render(&values)?);
         Ok(None)
     }
 

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -57,10 +57,10 @@ pub struct KDEConnectConfig {
     pub bat_critical: i32,
 
     /// Format string for displaying phone information.
-    pub format: String,
+    pub format: FormatTemplate,
 
     /// Format string for displaying phone information when it is disconnected.
-    pub format_disconnected: String,
+    pub format_disconnected: FormatTemplate,
 }
 
 impl Default for KDEConnectConfig {
@@ -71,8 +71,8 @@ impl Default for KDEConnectConfig {
             bat_info: 60,
             bat_warning: 30,
             bat_critical: 15,
-            format: "{name} {bat_icon}{bat_charge} {notif_icon}{notif_count}".to_string(),
-            format_disconnected: "{name}".to_string(),
+            format: FormatTemplate::default(),
+            format_disconnected: FormatTemplate::default(),
         }
     }
 }
@@ -539,8 +539,10 @@ impl ConfigBlock for KDEConnect {
             bat_info: block_config.bat_info,
             bat_warning: block_config.bat_warning,
             bat_critical: block_config.bat_critical,
-            format: FormatTemplate::from_string(&block_config.format)?,
-            format_disconnected: FormatTemplate::from_string(&block_config.format_disconnected)?,
+            format: block_config
+                .format
+                .with_default("{name} {bat_icon}{bat_charge} {notif_icon}{notif_count}")?,
+            format_disconnected: block_config.format_disconnected.with_default("{name}")?,
             output: TextWidget::new(id, 0, shared_config.clone()).with_icon("phone")?,
             shared_config,
         })
@@ -643,10 +645,10 @@ impl Block for KDEConnect {
             self.output.set_state(State::Critical);
             self.output.set_icon("phone_disconnected")?;
             self.output
-                .set_text(self.format_disconnected.render(&values)?);
+                .set_texts(self.format_disconnected.render(&values)?);
         } else {
             self.output.set_icon("phone")?;
-            self.output.set_text(self.format.render(&values)?);
+            self.output.set_texts(self.format.render(&values)?);
         }
 
         Ok(None)

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -416,7 +416,7 @@ impl KeyboardLayoutMonitor for Sway {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(default, deny_unknown_fields)]
 pub struct KeyboardLayoutConfig {
-    pub format: String,
+    pub format: FormatTemplate,
 
     driver: KeyboardLayoutDriver,
     #[serde(deserialize_with = "deserialize_duration")]
@@ -431,7 +431,7 @@ pub struct KeyboardLayoutConfig {
 impl Default for KeyboardLayoutConfig {
     fn default() -> Self {
         Self {
-            format: "{layout}".to_string(),
+            format: FormatTemplate::default(),
             driver: KeyboardLayoutDriver::SetXkbMap,
             interval: Duration::from_secs(60),
             sway_kb_identifier: None,
@@ -487,10 +487,7 @@ impl ConfigBlock for KeyboardLayout {
             output,
             monitor,
             update_interval,
-            format: FormatTemplate::from_string(&block_config.format).block_error(
-                "keyboard_layout",
-                "Invalid format specified for keyboard_layout",
-            )?,
+            format: block_config.format.with_default("{layout}")?,
             mappings: block_config.mappings,
         })
     }
@@ -514,7 +511,7 @@ impl Block for KeyboardLayout {
             "variant" => Value::from_string(variant)
         );
 
-        self.output.set_text(self.format.render(&values)?);
+        self.output.set_texts(self.format.render(&values)?);
         Ok(self.update_interval.map(|d| d.into()))
     }
 

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -29,7 +29,7 @@ pub struct Load {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields, default)]
 pub struct LoadConfig {
-    pub format: String,
+    pub format: FormatTemplate,
     #[serde(deserialize_with = "deserialize_duration")]
     pub interval: Duration,
 
@@ -46,7 +46,7 @@ pub struct LoadConfig {
 impl Default for LoadConfig {
     fn default() -> Self {
         Self {
-            format: "{1m}".to_string(),
+            format: FormatTemplate::default(),
             interval: Duration::from_secs(5),
             info: 0.3,
             warning: 0.6,
@@ -83,8 +83,7 @@ impl ConfigBlock for Load {
             minimum_info: block_config.info,
             minimum_warning: block_config.warning,
             minimum_critical: block_config.critical,
-            format: FormatTemplate::from_string(&block_config.format)
-                .block_error("load", "Invalid format specified for load")?,
+            format: block_config.format.with_default("{1m}")?,
             text,
         })
     }
@@ -124,7 +123,7 @@ impl Block for Load {
             _ => State::Idle,
         });
 
-        self.text.set_text(self.format.render(&values)?);
+        self.text.set_texts(self.format.render(&values)?);
 
         Ok(Some(self.update_interval.into()))
     }

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -229,7 +229,7 @@ pub struct MusicConfig {
     pub hide_when_empty: bool,
 
     /// Format string for displaying music player info.
-    pub format: String,
+    pub format: FormatTemplate,
 }
 
 impl Default for MusicConfig {
@@ -248,7 +248,7 @@ impl Default for MusicConfig {
             seek_step: 1000,
             interface_name_exclude: Vec::new(),
             hide_when_empty: false,
-            format: "{combo}".to_string(),
+            format: FormatTemplate::default(),
         }
     }
 }
@@ -369,13 +369,13 @@ impl ConfigBlock for Music {
                                         }
                                     }
                                     // workaround for `playerctld`
-                                    // This block keeps track of players currently active on the MPRIS bus, 
+                                    // This block keeps track of players currently active on the MPRIS bus,
                                     // and only clears the metadata when a player has disappeared from the bus.
                                     // However `playerctl` is essentially doing the same thing as this block by
                                     // keeping track of players by itself, and when the last player is closed
                                     // the playerctld bus still remains which means the block never clears the
                                     // metadata for the last player that disappeared. We can get around this by
-                                    // listening to the PlayerNames signal sent by playerctld and then only clear 
+                                    // listening to the PlayerNames signal sent by playerctld and then only clear
                                     // the metadata when there are no more players left.
                                     if let Some(data) = prop_changed.changed_properties.get("PlayerNames") {
                                         if data.0.as_iter().unwrap().peekable().peek().is_none() {
@@ -501,7 +501,7 @@ impl ConfigBlock for Music {
             players,
             hide_when_empty: block_config.hide_when_empty,
             send,
-            format: FormatTemplate::from_string(&block_config.format)?,
+            format: block_config.format.with_default("{combo}")?,
             scrolling: shared_config.scrolling,
         })
     }
@@ -565,7 +565,7 @@ impl Block for Music {
                 self.current_song_widget.set_text(String::new());
             } else {
                 self.current_song_widget
-                    .set_text(self.format.render(&values)?);
+                    .set_text(self.format.render(&values)?.0);
             }
         }
 

--- a/src/blocks/networkmanager.rs
+++ b/src/blocks/networkmanager.rs
@@ -478,13 +478,13 @@ pub struct NetworkManagerConfig {
     pub primary_only: bool,
 
     /// AP formatter
-    pub ap_format: String,
+    pub ap_format: FormatTemplate,
 
     /// Device formatter.
-    pub device_format: String,
+    pub device_format: FormatTemplate,
 
     /// Connection formatter.
-    pub connection_format: String,
+    pub connection_format: FormatTemplate,
 
     /// Interface name regex patterns to include.
     pub interface_name_exclude: Vec<String>,
@@ -497,9 +497,9 @@ impl Default for NetworkManagerConfig {
     fn default() -> Self {
         Self {
             primary_only: false,
-            ap_format: "{ssid}".to_string(),
-            device_format: "{icon}{ap} {ips}".to_string(),
-            connection_format: "{devices}".to_string(),
+            ap_format: FormatTemplate::default(),
+            device_format: FormatTemplate::default(),
+            connection_format: FormatTemplate::default(),
             interface_name_exclude: Vec::new(),
             interface_name_include: Vec::new(),
         }
@@ -568,9 +568,11 @@ impl ConfigBlock for NetworkManager {
             dbus_conn,
             manager,
             primary_only: block_config.primary_only,
-            ap_format: FormatTemplate::from_string(&block_config.ap_format)?,
-            device_format: FormatTemplate::from_string(&block_config.device_format)?,
-            connection_format: FormatTemplate::from_string(&block_config.connection_format)?,
+            ap_format: block_config.ap_format.with_default("{ssid}")?,
+            device_format: block_config
+                .device_format
+                .with_default("{icon}{ap} {ips}")?,
+            connection_format: block_config.connection_format.with_default("{devices}")?,
             interface_name_exclude_regexps: compile_regexps(block_config.interface_name_exclude)
                 .block_error("networkmanager", "failed to parse exclude patterns")?,
             interface_name_include_regexps: compile_regexps(block_config.interface_name_include)
@@ -721,7 +723,7 @@ impl Block for NetworkManager {
                                         "freq" => Value::from_string(freq).percents(),
                                     );
                                     if let Ok(s) = self.ap_format.render(&values) {
-                                        s
+                                        s.0
                                     } else {
                                         "[invalid device format string]".to_string()
                                     }
@@ -751,7 +753,7 @@ impl Block for NetworkManager {
                                 );
 
                                 if let Ok(s) = self.device_format.render(&values) {
-                                    devicevec.push(s);
+                                    devicevec.push(s.0);
                                 } else {
                                     devicevec.push("[invalid device format string]".to_string())
                                 }
@@ -769,7 +771,7 @@ impl Block for NetworkManager {
                         );
 
                         if let Ok(s) = self.connection_format.render(&values) {
-                            widget.set_text(s);
+                            widget.set_texts(s);
                         } else {
                             widget.set_text("[invalid connection format string]".to_string());
                         }

--- a/src/blocks/notify.rs
+++ b/src/blocks/notify.rs
@@ -32,14 +32,14 @@ pub struct Notify {
 #[serde(deny_unknown_fields, default)]
 pub struct NotifyConfig {
     /// Format string which describes the output of this block.
-    pub format: String,
+    pub format: FormatTemplate,
 }
 
 impl Default for NotifyConfig {
     fn default() -> Self {
         Self {
             // display just the bell icon
-            format: "".into(),
+            format: FormatTemplate::default(),
         }
     }
 }
@@ -109,7 +109,7 @@ impl ConfigBlock for Notify {
         Ok(Notify {
             id,
             paused: state,
-            format: FormatTemplate::from_string(&block_config.format)?,
+            format: block_config.format.with_default("")?,
             output: TextWidget::new(id, 0, shared_config).with_icon(icon)?,
         })
     }
@@ -130,7 +130,7 @@ impl Block for Notify {
             "state" => Value::from_string(paused.to_string())
         );
 
-        self.output.set_text(self.format.render(&values)?);
+        self.output.set_texts(self.format.render(&values)?);
 
         let icon = if paused == 1 { "bell-slash" } else { "bell" };
         self.output.set_icon(icon)?;

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -54,13 +54,13 @@ pub struct PacmanConfig {
     pub interval: Duration,
 
     /// Format override
-    pub format: String,
+    pub format: FormatTemplate,
 
     /// Alternative format override for when exactly 1 update is available
-    pub format_singular: String,
+    pub format_singular: FormatTemplate,
 
     /// Alternative format override for when no updates are available
-    pub format_up_to_date: String,
+    pub format_up_to_date: FormatTemplate,
 
     /// Indicate a `warning` state for the block if any pending update match the
     /// following regex. Default behaviour is that no package updates are deemed
@@ -81,9 +81,9 @@ impl Default for PacmanConfig {
     fn default() -> Self {
         Self {
             interval: Duration::from_secs(600),
-            format: "{pacman}".to_string(),
-            format_singular: "{pacman}".to_string(),
-            format_up_to_date: "{pacman}".to_string(),
+            format: FormatTemplate::default(),
+            format_singular: FormatTemplate::default(),
+            format_up_to_date: FormatTemplate::default(),
             warning_updates_regex: None,
             critical_updates_regex: None,
             aur_command: None,
@@ -94,20 +94,21 @@ impl Default for PacmanConfig {
 
 impl PacmanConfig {
     fn watched(
-        format: &str,
-        format_singular: &str,
-        format_up_to_date: &str,
+        format: &FormatTemplate,
+        format_singular: &FormatTemplate,
+        format_up_to_date: &FormatTemplate,
         aur_command: Option<String>,
     ) -> Result<Watched> {
-        let aur_format = "{aur";
-        let pacman_format = "{pacman";
-        let both_format = "{both";
-        let pacman_deprecated_format = "{count";
-        let concatenated_format_str = format!("{}{}{}", format, format_singular, format_up_to_date);
-        let aur = concatenated_format_str.contains(aur_format);
-        let pacman = concatenated_format_str.contains(pacman_format)
-            || concatenated_format_str.contains(pacman_deprecated_format);
-        let both = concatenated_format_str.contains(both_format);
+        macro_rules! any_format_contains {
+            ($name:expr) => {
+                format.contains($name)
+                    || format_singular.contains($name)
+                    || format_up_to_date.contains($name)
+            };
+        }
+        let aur = any_format_contains!("aur");
+        let pacman = any_format_contains!("pacman") || any_format_contains!("count");
+        let both = any_format_contains!("both");
         if both || (pacman && aur) {
             let aur_command = aur_command.block_error(
                 "pacman",
@@ -142,18 +143,6 @@ impl ConfigBlock for Pacman {
         Ok(Pacman {
             id,
             update_interval: block_config.interval,
-            format: FormatTemplate::from_string(&block_config.format)
-                .block_error("pacman", "Invalid format specified for pacman::format")?,
-            format_singular: FormatTemplate::from_string(&block_config.format_singular)
-                .block_error(
-                    "pacman",
-                    "Invalid format specified for pacman::format_singular",
-                )?,
-            format_up_to_date: FormatTemplate::from_string(&block_config.format_up_to_date)
-                .block_error(
-                    "pacman",
-                    "Invalid format specified for pacman::format_up_to_date",
-                )?,
             output,
             warning_updates_regex: match block_config.warning_updates_regex {
                 None => None, // no regex configured
@@ -187,6 +176,9 @@ impl ConfigBlock for Pacman {
             )?,
             uptodate: false,
             hide_when_uptodate: block_config.hide_when_uptodate,
+            format: block_config.format.with_default("{pacman}")?,
+            format_singular: block_config.format_singular.with_default("{pacman}")?,
+            format_up_to_date: block_config.format_up_to_date.with_default("{pacman}")?,
         })
     }
 }
@@ -380,7 +372,7 @@ impl Block for Pacman {
             }
             Watched::None => (std::collections::HashMap::new(), false, false, 0),
         };
-        self.output.set_text(match cum_count {
+        self.output.set_texts(match cum_count {
             0 => self.format_up_to_date.render(&formatting_map)?,
             1 => self.format_singular.render(&formatting_map)?,
             _ => self.format.render(&formatting_map)?,
@@ -415,6 +407,7 @@ mod tests {
     use crate::blocks::pacman::{
         get_aur_available_updates, get_update_count, PacmanConfig, Watched,
     };
+    use crate::formatting::FormatTemplate;
 
     #[test]
     fn test_get_update_count() {
@@ -429,41 +422,49 @@ mod tests {
 
     #[test]
     fn test_watched() {
-        let watched = PacmanConfig::watched("foo {count} bar", "foo {count} bar", "", None);
+        let fmt_count = FormatTemplate::new("foo {count} bar", None).unwrap();
+        let fmt_pacman = FormatTemplate::new("foo {pacman} bar", None).unwrap();
+        let fmt_aur = FormatTemplate::new("foo {aur} bar", None).unwrap();
+        let fmt_pacman_aur = FormatTemplate::new("foo {pacman} {aur} bar", None).unwrap();
+        let fmt_both = FormatTemplate::new("foo {both} bar", None).unwrap();
+        let fmt_none = FormatTemplate::new("foo bar", None).unwrap();
+        let fmt_empty = FormatTemplate::new("", None).unwrap();
+
+        let watched = PacmanConfig::watched(&fmt_count, &fmt_count, &fmt_empty, None);
         assert!(watched.is_ok());
         assert_eq!(watched.unwrap(), Watched::Pacman);
-        let watched = PacmanConfig::watched("foo {pacman} bar", "foo {pacman} bar", "", None);
+        let watched = PacmanConfig::watched(&fmt_pacman, &fmt_pacman, &fmt_empty, None);
         assert!(watched.is_ok());
         assert_eq!(watched.unwrap(), Watched::Pacman);
-        let watched = PacmanConfig::watched("foo bar", "foo bar", "", None);
-        assert!(watched.is_ok()); // missing formatter should not cause an error
-        let watched = PacmanConfig::watched("foo bar", "foo bar", "", Some("aur cmd".to_string()));
+        let watched = PacmanConfig::watched(&fmt_none, &fmt_none, &fmt_empty, None);
         assert!(watched.is_ok()); // missing formatter should not cause an error
         let watched = PacmanConfig::watched(
-            "foo {aur} bar",
-            "foo {aur} bar",
-            "",
+            &fmt_none,
+            &fmt_none,
+            &fmt_empty,
             Some("aur cmd".to_string()),
         );
+        assert!(watched.is_ok()); // missing formatter should not cause an error
+        let watched =
+            PacmanConfig::watched(&fmt_aur, &fmt_aur, &fmt_empty, Some("aur cmd".to_string()));
         assert!(watched.is_ok());
         assert_eq!(watched.unwrap(), Watched::AUR("aur cmd".to_string()));
         let watched = PacmanConfig::watched(
-            "foo {pacman} {aur} bar",
-            "foo {pacman} {aur} bar",
-            "",
+            &fmt_pacman_aur,
+            &fmt_pacman_aur,
+            &fmt_empty,
             Some("aur cmd".to_string()),
         );
         assert!(watched.is_ok());
         assert_eq!(watched.unwrap(), Watched::Both("aur cmd".to_string()));
-        let watched =
-            PacmanConfig::watched("foo {pacman} {aur} bar", "foo {pacman} {aur} bar", "", None);
+        let watched = PacmanConfig::watched(&fmt_pacman_aur, &fmt_pacman_aur, &fmt_empty, None);
         assert!(watched.is_err()); // missing aur command
-        let watched = PacmanConfig::watched("foo {both} bar", "foo {both} bar", "", None);
+        let watched = PacmanConfig::watched(&fmt_both, &fmt_both, &fmt_empty, None);
         assert!(watched.is_err()); // missing aur command
         let watched = PacmanConfig::watched(
-            "foo {both} bar",
-            "foo {both} bar",
-            "",
+            &fmt_both,
+            &fmt_both,
+            &fmt_empty,
             Some("aur cmd".to_string()),
         );
         assert!(watched.is_ok());

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -773,7 +773,7 @@ pub struct SoundConfig {
 
     /// Format string for displaying sound information.
     /// placeholders: {volume}
-    pub format: String,
+    pub format: FormatTemplate,
 
     pub show_volume_when_muted: bool,
 
@@ -791,7 +791,7 @@ impl Default for SoundConfig {
             device_kind: Default::default(),
             natural_mapping: false,
             step_width: 5,
-            format: "{volume}".to_string(),
+            format: FormatTemplate::default(),
             show_volume_when_muted: false,
             mappings: None,
             max_vol: None,
@@ -865,7 +865,7 @@ impl ConfigBlock for Sound {
             id,
             device,
             device_kind: block_config.device_kind,
-            format: FormatTemplate::from_string(&block_config.format)?,
+            format: block_config.format.with_default("{volume}")?,
             step_width,
             on_click: None,
             show_volume_when_muted: block_config.show_volume_when_muted,
@@ -918,13 +918,13 @@ impl Block for Sound {
             "output_name" => Value::from_string(output_name),
             "output_description" => Value::from_string(output_description),
         );
-        let text = self.format.render(&values)?;
+        let texts = self.format.render(&values)?;
 
         if self.device.muted() {
             self.text.set_icon(&self.icon(0))?;
             if self.show_volume_when_muted {
                 self.text.set_spacing(Spacing::Normal);
-                self.text.set_text(text);
+                self.text.set_texts(texts);
             } else {
                 self.text.set_text(String::new());
             }
@@ -933,7 +933,7 @@ impl Block for Sound {
             self.text.set_icon(&self.icon(volume))?;
             self.text.set_spacing(Spacing::Normal);
             self.text.set_state(State::Idle);
-            self.text.set_text(text);
+            self.text.set_texts(texts);
         }
 
         Ok(None)

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -62,7 +62,7 @@ pub enum OpenWeatherMapUnits {
 pub struct Weather {
     id: usize,
     weather: TextWidget,
-    format: String,
+    format: FormatTemplate,
     weather_keys: HashMap<&'static str, Value>,
     service: WeatherService,
     update_interval: Duration,
@@ -310,24 +310,16 @@ pub struct WeatherConfig {
         deserialize_with = "deserialize_duration"
     )]
     pub interval: Duration,
-    #[serde(default = "WeatherConfig::default_format")]
-    pub format: String,
+    #[serde(default)]
+    pub format: FormatTemplate,
     pub service: WeatherService,
-    #[serde(default = "WeatherConfig::default_autolocate")]
+    #[serde(default)]
     pub autolocate: bool,
 }
 
 impl WeatherConfig {
     fn default_interval() -> Duration {
         Duration::from_secs(600)
-    }
-
-    fn default_format() -> String {
-        "{weather} {temp}\u{00b0}".to_string()
-    }
-
-    fn default_autolocate() -> bool {
-        false
     }
 }
 
@@ -343,7 +335,9 @@ impl ConfigBlock for Weather {
         Ok(Weather {
             id,
             weather: TextWidget::new(id, 0, shared_config),
-            format: block_config.format,
+            format: block_config
+                .format
+                .with_default("{weather} {temp}\u{00b0}")?,
             weather_keys: HashMap::new(),
             service: block_config.service,
             update_interval: block_config.interval,
@@ -356,8 +350,8 @@ impl Block for Weather {
     fn update(&mut self) -> Result<Option<Update>> {
         match self.update_weather() {
             Ok(_) => {
-                let fmt = FormatTemplate::from_string(&self.format)?;
-                self.weather.set_text(fmt.render(&self.weather_keys)?);
+                self.weather
+                    .set_texts(self.format.render(&self.weather_keys)?);
                 self.weather.set_state(State::Idle)
             }
             Err(BlockError(block, _)) | Err(InternalError(block, _, _)) if block == "curl" => {

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -206,8 +206,8 @@ impl Xrandr {
                 "{display}: {brightness}"
             };
 
-            if let Ok(fmt_template) = FormatTemplate::from_string(format_str) {
-                self.text.set_text(fmt_template.render(&values)?);
+            if let Ok(fmt_template) = FormatTemplate::new(format_str, None) {
+                self.text.set_texts(fmt_template.render(&values)?);
             }
         }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,6 @@
 pub use std::error::Error as StdError;
 use std::fmt;
+pub use std::result::Result as StdResult;
 
 pub use self::Error::{BlockError, ConfigurationError, InternalError};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,11 @@
 mod de;
 #[macro_use]
 mod util;
+#[macro_use]
+mod formatting;
 pub mod blocks;
 mod config;
 mod errors;
-mod formatting;
 mod http;
 mod icons;
 mod protocol;

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -20,6 +20,30 @@ pub enum Spacing {
     Hidden,
 }
 
+impl Spacing {
+    pub fn from_content(content: &str) -> Self {
+        if content.is_empty() {
+            Self::Hidden
+        } else {
+            Self::Normal
+        }
+    }
+
+    pub fn to_string_leading(self) -> String {
+        match self {
+            Self::Normal => String::from(" "),
+            _ => String::from(""),
+        }
+    }
+
+    pub fn to_string_trailing(self) -> String {
+        match self {
+            Self::Hidden => String::from(""),
+            _ => String::from(" "),
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Deserialize)]
 pub enum State {
     Idle,

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -8,9 +8,11 @@ pub struct TextWidget {
     id: usize,
     pub instance: usize,
     content: Option<String>,
+    content_short: Option<String>,
     icon: Option<String>,
     state: State,
     spacing: Spacing,
+    spacing_short: Spacing,
     shared_config: SharedConfig,
     inner: I3BarBlock,
 }
@@ -30,9 +32,11 @@ impl TextWidget {
             id,
             instance,
             content: None,
+            content_short: None,
             icon: None,
             state: State::Idle,
             spacing: Spacing::Normal,
+            spacing_short: Spacing::Normal,
             shared_config,
             inner,
         }
@@ -58,6 +62,7 @@ impl TextWidget {
 
     pub fn with_spacing(mut self, spacing: Spacing) -> Self {
         self.spacing = spacing;
+        self.spacing_short = spacing;
         self.update();
         self
     }
@@ -74,12 +79,18 @@ impl TextWidget {
     }
 
     pub fn set_text(&mut self, content: String) {
-        self.spacing = if content.is_empty() {
-            Spacing::Hidden
+        self.set_texts((content, None));
+    }
+
+    pub fn set_texts(&mut self, contents: (String, Option<String>)) {
+        self.spacing = Spacing::from_content(&contents.0);
+        self.spacing_short = if let Some(ref short) = contents.1 {
+            Spacing::from_content(&short)
         } else {
-            Spacing::Normal
+            self.spacing
         };
-        self.content = Some(content);
+        self.content = Some(contents.0);
+        self.content_short = contents.1;
         self.update();
     }
 
@@ -93,24 +104,26 @@ impl TextWidget {
         self.update();
     }
 
+    fn format_text(&self, content: String, spacing: Spacing) -> String {
+        format!(
+            "{}{}{}",
+            self.icon
+                .clone()
+                .unwrap_or_else(|| spacing.to_string_leading()),
+            content,
+            spacing.to_string_trailing()
+        )
+    }
+
     fn update(&mut self) {
         let (key_bg, key_fg) = self.state.theme_keys(&self.shared_config.theme);
 
-        // When rendered inline, remove the leading space
-        self.inner.full_text = format!(
-            "{}{}{}",
-            self.icon.clone().unwrap_or_else(|| {
-                match self.spacing {
-                    Spacing::Normal => String::from(" "),
-                    _ => String::from(""),
-                }
-            }),
-            self.content.clone().unwrap_or_default(),
-            match self.spacing {
-                Spacing::Hidden => String::from(""),
-                _ => String::from(" "),
-            }
-        );
+        self.inner.full_text =
+            self.format_text(self.content.clone().unwrap_or_default(), self.spacing);
+        self.inner.short_text = match &self.content_short {
+            Some(text) => Some(self.format_text(text.clone(), self.spacing_short)),
+            _ => None,
+        };
         self.inner.background = key_bg.clone();
         self.inner.color = key_fg.clone();
     }


### PR DESCRIPTION
This is mostly a port from `MaxVerevkin/swaystatus@b26224d` and based on the discussions from #1205.

It works quite well for me.

Things that could be improved are:

- [x] ~~The `[block.format]` section *requires* the `full` field to be set and i couldn't figure out how to make `serde` fall back to the default if it's not given.~~
- [x] ~~The `pacman` block doesn't support the `[block.format]` section yet because it has some weird internal logic that requires direct access to the format string (which can't be accessed from the `FormatTemplate`). Possible fixes include either adding the format string to the `FormatTemplate` or reworking the way `pacman` figures out which package managers to monitor.~~
- `RotatingTextWidget`s can't be shortened from the format string, the interface doesn't really facilitate that. This only impacts the `music` block afaik. Something for a future PR imo.

Feedback + testing appreciated :)