### PR TITLE
Add possibility to unset colors using overrides

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,26 +34,7 @@ impl SharedConfig {
 
     pub fn theme_override(&mut self, overrides: &HashMap<String, String>) -> errors::Result<()> {
         let mut theme = self.theme.as_ref().clone();
-        for entry in overrides {
-            match entry.0.as_str() {
-                "idle_fg" => theme.idle_fg = Some(entry.1.to_string()),
-                "idle_bg" => theme.idle_bg = Some(entry.1.to_string()),
-                "info_fg" => theme.info_fg = Some(entry.1.to_string()),
-                "info_bg" => theme.info_bg = Some(entry.1.to_string()),
-                "good_fg" => theme.good_fg = Some(entry.1.to_string()),
-                "good_bg" => theme.good_bg = Some(entry.1.to_string()),
-                "warning_fg" => theme.warning_fg = Some(entry.1.to_string()),
-                "warning_bg" => theme.warning_bg = Some(entry.1.to_string()),
-                "critical_fg" => theme.critical_fg = Some(entry.1.to_string()),
-                "critical_bg" => theme.critical_bg = Some(entry.1.to_string()),
-                x => {
-                    return Err(errors::ConfigurationError(
-                        format!("Theme element \"{}\" cannot be overriden", x),
-                        String::new(),
-                    ))
-                }
-            }
-        }
+        theme.apply_overrides(overrides)?;
         self.theme = Rc::new(theme);
         Ok(())
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -126,3 +126,16 @@ where
         InternalError("unknown".to_string(), "send error".to_string(), None)
     }
 }
+
+pub trait ToSerdeError<T> {
+    fn serde_error<E: serde::de::Error>(self) -> StdResult<T, E>;
+}
+
+impl<T, F> ToSerdeError<T> for StdResult<T, F>
+where
+    F: fmt::Display,
+{
+    fn serde_error<E: serde::de::Error>(self) -> StdResult<T, E> {
+        self.map_err(|e| E::custom(e.to_string()))
+    }
+}

