### PR TITLE
Music: Add `players` field to the config

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -1235,6 +1235,7 @@ on_collapsed_click = "spotify"
 Key | Values | Required | Default
 ----|--------|----------|--------
 `player` | Name of the music player MPRIS interface. Run `busctl --user list \| grep "org.mpris.MediaPlayer2." \| cut -d' ' -f1` and the name is the part after "org.mpris.MediaPlayer2.". If unset, you can cycle through different players by right clicking on the widget. | No | None
+`players` | Name of the music players. Same as the `player` field but accepts an array of players. | No | None
 `interface_name_exclude` | A list of regex patterns for player MPRIS interface names to ignore. | No | ""
 `max_width` | Max width of the block in characters, not including the buttons. | No | `21`
 `dynamic_width` | Bool to specify whether the block will change width depending on the text content or remain static always (= `max_width`). | No | `false`

--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -1234,8 +1234,7 @@ on_collapsed_click = "spotify"
 
 Key | Values | Required | Default
 ----|--------|----------|--------
-`player` | Name of the music player MPRIS interface. Run `busctl --user list \| grep "org.mpris.MediaPlayer2." \| cut -d' ' -f1` and the name is the part after "org.mpris.MediaPlayer2.". If unset, you can cycle through different players by right clicking on the widget. | No | None
-`players` | Name of the music players. Same as the `player` field but accepts an array of players. | No | None
+`player` | Name(s) of the music player(s) MPRIS interface(s). This can be either a music player name or an array of music player names. Run `busctl --user list \| grep "org.mpris.MediaPlayer2." \| cut -d' ' -f1` and the name is the part after "org.mpris.MediaPlayer2.". If unset, you can cycle through different players by right clicking on the widget. | No | None
 `interface_name_exclude` | A list of regex patterns for player MPRIS interface names to ignore. | No | ""
 `max_width` | Max width of the block in characters, not including the buttons. | No | `21`
 `dynamic_width` | Bool to specify whether the block will change width depending on the text content or remain static always (= `max_width`). | No | `false`

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -797,7 +797,7 @@ fn ignored_player(
     preferred_players: &[String],
 ) -> bool {
     // If some players are specified in the config then we will ignore all others.
-    if preferred_players.len() > 0 {
+    if !preferred_players.is_empty() {
         if preferred_players
             .iter()
             .any(|player| name.starts_with(&format!("org.mpris.MediaPlayer2.{}", player)))

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -300,8 +300,8 @@ impl ConfigBlock for Music {
 
         if let Some(player) = block_config.player {
             match player {
-                PlayerName::PlayerName(player) => preferred_players.push(player.clone()),
-                PlayerName::PlayerNames(players) => preferred_players.extend(players.clone()),
+                PlayerName::PlayerName(player) => preferred_players.push(player),
+                PlayerName::PlayerNames(players) => preferred_players = players,
             }
         }
 


### PR DESCRIPTION
Addresses #1396 

The `players` field holds an array of players, which, along with the `player`, will be considered as the preferred players.
I couldn't build due to some linking errors, but `cargo check`ed successfully.