### PR TITLE
Added deb to cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,26 @@ features = ["std"]
 
 [dev-dependencies]
 assert_fs = "1.0"
+
+[package.metadata.deb]
+name = "i3status-rust"
+maintainer = "Aaron Jacobs <atheriel@gmail.com>"
+extended-description = """\
+Provides provides a way to display 'blocks' of system information (time, \
+battery status, volume, etc) on the i3 (https://i3wm.org/) bar.
+.
+Also compatible with Sway (http://swaywm.org/).
+.
+For a list of available blocks, see the block documentation in \
+usr/share/doc/i3status-rust/blocks.md."""
+license-file = ["LICENSE", "0"]
+depends = "$auto, libdbus-1-3 (>=1.6), libpulse0"
+section = "utils"
+priority = "optional"
+assets = [
+    ["target/release/i3status-rs", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/i3status-rust/README", "644"],
+    ["doc/blocks.md", "usr/share/doc/i3status-rust/blocks.md", "644"],
+    ["files/icons/*", "usr/share/i3status-rust/icons/", "644"],
+    ["files/themes/*", "usr/share/i3status-rust/themes/", "644"],
+]


### PR DESCRIPTION
Greetings, this is a draft PR to check if there would be some interest in having the deb meta in the cargo.toml

The reason I'm proposing this is the following, I install i3status-rs as a deb package for each release.
In order to do that I run this small `build.sh` script,  like `./build.sh -v 0.20.6` for instance. after I patched my fork with the added contents of that PR.

So having it in the base repo would alleviate the manual steps of having to patch it on my fork :)

No worries if that doesn't land, and thanks for the amazing bar !

```bash
#! /usr/bin/env bash

set -eux

IMAGE="debian:bullseye-slim"
TARGET="$(dirname "$0" | xargs realpath)"
VERSION="v0.21.1"

while getopts "v:i:h" opt
do
    case "$opt" in
        v)
            VERSION="$OPTARG"
            ;;
        h)
            echo "Usage: $0 [-i image] [-v version]"
            exit 0
            ;;
        *)
            exit 1
            ;;
    esac
done

main() {
	docker build --progress=plain -t i3status-build-$$ --build-arg VERSION=$VERSION .
	docker create --name i3status i3status-build-$$
	docker cp i3status:/target/i3status-rust_${VERSION}_amd64.deb "$TARGET" 
	docker rm i3status
}

main
```

```
FROM rust:1.58-slim-bullseye
ARG VERSION
RUN DEBIAN_FRONTEND=noninteractive && \
	apt-get update && \
	apt-get install -y git librust-libdbus-sys-dev libssl-dev libpulse-dev && \
	apt-get -y clean && \
	rm -rf /var/lib/apt/lists/*
RUN cargo install cargo-deb
RUN git clone -b v$VERSION.deb https://github.com/euri10/i3status-rust.git && \
	cd i3status-rust
WORKDIR /i3status-rust
RUN cargo deb -- --features=maildir
RUN mkdir /target && cp /i3status-rust/target/debian/*.deb /target
```
