### PR TITLE
sound: detect more portable speaker types

### DIFF
--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -955,7 +955,7 @@ impl Block for Sound {
         let headphones = self
             .device
             .active_port()
-            .map(|p| p.contains("headphones"))
+            .map(|p| p.starts_with("head") || p.starts_with("hand") || p.starts_with("ear"))
             .unwrap_or(false);
 
         if self.device.muted() {


### PR DESCRIPTION
Add detection for headset, earpiece and handsfree devices.
Taken from https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/blob/0ce3008605e5f644fac4bb5edbb1443110201ec1/src/pulse/def.h#L1073-1100