### PR TITLE
Focused window format

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -643,13 +643,15 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `max_width` | Truncates titles to this length. | No | `21`
 `show_marks` | Display marks instead of the title, if there are some. Options are `"none"`, `"all"` or `"visible"`, the latter of which ignores marks that start with an underscore. | No | `"none"`
-`format` | AA string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{total}"`
+`format` | AA string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{composed}"`
 
 #### Available Format Keys
 
  Key | Value | Type
 -----|-------|-----
-`{composed}` | The result of title + marks (if show_marks is enabled)
+`{title}` | Title | String
+`{marks}` | Marks | String
+`{composed}` | Title _or_ marks depending on whether the title is empty or not and show_marks is enabled or not | String
 
 ###### [↥ back to top](#list-of-available-blocks)
 

--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -643,7 +643,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `max_width` | Truncates titles to this length. | No | `21`
 `show_marks` | Display marks instead of the title, if there are some. Options are `"none"`, `"all"` or `"visible"`, the latter of which ignores marks that start with an underscore. | No | `"none"`
-`format` | AA string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{composed}"`
+`format` | AA string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{combo}"`
 
 #### Available Format Keys
 
@@ -651,7 +651,7 @@ Key | Values | Required | Default
 -----|-------|-----
 `{title}` | Title | String
 `{marks}` | Marks | String
-`{composed}` | Title _or_ marks depending on whether the title is empty or not and show_marks is enabled or not | String
+`{combo}` | Title _or_ marks depending on whether the title is empty or not and show_marks is enabled or not | String
 
 ###### [↥ back to top](#list-of-available-blocks)
 

--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -643,6 +643,13 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `max_width` | Truncates titles to this length. | No | `21`
 `show_marks` | Display marks instead of the title, if there are some. Options are `"none"`, `"all"` or `"visible"`, the latter of which ignores marks that start with an underscore. | No | `"none"`
+`format` | AA string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{total}"`
+
+#### Available Format Keys
+
+ Key | Value | Type
+-----|-------|-----
+`{composed}` | The result of title + marks (if show_marks is enabled)
 
 ###### [↥ back to top](#list-of-available-blocks)
 

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -190,7 +190,7 @@ impl ConfigBlock for FocusedWindow {
             text,
             max_width: block_config.max_width,
             show_marks: block_config.show_marks,
-            format: block_config.format.with_default("{composed}")?,
+            format: block_config.format.with_default("{combo}")?,
             title,
             marks,
         })
@@ -222,7 +222,7 @@ impl Block for FocusedWindow {
             }
         };
         let values = map!(
-            "composed" => Value::from_string(escape_pango_text(&out_str)),
+            "combo" => Value::from_string(escape_pango_text(&out_str)),
             "marks" => Value::from_string(escape_pango_text(&marks_string)),
             "title" => Value::from_string(escape_pango_text(&title_string))
         );

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -12,10 +12,10 @@ use crate::config::SharedConfig;
 use crate::errors::*;
 use crate::scheduler::Task;
 // use crate::util::escape_pango_text;
-use crate::widgets::text::TextWidget;
-use crate::widgets::I3BarWidget;
 use crate::formatting::value::Value;
 use crate::formatting::FormatTemplate;
+use crate::widgets::text::TextWidget;
+use crate::widgets::I3BarWidget;
 
 #[derive(Copy, Clone, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -184,8 +184,7 @@ impl ConfigBlock for FocusedWindow {
             })
             .expect("failed to start watching thread for `window` block");
 
-        let text = TextWidget::new(id, 0, shared_config)
-            .with_text("x");
+        let text = TextWidget::new(id, 0, shared_config).with_text("x");
         Ok(FocusedWindow {
             id,
             text,

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -11,7 +11,6 @@ use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::SharedConfig;
 use crate::errors::*;
 use crate::scheduler::Task;
-// use crate::util::escape_pango_text;
 use crate::formatting::value::Value;
 use crate::formatting::FormatTemplate;
 use crate::widgets::text::TextWidget;

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -184,7 +184,7 @@ impl ConfigBlock for FocusedWindow {
             })
             .expect("failed to start watching thread for `window` block");
 
-        let text = TextWidget::new(id, 0, shared_config).with_text("x");
+        let text = TextWidget::new(id, 0, shared_config);
         Ok(FocusedWindow {
             id,
             text,
@@ -212,17 +212,19 @@ impl Block for FocusedWindow {
         .clone();
         title_string = title_string.chars().take(self.max_width).collect();
         let out_str = match self.show_marks {
-            MarksType::None => title_string,
+            MarksType::None => &title_string,
             _ => {
                 if !marks_string.is_empty() {
-                    marks_string
+                    &marks_string
                 } else {
-                    title_string
+                    &title_string
                 }
             }
         };
         let values = map!(
-            "composed" => Value::from_string(escape_pango_text(out_str))
+            "composed" => Value::from_string(escape_pango_text(&out_str)),
+            "marks" => Value::from_string(escape_pango_text(&marks_string)),
+            "title" => Value::from_string(escape_pango_text(&title_string))
         );
 
         self.text.set_texts(self.format.render(&values)?);

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -10,9 +10,10 @@ use swayipc::{Connection, EventType};
 use crate::blocks::{Block, ConfigBlock, Update};
 use crate::config::SharedConfig;
 use crate::errors::*;
-use crate::scheduler::Task;
 use crate::formatting::value::Value;
 use crate::formatting::FormatTemplate;
+use crate::scheduler::Task;
+use crate::util::escape_pango_text;
 use crate::widgets::text::TextWidget;
 use crate::widgets::I3BarWidget;
 
@@ -221,7 +222,7 @@ impl Block for FocusedWindow {
             }
         };
         let values = map!(
-            "composed" => Value::from_string(out_str)
+            "composed" => Value::from_string(escape_pango_text(out_str))
         );
 
         self.text.set_texts(self.format.render(&values)?);

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -175,7 +175,7 @@ impl NetworkDevice {
                         continue;
                     }
 
-                    let ssid = Some(escape_pango_text(decode_escaped_unicode(&ssid)));
+                    let ssid = Some(escape_pango_text(&decode_escaped_unicode(&ssid)));
                     let freq = interface
                         .frequency
                         .map(|f| nl80211::parse_u32(&f) as f64 * 1e6);

--- a/src/util.rs
+++ b/src/util.rs
@@ -71,7 +71,7 @@ pub fn find_file(file: &str, subdir: Option<&str>, extension: Option<&str>) -> O
     None
 }
 
-pub fn escape_pango_text(text: String) -> String {
+pub fn escape_pango_text(text: &str) -> String {
     text.chars()
         .map(|x| match x {
             '&' => "&amp;".to_string(),

--- a/src/widgets/rotatingtext.rs
+++ b/src/widgets/rotatingtext.rs
@@ -158,7 +158,7 @@ impl RotatingTextWidget {
         self.inner.full_text = format!(
             "{}{}{}",
             icon,
-            escape_pango_text(self.get_rotated_content()),
+            escape_pango_text(&self.get_rotated_content()),
             match self.spacing {
                 Spacing::Hidden => String::from(""),
                 _ => String::from(" "),


### PR DESCRIPTION
This PR adds format support to the block focused_window.

The reason I need this is that I really want all my blocks to have a fixed width (not just maximum, also minimum) because I find it annoying when a block changing width moves the location of all the rest.

So I have this now in my config:
```
[[block]]
block = "focused_window"
max_width = 100
show_marks = "visible"
format = "{composed:50^50}"
```
