### PR TITLE
hueshift block: Add support for wlsunset

### DIFF
--- a/src/blocks/hueshift.rs
+++ b/src/blocks/hueshift.rs
@@ -101,6 +101,37 @@ impl HueShiftDriver for Gammastep {
         Ok(())
     }
 }
+struct Wlsunset();
+impl HueShiftDriver for Wlsunset {
+    fn update(&self, temp: u16) -> Result<()> {
+        Command::new("sh")
+            // wlsunset does not have a oneshot option, so set both day and
+            // night temperature. wlsunset dose not allow for day and night
+            // temperatures to be the same, so increment the day temperature.
+            .args(&[
+                "-c",
+                &format!("killall wlsunset; wlsunset -T {} -t {} &", temp + 1, temp),
+            ])
+            .spawn()
+            .block_error(
+                "hueshift",
+                "Failed to set new color temperature using wlsunset.",
+            )?;
+        Ok(())
+    }
+    fn reset(&self) -> Result<()> {
+        Command::new("sh")
+            // wlsunset does not have a reset option, so set temperature to
+            // wlsunset's default values
+            .args(&["-c", "wlsunset -T 6500 -t 4000 > /dev/null 2>&1"])
+            .spawn()
+            .block_error(
+                "hueshift",
+                "Failed to set new color temperature using wlsunset.",
+            )?;
+        Ok(())
+    }
+}
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -108,6 +139,7 @@ pub enum HueShifter {
     Redshift,
     Sct,
     Gammastep,
+    Wlsunset,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -145,6 +177,8 @@ impl Default for HueshiftConfig {
                 Some(HueShifter::Sct)
             } else if has_command("hueshift", "gammastep").unwrap_or(false) {
                 Some(HueShifter::Gammastep)
+            } else if has_command("hueshift", "wlsunset").unwrap_or(false) {
+                Some(HueShifter::Wlsunset)
             } else {
                 None
             },
@@ -185,6 +219,7 @@ impl ConfigBlock for Hueshift {
             HueShifter::Redshift => Box::new(Redshift {}),
             HueShifter::Sct => Box::new(Sct {}),
             HueShifter::Gammastep => Box::new(Gammastep {}),
+            HueShifter::Wlsunset => Box::new(Wlsunset {}),
         };
 
         Ok(Hueshift {

--- a/src/blocks/hueshift.rs
+++ b/src/blocks/hueshift.rs
@@ -121,9 +121,15 @@ impl HueShiftDriver for Wlsunset {
     }
     fn reset(&self) -> Result<()> {
         Command::new("sh")
-            // wlsunset does not have a reset option, so set temperature to
-            // wlsunset's default values
-            .args(&["-c", "wlsunset -T 6500 -t 4000 > /dev/null 2>&1"])
+            // wlsunset does not have a reset option, so just kill the process.
+            // Trying to call wlsunset without any arguments uses the defaults:
+            // day temp: 6500K
+            // night temp: 4000K
+            // latitude/longitude: NaN
+            //     ^ results in sun_condition == POLAR_NIGHT at time of testing
+            // With these defaults, this results in the the color temperature
+            // getting set to 4000K.
+            .args(&["-c", "killall wlsunset > /dev/null 2>&1"])
             .spawn()
             .block_error(
                 "hueshift",


### PR DESCRIPTION
This commit adds support for wlsunset and should close  #1316.

As I was reading how redshift/gammastep and sct do things so that I could make the behavior for wlsunset as simiar as possible, there were a couple of things to note.
1. While wlsunset has a gamma option, there does not seem to be an option to reset the gamma ramps like redshift/gammastep. I skimmed through wlsunset's code, and it seems like it might handle that automatically. I am going to leave the gamma CLI argument alone for now.
2. redshift/gammastep have a color reset option, sct and wlsunset do not. On the [github README for sct](https://github.com/faf0/sct), it states "_If `xsct` is called without parameters, **the current display temperature is estimated**._" (emphasis mine) I do not know what this means at a glance. I suppose if I used xsct, then I may figure that out. Calling wlsunset without arguments, like sct, does work. For wlsunset, the default color temperature and gamma values in its `config` struct work out fine. However, both `latitude` and `longitude` in its `config` struct are set to `NaN`. Running wlsunset without the latitude and longitude arguments works, but `sun_condition` gets set to `POLAR_NIGHT`. The value of `latitude`/`longitude` eventually is interpreted as a float, so the default `NaN` value is getting interpreted as a float. Until the hueshift block takes options for latitude and longitude, the solution that seems to work right now is just killing the wlsunset process when resetting the color temperature.
    