### PR TITLE
Fix music marquee updates after closing player

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -219,13 +219,13 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 blocks.get_mut(req.id)
                     .internal_error("scheduler", "could not get required block")?
                     .update()?;
-                protocol::print_blocks(&blocks, &shared_config)?;
                 } else {
                 // Otherwise add to scheduler tasks and trigger update
                 // In case this needs to schedule further updates e.g. marquee
                 scheduler.schedule.push(req);
                 scheduler.do_scheduled_updates(&mut blocks)?;
                 }
+                protocol::print_blocks(&blocks, &shared_config)?;
             },
             // Receive update timer events
             recv(ttnu) -> _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,11 +214,18 @@ fn run(matches: &ArgMatches) -> Result<()> {
             },
             // Receive async update requests
             recv(rx_update_requests) -> request => if let Ok(req) = request {
-                // Process immediately and forget
+                if scheduler.schedule.iter().filter(|x| x.id == req.id).next().is_some() {
+                // If block is already scheduled then process immediately and forget
                 blocks.get_mut(req.id)
                     .internal_error("scheduler", "could not get required block")?
                     .update()?;
                 protocol::print_blocks(&blocks, &shared_config)?;
+                } else {
+                // Otherwise add to scheduler tasks and trigger update
+                // In case this needs to schedule further updates e.g. marquee
+                scheduler.schedule.push(req);
+                scheduler.do_scheduled_updates(&mut blocks)?;
+                }
             },
             // Receive update timer events
             recv(ttnu) -> _ => {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -41,7 +41,7 @@ impl cmp::Ord for Task {
 }
 
 pub struct UpdateScheduler {
-    schedule: BinaryHeap<Task>,
+    pub schedule: BinaryHeap<Task>,
 }
 
 impl UpdateScheduler {


### PR DESCRIPTION
Previously closing the player would allow no further updates to be scheduled, since song change and right-click events would only be processed directly and not add to the scheduled queue (they could not schedule further events - necessary for the marquee).

This is fixed by making these events add to the scheduler queue _if_ the block does not currently have any update scheduled. So simply playing a new song or right-clicking the block will make the marquee start scheduling events again :)

See issue #1124 for more details.

This has been tested with the music block and seems to work well, it may be worth quickly checking other blocks to make sure that none of them rely upon the `update_requests` channel never scheduling further events.

Note that writing to the scheduler directly like this is okay for now since it runs on the same thread.