### PR TITLE
Add new apcupsd battery driver

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -206,7 +206,7 @@ Creates a block which displays the current battery state (Full, Charging or Disc
 
 The battery block collapses when the battery is fully charged -- or, in the case of some Thinkpad batteries, when it reports "Not charging".
 
-The battery block supports reading charging and status information from either `sysfs` or the [UPower](https://upower.freedesktop.org/) D-Bus interface. These "drivers" have largely identical features, but UPower does include support for `device = "DisplayDevice"`, which treats all physical power sources as a single logical battery. This is particularly useful if your system has multiple batteries.
+The battery block supports reading charging and status information from either `sysfs`, [apcaccess](http://www.apcaccess.org/manual/manual.html#nis-server-client-configuration-using-the-net-driver), or the [UPower](https://upower.freedesktop.org/) D-Bus interface. These "drivers" have largely identical features, but UPower does include support for `device = "DisplayDevice"`, which treats all physical power sources as a single logical battery. This is particularly useful if your system has multiple batteries.
 
 #### Examples
 
@@ -241,9 +241,9 @@ format = "{percentage} {time}"
 
 Key | Values | Required | Default
 ----|--------|----------|--------
-`device` | The device in `/sys/class/power_supply/` to read from. When using UPower, this can also be `"DisplayDevice"`. | No | sysfs: the first device starting with `"BAT"` in `/sys/class/power_supply`, usually "BAT0". upower: first matching device returned by the `EnumerateDevices` D-Bus method`
-`driver` | One of `"sysfs"` or `"upower"`. | No | `"sysfs"`
-`interval` | Update interval, in seconds. Only relevant for `driver = "sysfs"`. | No | `10`
+`device` | `sysfs`: The device in `/sys/class/power_supply/` to read from.<br />`apcaccess`: IPv4Address/hostname:port<br/>`UPower`: this can be `"DisplayDevice"` or any of the other paths found by running `upower --enumerate`. | No | `sysfs`: the first device starting with `"BAT"` in `/sys/class/power_supply`, usually "BAT0".<br />`apcaccess`: "localhost:3551"<br />`upower`: first matching device returned by the `EnumerateDevices` D-Bus method`
+`driver` | One of `"sysfs"`, `"apcaccess"`, or `"upower"`. | No | `"sysfs"`
+`interval` | Update interval, in seconds. Only relevant for `driver = "sysfs" \|\| "apcaccess"`. | No | `10`
 `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{percentage}"`
 `full_format` | Same as `format` but for when the battery is full. | No | `"{percentage}"`
 `missing_format` | Same as `format` but for when the specified battery is missing. | No | `"{percentage}"`

--- a/src/apcaccess.rs
+++ b/src/apcaccess.rs
@@ -28,7 +28,12 @@ impl ApcAccess {
     }
 
     pub fn is_available(&self) -> bool {
-        self.connect().is_ok()
+        if let Ok(status_data) = self.get_status() {
+            if let Some(status) = status_data.get("STATUS") {
+                return !status.contains("COMMLOST");
+            }
+        }
+        false
     }
 
     pub fn get_status(&self) -> Result<HashMap<String, String>> {

--- a/src/apcaccess.rs
+++ b/src/apcaccess.rs
@@ -1,0 +1,81 @@
+use crate::errors::*;
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+pub struct ApcAccess {
+    socket_addr: SocketAddr,
+    timeout_seconds: u64,
+}
+
+impl ApcAccess {
+    pub fn new(addr: &str, timeout_seconds: u64) -> Result<ApcAccess> {
+        Ok(ApcAccess {
+            socket_addr: addr.to_socket_addrs()?.find(|x| x.is_ipv4()).unwrap(),
+            timeout_seconds,
+        })
+    }
+
+    fn connect(&self) -> Result<TcpStream> {
+        let stream =
+            TcpStream::connect_timeout(&self.socket_addr, Duration::new(self.timeout_seconds, 0))?;
+        stream.set_write_timeout(Some(Duration::new(self.timeout_seconds, 0)))?;
+        stream.set_read_timeout(Some(Duration::new(self.timeout_seconds, 0)))?;
+
+        Ok(stream)
+    }
+
+    pub fn is_available(&self) -> bool {
+        self.connect().is_ok()
+    }
+
+    pub fn get_status(&self) -> Result<HashMap<String, String>> {
+        let mut stream = self.connect()?;
+
+        self.write(&mut stream, b"status")?;
+
+        let mut result = String::new();
+        self.read_to_string(&mut stream, &mut result)?;
+
+        let mut status_data: HashMap<String, String> = HashMap::new();
+        for line in result.lines() {
+            let (key, value) = line.split_once(':').unwrap();
+            status_data.insert(String::from(key.trim()), String::from(value.trim()));
+        }
+
+        Ok(status_data)
+    }
+
+    fn write(&self, stream: &mut TcpStream, msg: &[u8]) -> Result<()> {
+        let msg_len = msg.len();
+        if msg_len >= 1 << 16 {
+            return Err(InternalError(
+                "apcaccess".to_string(),
+                "msg is too long, it must be less than 2^16 characters long".to_string(),
+                None,
+            ));
+        }
+
+        stream.write_all(&msg_len.to_be_bytes()[6..])?;
+        stream.write_all(msg)?;
+
+        Ok(())
+    }
+
+    fn read_to_string(&self, stream: &mut TcpStream, buf: &mut String) -> Result<usize> {
+        let mut read_info = [0_u8, 2];
+        loop {
+            stream.read_exact(&mut read_info)?;
+            let read_size = ((read_info[0] as usize) << 8) + (read_info[1] as usize);
+            if read_size == 0 {
+                break;
+            }
+            let mut read_buf: Vec<u8> = vec![0; read_size];
+            stream.read_exact(&mut read_buf)?;
+            buf.extend(String::from_utf8(read_buf));
+        }
+        Ok(buf.len())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod de;
 mod util;
 #[macro_use]
 mod formatting;
+mod apcaccess;
 pub mod blocks;
 mod config;
 mod errors;


### PR DESCRIPTION
Added new apcupsd battery driver called apcaccess (like the command
line tool wich is used to query apcupsd for status and events).

Added information about new driver to blocks.md