### PR TITLE
allow non-default docker setups

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -534,6 +534,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `interval` | Update interval, in seconds. | No | `5`
 `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{running}"`
+`socket_path` | The path to the docker socket. | No | `"/var/run/docker.sock"`
 
 #### Available Format Keys
 


### PR DESCRIPTION
Allows configuration of the docker socket path so that non-default installations such as rootless-mode can use to block.

fixes #1309 

```
[[block]]
block = "docker"
format = "T:{total} R:{running} S:{stopped} P:{paused} I:{images}"
interval = 60

[[block]]
block = "docker"
format = "T:{total} R:{running} S:{stopped} P:{paused} I:{images}"
interval = 60
socket_path = "/run/user/1001/docker.sock"
```