### PR TITLE
Shellexpand on blocks

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -534,7 +534,7 @@ Key | Values | Required | Default
 `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{available}"`
 `info_type` | Currently supported options are `"available"`, `"free"`, and `"used"` (sets value for alert and percentage calculation). | No | `"available"`
 `interval` | Update interval, in seconds. | No | `20`
-`path` | Path to collect information from. | No | `"/"`
+`path` | Path to collect information from. Supports path expansions e.g. `~`. | No | `"/"`
 `unit` | Unit that is used when `alert_absolute` is set for `warning` and `alert`. Options are `"B"`, `"KB"` `"MB"`, `"GB"`, `"TB"`. | No | `"GB"`
 `alert_absolute` | Use Unit values for warning and alert instead of percentages. | No | `false`
 
@@ -550,7 +550,7 @@ Key | Value | Type
 `{available}` | Available disk space (free disk space minus reserved system space) | Float
 `{free}` | Free disk space | Float
 `{icon}` | Disk drive icon | String
-`{path}` | Path used for capacity check | String
+`{path}` | Path used for capacity check. Supports shell expansions like `${VARIABLE}` and `~`. | String
 `{percentage}` | Percentage of disk used or free (depends on info_type setting) | Float
 `{total}` | Total disk space | Float
 `{used}` | Used disk space | Float
@@ -1101,7 +1101,7 @@ display_type = "new"
 
 Key | Values | Required | Default
 ----|--------|----------|--------
-`inboxes` | List of maildir inboxes to look for mails in. | Yes | None
+`inboxes` | List of maildir inboxes to look for mails in. Supports path expansions e.g. `~`. | Yes | None
 `threshold_warning` | Number of unread mails where state is set to warning. | No | `1`
 `threshold_critical` | Number of unread mails where state is set to critical. | No | `10`
 `interval` | Update interval, in seconds. | No | `5`
@@ -1447,7 +1447,7 @@ name = "A"
 
 Key | Values | Required | Default
 ----|--------|----------|--------
-`maildir` | Path to the directory containing the notmuch database. | No | `$HOME/.mail`
+`maildir` | Path to the directory containing the notmuch database. Supports path expansions e.g. `~`. | No | `$HOME/.mail`
 `query` | Query to run on the database. | No | `""`
 `threshold_critical` | Mail count that triggers `critical` state. | No | `99999`
 `threshold_warning` | Mail count that triggers `warning` state. | No | `99999`
@@ -1672,7 +1672,7 @@ Key | Values | Required | Default
 ----|--------|----------|--------
 `interval` | Refresh rate in seconds. | No | `1`
 `format` | A string to customise the output of this block. See below for placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | No | `"{num}"`
-`socket_path` | Socket path for the rofication daemon. | No | "/tmp/rofi_notification_daemon"
+`socket_path` | Socket path for the rofication daemon. Supports path expansions e.g. `~`. | No | "/tmp/rofi_notification_daemon"
 
 ### Available Format Keys
 
@@ -2032,7 +2032,7 @@ state_path = "/home/user/.config/watson/state"
 Key | Values | Required | Default
 ----|--------|----------|--------
 `show_time` | Whether to show recorded time. | No | `false`
