### PR TITLE
Fix json output of configuration error

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -88,11 +88,11 @@ impl fmt::Debug for Error {
                 f.write_str(&format!("Error in block '{}': {}", block, message))
             }
             ConfigurationError(ref message, ref cause) => f.write_str(&format!(
-                "Configuration error: {}.\nCause: {}",
+                "Configuration error: {}. Cause: {}",
                 message, cause
             )),
             InternalError(ref context, ref message, Some((ref cause, _))) => f.write_str(&format!(
-                "Internal error in context '{}': {}.\nCause: {}",
+                "Internal error in context '{}': {}. Cause: {}",
                 context, message, cause
             )),
             InternalError(ref context, ref message, None) => f.write_str(&format!(


### PR DESCRIPTION
JSON of `ConfigurationError` which is passed to i3bar is separated by newline.
Because of that, a JSON parsing error is displayed by i3 instead of the proper i3status-rs error message.

before:
```
[{"full_text":" Configuration error: failed to parse TOML from file contents.
Cause: expected an equals, found a newline at line 1 column 13 ","color":"#dc322f","background":"#000000","name":"0","instance":"0","separator":false,"separator_block_width":0,"markup":"pango"}],
```
![image](https://user-images.githubusercontent.com/682607/117849643-ce35ed80-b284-11eb-9e83-5a583c0964d9.png)


after:
```
[{"full_text":" Configuration error: failed to parse TOML from file contents. Cause: expected an equals, found a newline at line 1 column 13 ","color":"#dc322f","background":"#000000","name":"0","instance":"0","separator":false,"separator_block_width":0,"markup":"pango"}],
```
![image](https://user-images.githubusercontent.com/682607/117849496-aa72a780-b284-11eb-9874-6e65084245fb.png)


Discussed in #1222 


Note: Escaping `\n` is not a solution as it's then displayed as literal. Not sure if it's possible or even desirable to have the line break interpreted by i3bar.
Alternatively a simplified error message could be written to i3bar json and the full only to stderr