### PR TITLE
Make rofication block support both the original version and regolith's fork

### DIFF
--- a/src/blocks/rofication.rs
+++ b/src/blocks/rofication.rs
@@ -146,7 +146,7 @@ fn rofication_status(socket_path: &str) -> Result<RotificationStatus> {
 
     // Request count
     stream
-        .write(b"num\n")
+        .write(b"num:\n")
         .block_error("rofication", "Failed to write to socket")?;
 
     // Response must be two comma separated integers: regular and critical
@@ -154,6 +154,8 @@ fn rofication_status(socket_path: &str) -> Result<RotificationStatus> {
     stream
         .read_to_string(&mut buffer)
         .block_error("rofication", "Failed to read from socket")?;
+
+    buffer = buffer.replace("\n", ","); // Original rofication uses NL to separate, while regolith forks uses comma. Convert if needed.
 
     let values = buffer.split(',').collect::<Vec<&str>>();
     if values.len() != 2 {


### PR DESCRIPTION
Simple modification to support both versions of rofication.

- Send b"num:\n" instead of b"num\n". This works because both versions split by : first (to separate the command from its arguments). Since "num" has no arguments, the newline is discarded by the original rofication (which doesn't like it) and present for the fork (which needs it).
- If the output is new-line separated (case of the original one) we convert that to commas so we can then split by it.

So trivial diff here.

Tested by replacing the fork rofication with the original one. Of course other things don't work since well, regolith needs its fork :-) But our block works with both versions now.
