### PR TITLE
Create block to display external IP address information

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -27,6 +27,7 @@ You may find that the block you desire is not in the list below. In that case, f
 - [Custom DBus](#custom-dbus)
 - [Disk Space](#disk-space)
 - [Docker](#docker)
+- [ExternalIP](#external-ip)
 - [Focused Window](#focused-window)
 - [GitHub](#github)
 - [Hueshift](#hueshift)
@@ -646,6 +647,57 @@ Key | Value | Type
 #### Icons Used
 
 - `docker`
+
+###### [↥ back to top](#list-of-available-blocks)
+
+## ExternalIP
+
+Creates a block which displays the external IP address and various information about it.
+
+#### Examples
+
+```toml
+[[block]]
+block = "externalip"
+format = "{address} {country_code}"
+```
+
+#### Options
+
+Key | Values | Required | Default
+----|--------|----------|--------
+`format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{address} {country_flag}"`
+`refresh_interval_success` | Interval in seconds for automatic updates when the previous update was successful | No | 300
+`refresh_interval_failure` | Interval in seconds for automatic updates when the previous update failed | No | 15
+
+#### Available Format Keys
+
+ Key | Value | Type
+-----|-------|-----
+`{address}` | The external IP address, as seen from a remote server | String
+`{country}` | Full country name, such as "Spain" | Integer
+`{country_code}` | Two characters country code, such as "ES" | String
+`{region}` | Region name, such as "California" | String
+`{region_name}` | Region code, such as "CA" | String
+`{city}` | City | String
+`{zip}` | ZIP / Postal code | String
+`{latitude}` | Latitude | Float
+`{longitude}` | Longitude | Float
+`{timezone}` | Time zone | String
+`{isp}` | Internet Service Provider | String
+`{org}` | Organization | String
+`{autonomous_system}` | Autonomous system (AS) | String
+`{country_flag}` | Flag of the country | String (glyph)
+
+##### Notes
+The external IP address system uses the free tier of ip-api.com which is
+http, not https.
+The IP is queried, 1) When i3status-rs starts, 2) When a signal is received
+on D-Bus about a network configuration change, 3) Every 5 minutes. This
+periodic refresh exists to catch IP updates that don't trigger a notification,
+for example due to a IP refresh at the router.
+Flags: They are not icons but unicode glyphs. You will need a font that
+includes them. Tested with: https://www.babelstone.co.uk/Fonts/Flags.html
 
 ###### [↥ back to top](#list-of-available-blocks)
 

--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -669,6 +669,7 @@ Key | Values | Required | Default
 `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{address} {country_flag}"`
 `refresh_interval_success` | Interval in seconds for automatic updates when the previous update was successful | No | 300
 `refresh_interval_failure` | Interval in seconds for automatic updates when the previous update failed | No | 15
+`with_network_manager` | If 'true', listen for NetworkManager events and update the IP immediately if there was a change | No | "true"
 
 #### Available Format Keys
 

--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -659,7 +659,7 @@ Creates a block which displays the external IP address and various information a
 ```toml
 [[block]]
 block = "externalip"
-format = "{address} {country_code}"
+format = "{ip} {country_code}"
 ```
 
 #### Options
@@ -674,28 +674,44 @@ Key | Values | Required | Default
 
  Key | Value | Type
 -----|-------|-----
-`{address}` | The external IP address, as seen from a remote server | String
-`{country}` | Full country name, such as "Spain" | Integer
-`{country_code}` | Two characters country code, such as "ES" | String
+`{ip}` | The external IP address, as seen from a remote server | String
+`{version}` | IPv4 or IPv6 | String
+`{city}` | City name, such as "San Francisco" | Integer
 `{region}` | Region name, such as "California" | String
-`{region_name}` | Region code, such as "CA" | String
-`{city}` | City | String
-`{zip}` | ZIP / Postal code | String
+`{region_code}` | Region code, such as "CA" for California | String
+`{country}` | Country code (2 letter, ISO 3166-1 alpha-2) | String
+`{country_name}` | Short country name | String
+`{country_code}` | Country code (2 letter, ISO 3166-1 alpha-2) | String
+`{country_code_iso3}` | Country code (3 letter, ISO 3166-1 alpha-3) | String
+`{country_capital}` | Capital of the country | String
+`{country_tld}` | Country specific TLD (top-level domain) | String
+`{continent_code}` | Continent code | String
+`{in_eu}` | Region code, such as "CA" | String
+`{postal}` | ZIP / Postal code | String
 `{latitude}` | Latitude | Float
 `{longitude}` | Longitude | Float
+`{timezone}` | City | String
+`{utc_offset}` | UTC offset (with daylight saving time) as +HHMM or -HHMM (HH is hours, MM is minutes) | String
+`{country_calling_code}` | Country calling code (dial in code, comma separated) | String
+`{currency}` | Currency code (ISO 4217) | String
+`{currency_name}` | Currency name | String
+`{languages}` | Languages spoken (comma separated 2 or 3 letter ISO 639 code with optional hyphen separated country suffix) | String
+`{country_area}` | Area of the country (in sq km) | Float
+`{country_population}` | Population of the country | Float
 `{timezone}` | Time zone | String
-`{isp}` | Internet Service Provider | String
 `{org}` | Organization | String
-`{autonomous_system}` | Autonomous system (AS) | String
+`{asn}` | Autonomous system (AS) | String
 `{country_flag}` | Flag of the country | String (glyph)
 
 ##### Notes
-The external IP address system uses the free tier of ip-api.com which is
-http, not https.
+All the information comes from https://ipapi.co/json/ 
+Check their documentation here: https://ipapi.co/api/#complete-location5
+
 The IP is queried, 1) When i3status-rs starts, 2) When a signal is received
 on D-Bus about a network configuration change, 3) Every 5 minutes. This
 periodic refresh exists to catch IP updates that don't trigger a notification,
 for example due to a IP refresh at the router.
+
 Flags: They are not icons but unicode glyphs. You will need a font that
 includes them. Tested with: https://www.babelstone.co.uk/Fonts/Flags.html
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -9,6 +9,7 @@ pub mod custom_dbus;
 pub mod disk_space;
 pub mod dnf;
 pub mod docker;
+pub mod external_ip;
 pub mod focused_window;
 pub mod github;
 pub mod hueshift;
@@ -52,6 +53,7 @@ use self::custom_dbus::*;
 use self::disk_space::*;
 use self::dnf::*;
 use self::docker::*;
+use self::external_ip::*;
 use self::focused_window::*;
 use self::github::*;
 use self::hueshift::*;
@@ -234,6 +236,7 @@ pub fn create_block(
         "disk_space" => block!(DiskSpace, id, block_config, shared_config, update_request),
         "dnf" => block!(Dnf, id, block_config, shared_config, update_request),
         "docker" => block!(Docker, id, block_config, shared_config, update_request), ///////
+        "external_ip" => block!(ExternalIP, id, block_config, shared_config, update_request),
         "focused_window" => block!(
             FocusedWindow,
             id,

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -1,0 +1,196 @@
+use std::thread;
+use std::time::Instant;
+
+use crossbeam_channel::Sender;
+use dbus::ffidisp::{BusType, Connection, ConnectionItem};
+use serde::{Deserialize as des, Serialize as ser};
+use serde_derive::Deserialize;
+
+use crate::blocks::{Block, ConfigBlock, Update};
+use crate::config::SharedConfig;
+use crate::errors::*;
+use crate::formatting::value::Value;
+use crate::formatting::FormatTemplate;
+use crate::http;
+use crate::scheduler::Task;
+use crate::util::country_flag_from_iso_code;
+use crate::widgets::text::TextWidget;
+use crate::widgets::{I3BarWidget, State};
+use crate::Duration;
+
+const API_ENDPOINT: &str = "http://ip-api.com/json";
+
+#[derive(ser, des, Default)]
+struct IPAddressInfo {
+    #[serde(rename = "query")]
+    address: String,
+    status: String,
+    country: String,
+    #[serde(rename = "countryCode")]
+    country_code: String,
+    region: String,
+    #[serde(rename = "regionName")]
+    region_name: String,
+    city: String,
+    zip: String,
+    lat: f64,
+    lon: f64,
+    timezone: String,
+    isp: String,
+    org: String,
+    #[serde(rename = "as")]
+    autonomous_system: String,
+}
+
+pub struct ExternalIP {
+    id: usize,
+    output: TextWidget,
+    format: FormatTemplate,
+    refresh_interval_success: u64,
+    refresh_interval_failure: u64,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
+pub struct ExternalIPConfig {
+    /// External IP formatter.
+    pub format: FormatTemplate,
+    pub refresh_interval_success: u64,
+    pub refresh_interval_failure: u64,
+}
+
+impl Default for ExternalIPConfig {
+    fn default() -> Self {
+        Self {
+            format: FormatTemplate::default(),
+            refresh_interval_success: 300,
+            refresh_interval_failure: 15,
+        }
+    }
+}
+
+impl ConfigBlock for ExternalIP {
+    type Config = ExternalIPConfig;
+
+    fn new(
+        id: usize,
+        block_config: Self::Config,
+        shared_config: SharedConfig,
+        send: Sender<Task>,
+    ) -> Result<Self> {
+        thread::Builder::new()
+            .name("externalip".into())
+            .spawn(move || {
+                let c = Connection::get_private(BusType::System).unwrap();
+                c.add_match(
+                    "type='signal',\
+                    path='/org/freedesktop/NetworkManager',\
+                    interface='org.freedesktop.DBus.Properties',\
+                    member='PropertiesChanged'",
+                )
+                .unwrap();
+                c.add_match(
+                    "type='signal',\
+                    path_namespace='/org/freedesktop/NetworkManager/ActiveConnection',\
+                    interface='org.freedesktop.DBus.Properties',\
+                    member='PropertiesChanged'",
+                )
+                .unwrap();
+                c.add_match(
+                    "type='signal',\
+                    path_namespace='/org/freedesktop/NetworkManager/IP4Config',\
+                    interface='org.freedesktop.DBus',\
+                    member='PropertiesChanged'",
+                )
+                .unwrap();
+
+                loop {
+                    let timeout = 300_000;
+
+                    for event in c.iter(timeout) {
+                        match event {
+                            ConnectionItem::Nothing => (),
+                            _ => {
+                                send.send(Task {
+                                    id,
+                                    update_time: Instant::now(),
+                                })
+                                .unwrap();
+                            }
+                        }
+                    }
+                }
+            })
+            .unwrap();
+
+        Ok(ExternalIP {
+            id,
+            output: TextWidget::new(id, 0, shared_config),
+            format: block_config
+                .format
+                .with_default("{address} {country_flag}")?,
+            refresh_interval_success: block_config.refresh_interval_success,
+            refresh_interval_failure: block_config.refresh_interval_failure,
+        })
+    }
+}
+
+impl Block for ExternalIP {
+    fn id(&self) -> usize {
+        self.id
+    }
+
+    fn update(&mut self) -> Result<Option<Update>> {
+        let (external_ip, success) = {
+            let ip_info =
+                match http::http_get_json(API_ENDPOINT, Some(Duration::from_secs(3)), vec![]) {
+                    Ok(ip_info_json) => serde_json::from_value(ip_info_json.content).unwrap(),
+                    _ => IPAddressInfo::default(),
+                };
+            match ip_info.status.as_ref() {
+                "success" => {
+                    self.output.set_state(State::Idle);
+                    let flag = country_flag_from_iso_code(ip_info.country_code.as_str());
+                    let values = map!(
+                        "address" => Value::from_string (ip_info.address),
+                        "country" => Value::from_string (ip_info.country),
+                        "country_code" => Value::from_string (ip_info.country_code),
+                        "region" => Value::from_string (ip_info.region),
+                        "region_name" => Value::from_string (ip_info.region_name),
+                        "city" => Value::from_string (ip_info.city),
+                        "zip" => Value::from_string (ip_info.zip),
+                        "latitude" => Value::from_float (ip_info.lat),
+                        "longitude" => Value::from_float (ip_info.lon),
+                        "timezone" => Value::from_string (ip_info.timezone),
+                        "isp" => Value::from_string (ip_info.isp),
+                        "org" => Value::from_string (ip_info.org),
+                        "autonomous_system" => Value::from_string (ip_info.autonomous_system),
+                        "country_flag" => Value::from_string(flag),
+                    );
+                    let s = self.format.render(&values)?;
+                    (s.0, true)
+                }
+                _ => {
+                    self.output.set_state(State::Critical);
+                    ("Request to IP service failed".to_string(), false)
+                }
+            }
+        };
+        self.output.set_text(external_ip);
+        match success {
+            /* The external IP address can change without triggering a
+             * notification (for example a refresh between the router and
+             * the ISP) so check from time to time even on success */
+            true => Ok(Some(
+                Duration::from_secs(self.refresh_interval_success).into(),
+            )),
+            false => Ok(Some(
+                Duration::from_secs(self.refresh_interval_failure).into(),
+            )),
+        }
+    }
+
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
+        vec![&self.output]
+    }
+}

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -22,9 +22,10 @@ const API_ENDPOINT: &str = "https://ipapi.co/json/";
 const BLOCK_NAME: &str = "external_ip";
 
 #[derive(ser, des, Default)]
+#[serde(default)]
 struct IPAddressInfo {
-    #[serde(default = "bool::default")]
     error: bool,
+    reason: String,
     ip: String,
     version: String,
     city: String,
@@ -38,8 +39,7 @@ struct IPAddressInfo {
     country_tld: String,
     continent_code: String,
     in_eu: bool,
-    #[serde(default)]
-    postal: String,
+    postal: Option<String>,
     latitude: f64,
     longitude: f64,
     timezone: String,
@@ -183,7 +183,7 @@ impl Block for ExternalIP {
                             "country_tld" => Value::from_string (ip_info.country_tld),
                             "continent_code" => Value::from_string (ip_info.continent_code),
                             "in_eu" => Value::from_boolean (ip_info.in_eu),
-                            "postal" => Value::from_string (ip_info.postal),
+                            "postal" => Value::from_string (ip_info.postal.unwrap_or("No postal code".to_string())),
                             "latitude" => Value::from_float (ip_info.latitude),
                             "longitude" => Value::from_float (ip_info.longitude),
                             "timezone" => Value::from_string (ip_info.timezone),
@@ -203,7 +203,7 @@ impl Block for ExternalIP {
                     }
                     true => {
                         self.output.set_state(State::Critical);
-                        ("Request to IP service failed".to_string(), false)
+                        (format!("Error: {}", ip_info.reason.clone()), false)
                     }
                 },
                 Err(err) => {

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -38,6 +38,7 @@ struct IPAddressInfo {
     country_tld: String,
     continent_code: String,
     in_eu: bool,
+    #[serde(default)]
     postal: String,
     latitude: f64,
     longitude: f64,

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -183,7 +183,7 @@ impl Block for ExternalIP {
                             "country_tld" => Value::from_string (ip_info.country_tld),
                             "continent_code" => Value::from_string (ip_info.continent_code),
                             "in_eu" => Value::from_boolean (ip_info.in_eu),
-                            "postal" => Value::from_string (ip_info.postal.unwrap_or("No postal code".to_string())),
+                            "postal" => Value::from_string (ip_info.postal.unwrap_or_else(|| "No postal code".to_string())),
                             "latitude" => Value::from_float (ip_info.latitude),
                             "longitude" => Value::from_float (ip_info.longitude),
                             "timezone" => Value::from_string (ip_info.timezone),
@@ -203,7 +203,7 @@ impl Block for ExternalIP {
                     }
                     true => {
                         self.output.set_state(State::Critical);
-                        (format!("Error: {}", ip_info.reason.clone()), false)
+                        (format!("Error: {}", ip_info.reason), false)
                     }
                 },
                 Err(err) => {

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -61,6 +61,11 @@ impl FormatTemplate {
         Self::format_contains(&self.full, var) || Self::format_contains(&self.short, var)
     }
 
+    pub fn has_tokens(&self) -> bool {
+        !self.full.as_ref().map(Vec::is_empty).unwrap_or(true)
+            || !self.short.as_ref().map(Vec::is_empty).unwrap_or(true)
+    }
+
     fn format_contains(format: &Option<Vec<Token>>, var: &str) -> bool {
         if let Some(tokens) = format {
             for token in tokens {

--- a/src/formatting/value.rs
+++ b/src/formatting/value.rs
@@ -17,6 +17,7 @@ enum InternalValue {
     Text(String),
     Integer(i64),
     Float(f64),
+    Boolean(bool),
 }
 
 fn format_number(
@@ -150,6 +151,14 @@ impl Value {
             value: InternalValue::Float(value),
         }
     }
+    pub fn from_boolean(value: bool) -> Self {
+        Self {
+            icon: None,
+            min_width: 2,
+            unit: Unit::None,
+            value: InternalValue::Boolean(value),
+        }
+    }
 
     // Set options
     pub fn icon(mut self, icon: String) -> Self {
@@ -248,6 +257,10 @@ impl Value {
                 // Apply engineering notation (Float-only)
                 format_number(value, min_width, var.min_prefix, unit, pad_with)
             }
+            InternalValue::Boolean(value) => match value {
+                true => String::from("T"),
+                false => String::from("F"),
+            },
         };
 
         // We prepend the resulting string with the icon if it is set


### PR DESCRIPTION
Display our external IP address and information about it (country, region, location, ISP, etc). 

- To test

```
[[block]]
block = "external_ip"
format = "{address} {country} {country_code} {region} {region_name} {city} {zip} {latitude} {longitude} {timezone} {isp} {org} {autonomous_system} {country_flag}"
```

- Possibly some non-rustic code there, feel free to school me.
- serde_derive and service don't get really well (both export Serialize). Used an alias for one of them. Proper solution welcome.
- Using a free API to get all the info. Only limitation this API has that we might sort of care about is that it's http, not https (on the free tier).
- Includes country flag representation but it requires a font that includes them. See blocks doc for details.
-Tested with IPv4 only.