-`state_path` | Path to the Watson state file. | No | `$XDG_CONFIG_HOME/watson/state`
+`state_path` | Path to the Watson state file. Supports path expansions e.g. `~`. | No | `$XDG_CONFIG_HOME/watson/state`
 `interval` | Update interval, in seconds. | No | `60`
 
 ## Weather

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -138,7 +138,14 @@ impl ConfigBlock for DiskSpace {
             id,
             update_interval: block_config.interval,
             disk_space: TextWidget::new(id, 0, shared_config),
-            path: block_config.path,
+            path: shellexpand::full(&block_config.path)
+                .map_err(|e| {
+                    ConfigurationError(
+                        "disk_space".to_string(),
+                        format!("Failed to expand file path {}: {}", &block_config.path, e),
+                    )
+                })?
+                .to_string(),
             format: block_config.format.with_default("{available}")?,
             info_type: block_config.info_type,
             unit: match block_config.unit.as_str() {

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -88,7 +88,17 @@ impl ConfigBlock for Notmuch {
         Ok(Notmuch {
             id,
             update_interval: block_config.interval,
-            db: block_config.maildir,
+            db: shellexpand::full(&block_config.maildir)
+                .map_err(|e| {
+                    ConfigurationError(
+                        "notmuch".to_string(),
+                        format!(
+                            "Failed to expand file path {}: {}",
+                            &block_config.maildir, e
+                        ),
+                    )
+                })?
+                .to_string(),
             query: block_config.query,
             threshold_info: block_config.threshold_info,
             threshold_good: block_config.threshold_good,

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::time::Duration;
 
 use crossbeam_channel::Sender;
@@ -45,12 +44,7 @@ pub struct NotmuchConfig {
 
 impl Default for NotmuchConfig {
     fn default() -> Self {
-        #[allow(deprecated)]
-        let home_dir = match env::home_dir() {
-            Some(path) => path.into_os_string().into_string().unwrap(),
-            None => "".to_owned(),
-        };
-        let maildir = format!("{}/.mail", home_dir);
+        let maildir = "~/.mail".to_string();
 
         Self {
             interval: Duration::from_secs(10),

--- a/src/blocks/rofication.rs
+++ b/src/blocks/rofication.rs
@@ -80,7 +80,17 @@ impl ConfigBlock for Rofication {
             id,
             update_interval: block_config.interval,
             text,
-            socket_path: block_config.socket_path,
+            socket_path: shellexpand::full(&block_config.socket_path)
+                .map_err(|e| {
+                    ConfigurationError(
+                        "rofi".to_string(),
+                        format!(
+                            "Failed to expand socket path {}: {}",
+                            &block_config.socket_path, e
+                        ),
+                    )
+                })?
+                .to_string(),
             format: block_config.format.with_default("{num}")?,
         })
     }

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -64,10 +64,25 @@ impl ConfigBlock for Watson {
         shared_config: SharedConfig,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
+        let state_path_string: String = block_config
+            .state_path
+            .clone()
+            .into_os_string()
+            .into_string()
+            .unwrap();
         let watson = Watson {
             id,
             text: TextWidget::new(id, 0, shared_config),
-            state_path: block_config.state_path.clone(),
+            state_path: PathBuf::from(
+                shellexpand::full(&state_path_string)
+                    .map_err(|e| {
+                        ConfigurationError(
+                            "watson".to_string(),
+                            format!("Failed to expand state path {}: {}", &state_path_string, e),
+                        )
+                    })?
+                    .to_string(),
+            ),
             show_time: block_config.show_time,
             update_interval: block_config.interval,
             prev_state: None,

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -64,12 +64,19 @@ impl ConfigBlock for Watson {
         shared_config: SharedConfig,
         tx_update_request: Sender<Task>,
     ) -> Result<Self> {
-        let state_path_string: String = block_config
-            .state_path
-            .clone()
-            .into_os_string()
-            .into_string()
-            .unwrap();
+        // TODO test if state_path PathBuf is being properly converted and erroring out if not
+        let state_path_string = match block_config.state_path.to_str() {
+            Some(str) => str,
+            None => {
+                return Err(BlockError(
+                    "watson".to_string(),
+                    format!(
+                        "Error converting state_path to unicode string: '{}'. Can you try renaming one of the folders?",
+                        block_config.state_path.to_string_lossy()
+                    ),
+                ))
+            }
+        };
         let watson = Watson {
             id,
             text: TextWidget::new(id, 0, shared_config),


### PR DESCRIPTION
As discussed in #1246, this runs `shellexpand::full` on paths the user might enter, thus expanding shell syntax like `~/file` and `${HOME}/file` to `/home/user/file`.
This is a created as a draft because I couldn't properly teste some of the changes, as I don't use these mail clients like a lot of users do, I take quite a beating from these cli clients, so I can't properly test maildir, notmuch and watson, all I could do is to try the config appropriately, and the error it spat out was not about _i3status-rust_'s config, or none at all, but I couldn't validate that I properly set up the program and whatnot. Watson requires extra attention because it uses `Pathbuf` on the config instead of `String`, like the others, since it needs it to spawn a watcher thread over it. I need some help here.
Since it's my first PR, I'd like some insight on idiomacies, since I've encountered some hard time with watson, but for the most time, followed what @ammgws did on custom block.

My method was to skim through the documentation, checking for anywhere a path was required, jumping in and change that to use shellexpand, then update the `.md` appropriately.