### PR TITLE
Changed packager-agnostic name on requirements to package name on apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a list of available blocks, see the [block documentation](https://github.com
 
 ## Requirements
 
-The Rust compiler `rustc`, `cargo` package manager, C compiler `gcc` and `openssl-sys` are required to build the binary.
+The Rust compiler `rustc`, `cargo` package manager, C compiler `gcc` and `libssl-dev` packages are required to build the binary.
 
 We also require Libdbus 1.6 or higher. On some older systems this may require installing `libdbus-1-dev`. See [#194](https://github.com/greshake/i3status-rust/issues/194) if you are having dbus-related compilation issues.
 


### PR DESCRIPTION
As discussed [here](https://github.com/greshake/i3status-rust/pull/1300#issuecomment-909378597).
The current version is using the packager-agnostic of the dependencies on the build dependencies, and apt names on runtime dependencies.

The reasoning for using apt names are to simply make it easy for beginners, who are a lot likely to be running debianlike distros (apt). People not using debians are more likely to be more experienced, and therefore more likely to have those dependencies already installed, since a lot of things depends on them.

The reasoning for not doing so is that this program is made for a tiling style window manager, which may already imply the user isn't quite novice, and can find their way on their own packagers.
This doesn't completely invalidate the reason for making it specific still, for they are even more likely to know how to translate from Debian package names to their own.

A third option would be to make easy copy-paste commands for the most common packagers to install the dependencies, after presenting their proper packager-agnostic names, but that would make the README even more lenghty, something I think should be avoided when viable.