### PR TITLE
Revert "sound: detect more portable speaker types"

### DIFF
--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -957,7 +957,7 @@ impl Block for Sound {
         let headphones = self
             .device
             .active_port()
-            .map(|p| p.starts_with("head") || p.starts_with("hand") || p.starts_with("ear"))
+            .map(|p| p.contains("headphones"))
             .unwrap_or(false);
 
         if self.device.muted() {


### PR DESCRIPTION
This reverts commit 5611e2dd7302b62c3a4e4883c7291f1d2f4d765f.

As explained in https://github.com/greshake/i3status-rust/pull/1348#issuecomment-984894163 this change is not correct. The PR mentions port types, but it's port names that are being queried. 

Alternatively I can make a change to query port types instead of names, but as mentioned [here](https://docs.rs/libpulse-binding/2.25.0/libpulse_binding/context/introspect/struct.SinkPortInfo.html#structfield.type) that would require building `libpulse-bindings` with support for pulseaudio v14, breaking support for older pulseaudio versions. Not sure if that's a concern or not.