### PR TITLE
Enable allow_missing for the UPower driver

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -247,7 +247,7 @@ Key | Values | Required | Default
 `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{percentage}"`
 `full_format` | Same as `format` but for when the battery is full. | No | `"{percentage}"`
 `missing_format` | Same as `format` but for when the specified battery is missing. | No | `"{percentage}"`
-`allow_missing` | Don't display errors when the battery cannot be found. Only works with the `sysfs` driver. | No | `false`
+`allow_missing` | Don't display errors when the battery cannot be found. | No | `false`
 `hide_missing` | Completely hide this block if the battery cannot be found. Only works in combination with `allow_missing`. | No | `false`
 `full_threshold` | Percentage at which the battery is considered full (`full_format` shown) | No | `100`
 `good` | Minimum battery level, where state is set to good. | No | `60`


### PR DESCRIPTION
Added additonal match filters in the monitor function to let us know
when a upower devices is added or removed.

Implimented the is_availible function for UpowerDevice.

Deduplicated logic in Battery's update function regarding the return
values.

Updated blocks.md to remove note about allow_missing not working for
drivers other than the sysfs driver.