### PR TITLE
Update compilation requirements according to #1268

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a list of available blocks, see the [block documentation](https://github.com
 
 ## Requirements
 
-The Rust language and the `cargo` package manager are required to build the binary.
+The Rust compilter `rustc`, the `cargo` package manager, the C compiler `gcc` and `openssl-sys` are required to build the binary.
 
 We also require Libdbus 1.6 or higher. On some older systems this may require installing `libdbus-1-dev`. See [#194](https://github.com/greshake/i3status-rust/issues/194) if you are having dbus-related compilation issues.
 


### PR DESCRIPTION
This has been tested by using a Docker image to replicate a fresh Ubuntu install. I chose to do it on Ubuntu since it's the distro mentioned in #1268, and is also a very common distro.