### PR TITLE
Display "available" memory instead of "free" memory in examples

### DIFF
--- a/examples/config.toml
+++ b/examples/config.toml
@@ -14,7 +14,7 @@ alert = 10.0
 [[block]]
 block = "memory"
 display_type = "memory"
-format_mem = "{mem_total_used_percents}"
+format_mem = "{mem_used_percents}"
 format_swap = "{swap_used_percents}"
 
 [[block]]

--- a/examples/config_icon_override.toml
+++ b/examples/config_icon_override.toml
@@ -19,7 +19,7 @@ interval = 20
 [[block]]
 block = "memory"
 display_type = "memory"
-format_mem = "{mem_total_used_percents}"
+format_mem = "{mem_used_percents}"
 format_swap = "{swap_used_percents}"
 
 [[block]]

--- a/examples/config_theme_override.toml
+++ b/examples/config_theme_override.toml
@@ -17,7 +17,7 @@ interval = 20
 [[block]]
 block = "memory"
 display_type = "memory"
-format_mem = "{mem_total_used_percents}"
+format_mem = "{mem_used_percents}"
 format_swap = "{swap_used_percents}"
 
 [[block]]


### PR DESCRIPTION
The example configurations come with a memory block which displays total memory used, including buffers, cache, and ZFS ARC. I would imagine the majority of people do not want this, and would rather see the amount of memory available for applications.

It appears the example used to work this way, but was changed in https://github.com/greshake/i3status-rust/commit/04105c7535e1fc6100ce76bb4bb2bfc4f69d8656 (perhaps accidentally?) to include buffers/cache.

`Mup == mem_used_percents`
`MUp == mem_total_used_percents`
https://github.com/greshake/i3status-rust/blob/v0.20.2/NEWS.md