### PR TITLE
`backlight` block: adapt configuration options to precedent set by `sound` block

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -131,6 +131,18 @@ Show brightness for the default device:
 block = "backlight"
 ```
 
+Setup bounds and cycle:
+
+```toml
+[[block]]
+block = "backlight"
+minimum = 15
+maximum = 100
+cycle = [100, 50, 0, 50]
+```
+
+Note that `cycle = []` will disable cycling, and `cycle = [n]` will reset brightness to `n` on each click
+
 #### Options
 
 Key | Values | Required | Default
@@ -138,14 +150,15 @@ Key | Values | Required | Default
 `device` | The `/sys/class/backlight` device to read brightness information from. | No | Default device
 `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{brightness}"`
 `step_width` | The brightness increment to use when scrolling, in percent. | No | `5`
-`min_bright` | The minimum brightness that can be scrolled down or clicked to | No | `1`
-`max_bright` | The maximum brightness that can be scrolled up or clicked to | No | `100`
+`minimum` | The minimum brightness that can be scrolled down to | No | `1`
+`maximum` | The maximum brightness that can be scrolled up to | No | `100`
+`cycle` | The brightnesses to cycle through on each click | No | `[minimum, maximum]`
 `root_scaling` | Scaling exponent reciprocal (ie. root). | No | `1.0`
 `invert_icons` | Invert icons' ordering, useful if you have colorful emoji. | No | `false`
 
 Some devices expose raw values that are best handled with nonlinear scaling. The human perception of lightness is close to the cube root of relative luminance, so settings for `root_scaling` between 2.4 and 3.0 are worth trying. For devices with few discrete steps this should be 1.0 (linear). More information: <https://en.wikipedia.org/wiki/Lightness>
 
-Also be aware that some devices turn off when brightness is set to `0`. Be careful when setting `min_bright` to 0.
+Also be aware that some devices turn off when brightness is set to `0`. Be careful when setting `minimum` to 0.
 
 #### Available Format Keys
 

--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -138,10 +138,14 @@ Key | Values | Required | Default
 `device` | The `/sys/class/backlight` device to read brightness information from. | No | Default device
 `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{brightness}"`
 `step_width` | The brightness increment to use when scrolling, in percent. | No | `5`
+`min_bright` | The minimum brightness that can be scrolled down or clicked to | No | `1`
+`max_bright` | The maximum brightness that can be scrolled up or clicked to | No | `100`
 `root_scaling` | Scaling exponent reciprocal (ie. root). | No | `1.0`
 `invert_icons` | Invert icons' ordering, useful if you have colorful emoji. | No | `false`
 
 Some devices expose raw values that are best handled with nonlinear scaling. The human perception of lightness is close to the cube root of relative luminance, so settings for `root_scaling` between 2.4 and 3.0 are worth trying. For devices with few discrete steps this should be 1.0 (linear). More information: <https://en.wikipedia.org/wiki/Lightness>
+
+Also be aware that some devices turn off when brightness is set to `0`. Be careful when setting `min_bright` to 0.
 
 #### Available Format Keys
 

--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -136,15 +136,22 @@ block = "backlight"
 Key | Values | Required | Default
 ----|--------|----------|--------
 `device` | The `/sys/class/backlight` device to read brightness information from. | No | Default device
+`format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{brightness}"`
 `step_width` | The brightness increment to use when scrolling, in percent. | No | `5`
 `root_scaling` | Scaling exponent reciprocal (ie. root). | No | `1.0`
 `invert_icons` | Invert icons' ordering, useful if you have colorful emoji. | No | `false`
 
 Some devices expose raw values that are best handled with nonlinear scaling. The human perception of lightness is close to the cube root of relative luminance, so settings for `root_scaling` between 2.4 and 3.0 are worth trying. For devices with few discrete steps this should be 1.0 (linear). More information: <https://en.wikipedia.org/wiki/Lightness>
 
+#### Available Format Keys
+
+Placeholder | Description | Type
+------------|-------------|-----
+`{brightness}` | Device brightness percentage | String or Integer
+
 #### Setting Brightness with the Mouse Wheel
 
-The block allows for setting brightness with the mouse wheel. However, depending on how you installed i3status-rust, it may not have the appropriate permissions to modify these files, and will fail silently. To remedy this you can write a `udev` rule for your system (if you are comfortable doing so).
+The block allows for setting brightness with the mouse wheel and toggling min/max brightness on click. However, depending on how you installed i3status-rust, it may not have the appropriate permissions to modify these files, and will fail silently. To remedy this you can write a `udev` rule for your system (if you are comfortable doing so).
 
 First, check that your user is a member of the "video" group using the `groups` command. Then add a rule in the `/etc/udev/rules.d/` directory containing the following, for example in `backlight.rules`:
 

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -303,7 +303,7 @@ impl ConfigBlock for Backlight {
         let backlight = Self {
             id,
             device,
-            step_width: block_config.step_width.max(1),
+            step_width: block_config.step_width,
             minimum,
             maximum,
             cycle: block_config.cycle.unwrap_or_else(|| vec![minimum, maximum]),

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -143,11 +143,7 @@ impl BacklitDevice {
 
     fn toggle(&mut self) -> Result<()> {
         let current = self.brightness()?;
-        let target = if current > 50 {
-            0
-        } else {
-            100
-        };
+        let target = if current > 50 { 0 } else { 100 };
         self.set_brightness(target)
     }
 
@@ -362,7 +358,7 @@ impl Block for Backlight {
                         Down => -1,
                     };
                     self.device.set_brightness(
-                        (brightness as i64 + sign * self.step_width as i64).clamp(0, 100) as u64
+                        (brightness as i64 + sign * self.step_width as i64).clamp(0, 100) as u64,
                     )?;
                 }
             }


### PR DESCRIPTION
## Current state
The `backlight` block has a few configuration differences compared to `sound`, the last of which may be considered a bug.
- there is no `format` option (`volume` has one)
- `on_click` does nothing by default  (`volume` toggles on click)
- `on_click` override _erases the preset scroll action_ of changing brightness by small increments (scrolling on `volume` is still available when `on_click` is set)

## Proposed fix
This PR fixes these three differences by adding behavior to the `backlight` block:
- `format` is by default set to the only placeholder available, `"{brightness}"`
- by default, both left and right clicks "toggle" brightness (same as `volume`)
- if `on_click` is set, left click becomes `on_click` and right click remains the default toggle (same (I think) as `volume`)

"toggle" brightness: if less than 50% set to 100%, otherwise set to 0%


### Other (somewhat) unrelated fix
```rust
if brightness < 100 {
    set_brightness(brightness + step_width);
}
if brightness > step_width {
    set_brightness(brightness - step_width)?;
}
```
this code behaves inconsistently with regards to edge cases:
- `5 - 10 -> 5`
- `10 - 10 -> 10`
- `11 - 10 -> 1`
- `99 + 10 -> 109`
- `100 + 10 -> 100`
etc

The following is much more consistent:
```rust
(brightness + sign * step_width).clamp(0, 100)
```