### PR TITLE
Adjust example; BAT0 is typically a symlink

### DIFF
--- a/examples/config.toml
+++ b/examples/config.toml
@@ -36,4 +36,4 @@ format = "%a %d/%m %R"
 
 [[block]]
 block = "battery"
-if_command = "test -f /sys/class/power_supply/BAT0"
+if_command = "test -e /sys/class/power_supply/BAT0"


### PR DESCRIPTION
Test for existance, not for regular file.