### PR TITLE
Weather: Remove duplicate degree symbol from default format

### DIFF
--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -338,7 +338,7 @@ impl ConfigBlock for Weather {
             weather: TextWidget::new(id, 0, shared_config),
             format: block_config
                 .format
-                .with_default("{weather} {temp}\u{00b0}")?,
+                .with_default("{weather} {temp}")?,
             weather_keys: HashMap::new(),
             service: block_config.service,
             update_interval: block_config.interval,


### PR DESCRIPTION
A degree symbol is added by the Unit formatter already, so there should
not be an additional one added in the default format string.
