### PR TITLE
Fix battery block's spacing

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -22,7 +22,7 @@ use crate::formatting::FormatTemplate;
 use crate::scheduler::Task;
 use crate::util::{battery_level_to_icon, read_file};
 use crate::widgets::text::TextWidget;
-use crate::widgets::{I3BarWidget, Spacing, State};
+use crate::widgets::{I3BarWidget, State};
 
 /// A battery device can be queried for a few properties relevant to the user.
 pub trait BatteryDevice {
@@ -700,7 +700,6 @@ impl Block for Battery {
             self.output.set_icon("bat_full")?;
             self.output.set_texts(self.full_format.render(&values)?);
             self.output.set_state(State::Good);
-            self.output.set_spacing(Spacing::Hidden);
         } else {
             self.output.set_texts(self.format.render(&values)?);
 
@@ -735,7 +734,6 @@ impl Block for Battery {
                 "Charging" => "bat_charging",
                 _ => battery_level_to_icon(capacity, self.fallback_icons),
             })?;
-            self.output.set_spacing(Spacing::Normal);
         }
 
         match self.driver {

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -304,11 +304,6 @@ impl Block for NvidiaGpu {
                 self.name_widget.set_spacing(Spacing::Inline);
             }
             NameWidgetMode::ShowLabel => {
-                if self.label.is_empty() {
-                    self.name_widget.set_spacing(Spacing::Hidden);
-                } else {
-                    self.name_widget.set_spacing(Spacing::Inline);
-                }
                 self.name_widget.set_text(self.label.to_string());
             }
         }

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -40,7 +40,7 @@ use crate::protocol::i3bar_event::{I3BarEvent, MouseButton};
 use crate::scheduler::Task;
 use crate::subprocess::spawn_child_async;
 use crate::widgets::text::TextWidget;
-use crate::widgets::{I3BarWidget, Spacing, State};
+use crate::widgets::{I3BarWidget, State};
 
 trait SoundDevice {
     fn volume(&self) -> u32;
@@ -964,7 +964,6 @@ impl Block for Sound {
         if self.device.muted() {
             self.text.set_icon(&self.icon(0, headphones))?;
             if self.show_volume_when_muted {
-                self.text.set_spacing(Spacing::Normal);
                 self.text.set_texts(texts);
             } else {
                 self.text.set_text(String::new());
@@ -972,7 +971,6 @@ impl Block for Sound {
             self.text.set_state(State::Warning);
         } else {
             self.text.set_icon(&self.icon(volume, headphones))?;
-            self.text.set_spacing(Spacing::Normal);
             self.text.set_state(State::Idle);
             self.text.set_texts(texts);
         }

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -390,10 +390,8 @@ impl Block for Temperature {
             self.collapsed = !self.collapsed;
             if self.collapsed {
                 self.text.set_text(String::new());
-                self.text.set_spacing(Spacing::Hidden);
             } else {
                 self.text.set_texts(self.output.clone());
-                self.text.set_spacing(Spacing::Normal);
             }
         }
 


### PR DESCRIPTION
Currently the full format for the battery block uses the hidden spacing.
However the hidden spacing should only be used when there's no tokens
in the full format.