--- a/src/protocol/i3bar_block.rs
+++ b/src/protocol/i3bar_block.rs
@@ -1,11 +1,13 @@
+use crate::themes::Color;
+
 /// Represent block as described in https://i3wm.org/docs/i3bar-protocol.html
 
 #[derive(Debug, Clone)]
 pub struct I3BarBlock {
     pub full_text: String,
     pub short_text: Option<String>,
-    pub color: Option<String>,
-    pub background: Option<String>,
+    pub color: Color,
+    pub background: Color,
     pub border: Option<String>,
     pub border_top: Option<usize>,
     pub border_right: Option<usize>,
@@ -52,8 +54,8 @@ impl I3BarBlock {
 
         json_add_str!(retval, Some(&self.full_text), full_text);
         json_add_str!(retval, self.short_text, short_text);
-        json_add_str!(retval, self.color, color);
-        json_add_str!(retval, self.background, background);
+        json_add_str!(retval, self.color.to_string(), color);
+        json_add_str!(retval, self.background.to_string(), background);
         json_add_str!(retval, self.border, border);
         json_add_val!(retval, self.border_top, border_top);
         json_add_val!(retval, self.border_right, border_right);
@@ -92,8 +94,8 @@ impl Default for I3BarBlock {
         Self {
             full_text: String::new(),
             short_text: None,
-            color: None,
-            background: None,
+            color: Color::None,
+            background: Color::None,
             border,
             border_top: None,
             border_right: None,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -4,7 +4,7 @@ pub mod i3bar_event;
 use crate::blocks::Block;
 use crate::config::SharedConfig;
 use crate::errors::*;
-use crate::util::add_colors;
+use crate::themes::Color;
 
 use i3bar_block::I3BarBlock;
 
@@ -17,7 +17,7 @@ pub fn init(never_pause: bool) {
 }
 
 pub fn print_blocks(blocks: &[Box<dyn Block>], config: &SharedConfig) -> Result<()> {
-    let mut last_bg: Option<String> = None;
+    let mut last_bg = Color::None;
 
     let mut rendered_blocks = vec![];
 
@@ -45,16 +45,9 @@ pub fn print_blocks(blocks: &[Box<dyn Block>], config: &SharedConfig) -> Result<
                 let mut data = widget.get_data();
                 if alternator {
                     // Apply tint for all widgets of every second block
-                    data.background = add_colors(
-                        data.background.as_deref(),
-                        config.theme.alternating_tint_bg.as_deref(),
-                    )
-                    .unwrap();
-                    data.color = add_colors(
-                        data.color.as_deref(),
-                        config.theme.alternating_tint_bg.as_deref(),
-                    )
-                    .unwrap();
+                    // TODO: Allow for other non-additive tints
+                    data.background = data.background + config.theme.alternating_tint_bg;
+                    data.color = data.color + config.theme.alternating_tint_fg;
                 }
                 data
             })
@@ -82,14 +75,14 @@ pub fn print_blocks(blocks: &[Box<dyn Block>], config: &SharedConfig) -> Result<
         }
 
         // The first widget's BG is used to get the FG color for the current separator
-        let sep_fg = if config.theme.separator_fg == Some("auto".to_string()) {
+        let sep_fg = if config.theme.separator_fg == Color::Auto {
             rendered_widgets.first().unwrap().background.clone()
         } else {
             config.theme.separator_fg.clone()
         };
 
         // The separator's BG is the last block's last widget's BG
-        let sep_bg = if config.theme.separator_bg == Some("auto".to_string()) {
+        let sep_bg = if config.theme.separator_bg == Color::Auto {
             last_bg
         } else {
             config.theme.separator_bg.clone()

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,49 +1,137 @@
+use std::collections::HashMap;
 use std::default::Default;
 use std::fmt;
+use std::ops::Add;
+use std::str::FromStr;
 
 use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
 use serde_derive::Deserialize;
 
+use crate::errors::ToSerdeError;
 use crate::util;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Color {
+    None,
+    Auto,
+    Rgba(u8, u8, u8, u8),
+}
+
+impl Add for Color {
+    type Output = Color;
+    fn add(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (x, Color::None) => x,
+            (x, Color::Auto) => x,
+            (Color::None, x) => x,
+            (Color::Auto, x) => x,
+            (Color::Rgba(r1, g1, b1, a1), Color::Rgba(r2, g2, b2, a2)) => Color::Rgba(
+                r1.saturating_add(r2),
+                g1.saturating_add(g2),
+                b1.saturating_add(b2),
+                a1.saturating_add(a2),
+            ),
+        }
+    }
+}
+
+impl FromStr for Color {
+    type Err = crate::errors::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "none" || s.is_empty() {
+            Ok(Color::None)
+        } else if s == "auto" {
+            Ok(Color::Auto)
+        } else {
+            use crate::errors::{OptionExt, ResultExtInternal};
+            let err_msg = "invaild RGBA color";
+            let r = s.get(1..3).internal_error("color parser", err_msg)?;
+            let g = s.get(3..5).internal_error("color parser", err_msg)?;
+            let b = s.get(5..7).internal_error("color parser", err_msg)?;
+            let a = s.get(7..9).unwrap_or("FF");
+            Ok(Color::Rgba(
+                u8::from_str_radix(r, 16).internal_error("color parser", err_msg)?,
+                u8::from_str_radix(g, 16).internal_error("color parser", err_msg)?,
+                u8::from_str_radix(b, 16).internal_error("color parser", err_msg)?,
+                u8::from_str_radix(a, 16).internal_error("color parser", err_msg)?,
+            ))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Color {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ColorVisitor;
+
+        impl<'de> Visitor<'de> for ColorVisitor {
+            type Value = Color;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("color")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Color, E>
+            where
+                E: de::Error,
+            {
+                s.parse().serde_error()
+            }
+        }
+
+        deserializer.deserialize_any(ColorVisitor)
+    }
+}
+
+impl Color {
+    pub fn to_string(&self) -> Option<String> {
+        match self {
+            Color::Rgba(r, g, b, a) => Some(format!("#{:02X}{:02X}{:02X}{:02X}", r, g, b, a)),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(default, deny_unknown_fields)]
 pub struct InternalTheme {
-    pub idle_bg: Option<String>,
-    pub idle_fg: Option<String>,
-    pub info_bg: Option<String>,
-    pub info_fg: Option<String>,
-    pub good_bg: Option<String>,
-    pub good_fg: Option<String>,
-    pub warning_bg: Option<String>,
-    pub warning_fg: Option<String>,
-    pub critical_bg: Option<String>,
-    pub critical_fg: Option<String>,
+    pub idle_bg: Color,
+    pub idle_fg: Color,
+    pub info_bg: Color,
+    pub info_fg: Color,
+    pub good_bg: Color,
+    pub good_fg: Color,
+    pub warning_bg: Color,
+    pub warning_fg: Color,
+    pub critical_bg: Color,
+    pub critical_fg: Color,
     pub separator: Option<String>,
-    pub separator_bg: Option<String>,
-    pub separator_fg: Option<String>,
-    pub alternating_tint_bg: Option<String>,
-    pub alternating_tint_fg: Option<String>,
+    pub separator_bg: Color,
+    pub separator_fg: Color,
+    pub alternating_tint_bg: Color,
+    pub alternating_tint_fg: Color,
 }
 
 impl Default for InternalTheme {
     fn default() -> Self {
         Self {
-            idle_bg: None,
-            idle_fg: None,
-            info_bg: None,
-            info_fg: None,
-            good_bg: None,
-            good_fg: None,
-            warning_bg: None,
-            warning_fg: None,
-            critical_bg: None,
-            critical_fg: None,
+            idle_bg: Color::None,
+            idle_fg: Color::None,
+            info_bg: Color::None,
+            info_fg: Color::None,
+            good_bg: Color::None,
+            good_fg: Color::None,
+            warning_bg: Color::None,
+            warning_fg: Color::None,
+            critical_bg: Color::None,
+            critical_fg: Color::None,
             separator: None,
-            separator_bg: None,
-            separator_fg: None,
-            alternating_tint_bg: None,
-            alternating_tint_fg: None,
+            separator_bg: Color::None,
+            separator_fg: Color::None,
+            alternating_tint_bg: Color::None,
+            alternating_tint_fg: Color::None,
         }
     }
 }
@@ -74,6 +162,37 @@ impl Theme {
     pub fn from_file(file: &str) -> Option<Theme> {
         let file = util::find_file(file, Some("themes"), Some("toml"))?;
         Some(Theme(util::deserialize_file(&file).ok()?))
+    }
+
+    pub fn apply_overrides(
+        &mut self,
+        overrides: &HashMap<String, String>,
+    ) -> Result<(), crate::errors::Error> {
+        if let Some(separator) = overrides.get("separator") {
+            self.separator = Some(separator.clone());
+        }
+        macro_rules! apply {
+            ($prop:tt) => {
+                if let Some(val) = overrides.get(stringify!($prop)) {
+                    self.$prop = val.parse()?;
+                }
+            };
+        }
+        apply!(idle_bg);
+        apply!(idle_fg);
+        apply!(info_bg);
+        apply!(info_fg);
+        apply!(good_bg);
+        apply!(good_fg);
+        apply!(warning_bg);
+        apply!(warning_fg);
+        apply!(critical_bg);
+        apply!(critical_fg);
+        apply!(separator_bg);
+        apply!(separator_fg);
+        apply!(alternating_tint_bg);
+        apply!(alternating_tint_fg);
+        Ok(())
     }
 }
 
@@ -122,8 +241,8 @@ impl<'de> Deserialize<'de> for Theme {
             where
                 V: MapAccess<'de>,
             {
-                let mut theme = None;
-                let mut overrides: Option<InternalTheme> = None;
+                let mut theme: Option<String> = None;
+                let mut overrides: Option<HashMap<String, String>> = None;
                 while let Some(key) = map.next_key()? {
                     match key {
                         // TODO merge name and file into one option (let's say "theme")
@@ -152,26 +271,8 @@ impl<'de> Deserialize<'de> for Theme {
                 let mut theme = Theme::from_file(&theme)
                     .ok_or_else(|| de::Error::custom(format!("Theme '{}' not found.", theme)))?;
 
-                if let Some(overrides) = overrides {
-                    theme.0.idle_bg = overrides.idle_bg.or(theme.0.idle_bg);
-                    theme.0.idle_fg = overrides.idle_fg.or(theme.0.idle_fg);
-                    theme.0.info_bg = overrides.info_bg.or(theme.0.info_bg);
-                    theme.0.info_fg = overrides.info_fg.or(theme.0.info_fg);
-                    theme.0.good_bg = overrides.good_bg.or(theme.0.good_bg);
-                    theme.0.good_fg = overrides.good_fg.or(theme.0.good_fg);
-                    theme.0.warning_bg = overrides.warning_bg.or(theme.0.warning_bg);
-                    theme.0.warning_fg = overrides.warning_fg.or(theme.0.warning_fg);
-                    theme.0.critical_bg = overrides.critical_bg.or(theme.0.critical_bg);
-                    theme.0.critical_fg = overrides.critical_fg.or(theme.0.critical_fg);
-                    theme.0.separator = overrides.separator.or(theme.0.separator);
-                    theme.0.separator_bg = overrides.separator_bg.or(theme.0.separator_bg);
-                    theme.0.separator_fg = overrides.separator_fg.or(theme.0.separator_fg);
-                    theme.0.alternating_tint_bg = overrides
-                        .alternating_tint_bg
-                        .or(theme.0.alternating_tint_bg);
-                    theme.0.alternating_tint_fg = overrides
-                        .alternating_tint_fg
-                        .or(theme.0.alternating_tint_fg);
+                if let Some(ref overrides) = overrides {
+                    theme.apply_overrides(overrides).serde_error()?;
                 }
                 Ok(theme)
             }

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -8,7 +8,7 @@ use serde::de::{Deserialize, IntoDeserializer};
 use serde_derive::Deserialize;
 
 use crate::protocol::i3bar_block::I3BarBlock;
-use crate::themes::Theme;
+use crate::themes::{Color, Theme};
 
 #[derive(Debug, Copy, Clone, Deserialize)]
 pub enum Spacing {
@@ -54,14 +54,14 @@ pub enum State {
 }
 
 impl State {
-    pub fn theme_keys(self, theme: &Theme) -> (&Option<String>, &Option<String>) {
+    pub fn theme_keys(self, theme: &Theme) -> (Color, Color) {
         use self::State::*;
         match self {
-            Idle => (&theme.idle_bg, &theme.idle_fg),
-            Info => (&theme.info_bg, &theme.info_fg),
-            Good => (&theme.good_bg, &theme.good_fg),
-            Warning => (&theme.warning_bg, &theme.warning_fg),
-            Critical => (&theme.critical_bg, &theme.critical_fg),
+            Idle => (theme.idle_bg, theme.idle_fg),
+            Info => (theme.info_bg, theme.info_fg),
+            Good => (theme.good_bg, theme.good_fg),
+            Warning => (theme.warning_bg, theme.warning_fg),
+            Critical => (theme.critical_bg, theme.critical_fg),
         }
     }
 }


### PR DESCRIPTION
by creating `Color` enum and using `serde` to parse it from theme/config overrides.

Based on @MaxVerevkin's implementation in [MaxVerevkin/swaystatus@1c2516a](https://github.com/MaxVerevkin/swaystatus/commit/1c2516abeee95a7c6f42cac59b1b186c9698fe68) with a few changes.

Resolves #1276