### PR TITLE
http: Escape URLs before they are used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1.0"
 signal-hook = "0.3"
 swayipc = "2.7"
 toml = "0.5"
+url = "2.2"
 
 # Optional features/blocks
 libpulse-binding = { optional = true, version = "2.0", default-features = false }


### PR DESCRIPTION
Previously, URLs with spaces, etc. (e.g. a city name with spaces when `autolocate=true` for the Weather block) would fail inside curl.