### PR TITLE
Fix version info collect at build time

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ use std::process::Command;
 fn main() {
     let output = Command::new("git")
         .args(&["rev-parse", "--short", "HEAD"])
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
         .output();
     let hash = match output {
         Ok(o) => String::from_utf8(o.stdout).unwrap(),
@@ -12,6 +13,7 @@ fn main() {
 
     let output = Command::new("git")
         .args(&["log", "--pretty=format:'%ad'", "-n1", "--date=short"])
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
         .output();
     let date = match output {
         Ok(o) => String::from_utf8(o.stdout)


### PR DESCRIPTION
Users may have set variables for git's config that cause the output
data to be in an unexpected format.

For example I have the following set:

```
[commit]
    gpgsign = true
```
Causing my version to look like:
```
i3status-rs 0.20.8 (commit b5dec12 gpg: Signature made Wed 29 Dec 2021 11:43:07 PM CST)
```

Instead of:
```
i3status-rs 0.20.8 (commit b0b8b7c 2021-12-31)
```

We can tell get to ignore the user's .gitconfig by setting the
environment variable `GIT_CONFIG_GLOBAL=/dev/null`