### PR TITLE
Use a standarized license expression ( "GPL-3.0-only" instead of "GPLv3" )

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "i3status-rs"
 description = "A feature-rich and resource-friendly replacement for i3status, written in Rust."
 repository = "https://github.com/greshake/i3status-rust/"
 readme = "README.md"
-license = "GPLv3"
+license = "GPL-3.0-only"
 version = "0.21.1"
 authors = ["Kai Greshake <development@kai-greshake.de>",
            "Contributors on GitHub (https://github.com/greshake/i3status-rust/graphs/contributors)"]


### PR DESCRIPTION
crates.io requires a license expression from here:

http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers

We do need to have a published crate on crates.io as Debian packaging scripts require it.

I published 0.21.1 -from master, no changes- with this license (the alternative is GPL3 or later instead of exactly 3.0), feel free to discard this PR and update with the other one if that's preferred.