### PR TITLE
Escape html entities in focused_window block

### DIFF
--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -11,6 +11,7 @@ use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::SharedConfig;
 use crate::errors::*;
 use crate::scheduler::Task;
+use crate::util::escape_pango_text;
 use crate::widgets::text::TextWidget;
 use crate::widgets::I3BarWidget;
 
@@ -212,7 +213,7 @@ impl Block for FocusedWindow {
                 }
             }
         };
-        self.text.set_text(out_str);
+        self.text.set_text(escape_pango_text(out_str));
 
         Ok(None)
     }


### PR DESCRIPTION
Block would fail to render text containing `&` or `<` with pango emitting errors e.g:

    pango_layout_set_markup_with_accel: Error on line 1:
    Entity did not end with a semicolon; etc.

I've used the [html-escape crate](https://crates.io/crates/html-escape) which may be overkill for this but was easiest. I can write a smaller implementation if you don't want to take the dependency.