### PR TITLE
Net graph formatting

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -1273,18 +1273,28 @@ Key | Values | Required | Default
 
 Creates a block which displays the upload and download throughput for a network interface.
 
-`bitrate` requires either `ethtool` for wired devices or `iw` for wireless devices.  
-`ip` and `ipv6` require `ip`.  
+`bitrate` requires either `ethtool` for wired devices or `iw` for wireless devices.
+`ip` and `ipv6` require `ip`.
+
+Placeholder for the `graph_up` and `graph_down` is interpreted in the following manner:
+
+Part          | Meaning                                                                                                            | Default
+--------------|--------------------------------------------------------------------------------------------------------------------|----------
+`min_width`   | Sets width of the graph in characters.                                                                             | 10
+`max_width`   | Ignored.                                                                                                           | -
+`min_prefix`  | Determines how the `bar_max_val` value is interpreted.                                                             | No prefix
+`unit`        | Determines how the `bar_max_val` value is interpreted and how the unit is displayed after the graph.               | B
+`bar_max_val` | At what value the full bar is drawn. The unit of this value is determined from the `min_prefix` and `unit` fields. | Dynamic (set to largest value in graph)
 
 #### Examples
 
-Displays ssid, signal strength, ip, down speed and up speed as bits per second. Minimal prefix is set to `K` in order to prevent the block to change it's size.
+Displays ssid, signal strength, ip, download speed in bits and download speed graph. Minimal prefix on the `speed_down` block is set to `K` in order to prevent the `speed_down` block from changing it's size when switching between the `b` and `Kb` suffix. The graph in the example will be represented by 8 characters (40 seconds), will have the units hidden and will be on a constant scale from 0 to 50 Mb/s.
 
 ```toml
 [[block]]
 block = "net"
 device = "wlp2s0"
-format = "{ssid} {signal_strength} {ip} {speed_down;K*b} {graph_down;K*b}"
+format = "{ssid} {signal_strength} {ip} {speed_down;K*b} {graph_down:8;M*_b#50}"
 interval = 5
 ```
 
@@ -2206,7 +2216,7 @@ This is just a name of a placeholder. Each block that uses formatting will list 
 
 ### `[0]<min width>`
 
-Sets the minimum width of the content (in characters). If starts with a zero, `0` symbol will be used to pad the content. A space is used otherwise. Floats and Integers are shifted to the right, while Strings are to the left. Defaults to `0` for Strings, `2` for Integers and `3` for Floats.
+Sets the minimum width of the content (in characters). If starts with a zero, `0` symbol will be used to pad the content. A space is used otherwise. Floats and Integers are shifted to the right, while Strings are to the left. Defaults to `0` for Strings, `2` for Integers, `3` for Floats and `10` for bar graphs.
 
 #### Examples (spaces are shown as '□' to make the differences more obvious)
 

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -297,16 +297,16 @@ mod tests {
 
         let bar = format.get("bar").0.unwrap();
         assert!(bar.name == "bar");
-        
+
         assert!(bar.min_width.value == Some(8));
         assert!(bar.min_width.pad_with == ' ');
 
         assert!(bar.max_width == Some(12));
-        
+
         assert!(bar.min_prefix.hidden);
         assert!(!bar.min_prefix.space);
         assert!(bar.min_prefix.value == Some(prefix::Prefix::Mega));
-        
+
         assert!(bar.unit.hidden);
         assert!(bar.unit.unit == Some(unit::Unit::Bits));
         assert!(bar.bar_max_value == Some(50_f64));

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -58,7 +58,13 @@ impl FormatTemplate {
 
     /// Whether the format string contains a given placeholder
     pub fn contains(&self, var: &str) -> bool {
-        Self::format_contains(&self.full, var) || Self::format_contains(&self.short, var)
+        Self::format_get(&self.full, var).is_some() || Self::format_get(&self.short, var).is_some()
+    }
+    /// Returns given placeholders if the format string contain them in the (full, short) order
+    pub fn get(&self, var: &str) -> (Option<&Placeholder>, Option<&Placeholder>) {
+        let full = Self::format_get(&self.full, var);
+        let short = Self::format_get(&self.short, var);
+        (full, short)
     }
 
     pub fn has_tokens(&self) -> bool {
@@ -66,17 +72,17 @@ impl FormatTemplate {
             || !self.short.as_ref().map(Vec::is_empty).unwrap_or(true)
     }
 
-    fn format_contains(format: &Option<Vec<Token>>, var: &str) -> bool {
+    fn format_get<'a>(format: &'a Option<Vec<Token>>, var: &str) -> Option<&'a Placeholder> {
         if let Some(tokens) = format {
             for token in tokens {
                 if let Token::Var(ref placeholder) = token {
                     if placeholder.name == var {
-                        return true;
+                        return Some(placeholder);
                     }
                 }
             }
         }
-        false
+        None
     }
 
     fn tokens_from_string(mut s: &str) -> Result<Vec<Token>> {
@@ -275,5 +281,34 @@ mod tests {
         assert!(format.contains("bar"));
         assert!(!format.contains("foobar"));
         assert!(!format.contains("random string"));
+    }
+
+    #[test]
+    fn get() {
+        let format = FormatTemplate::new("some text {foo} {bar:8^12;_M*_b#50} foobar", None);
+        assert!(format.is_ok());
+        let format = format.unwrap();
+        assert!(format.get("foo").1.is_none());
+
+        let foo = format.get("foo").0.unwrap();
+        let mut empty_foo = "".parse::<Placeholder>().unwrap();
+        empty_foo.name = "foo".to_owned();
+        assert!(foo == &empty_foo);
+
+        let bar = format.get("bar").0.unwrap();
+        assert!(bar.name == "bar");
+        
+        assert!(bar.min_width.value == Some(8));
+        assert!(bar.min_width.pad_with == ' ');
+
+        assert!(bar.max_width == Some(12));
+        
+        assert!(bar.min_prefix.hidden);
+        assert!(!bar.min_prefix.space);
+        assert!(bar.min_prefix.value == Some(prefix::Prefix::Mega));
+        
+        assert!(bar.unit.hidden);
+        assert!(bar.unit.unit == Some(unit::Unit::Bits));
+        assert!(bar.bar_max_value == Some(50_f64));
     }
 }

--- a/src/formatting/placeholder.rs
+++ b/src/formatting/placeholder.rs
@@ -85,7 +85,7 @@ impl FromStr for Placeholder {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MinWidthConfig {
-    pub min_width: Option<usize>,
+    pub value: Option<usize>,
     pub pad_with: char,
 }
 
@@ -99,7 +99,7 @@ impl FromStr for MinWidthConfig {
         }
 
         Ok(MinWidthConfig {
-            min_width: if s.is_empty() {
+            value: if s.is_empty() {
                 None
             } else {
                 Some(s.parse().internal_error(

--- a/src/formatting/prefix.rs
+++ b/src/formatting/prefix.rs
@@ -64,7 +64,7 @@ impl Prefix {
         self.to_f64() / into.to_f64()
     }
 
-    pub fn to_f64(&self) -> f64 {
+    pub fn to_f64(self) -> f64 {
         match self {
             Self::One => 1e0,
             // SI prefixes

--- a/src/formatting/prefix.rs
+++ b/src/formatting/prefix.rs
@@ -61,7 +61,7 @@ impl FromStr for Prefix {
 
 impl Prefix {
     pub fn convert(&self, into: Self) -> f64 {
-        self.to_f64() / into.to_f64()   
+        self.to_f64() / into.to_f64()
     }
 
     pub fn to_f64(&self) -> f64 {

--- a/src/formatting/prefix.rs
+++ b/src/formatting/prefix.rs
@@ -58,3 +58,23 @@ impl FromStr for Prefix {
         }
     }
 }
+
+impl Prefix {
+    pub fn convert(&self, into: Self) -> f64 {
+        self.to_f64() / into.to_f64()   
+    }
+
+    pub fn to_f64(&self) -> f64 {
+        match self {
+            Self::One => 1e0,
+            // SI prefixes
+            Self::Nano => 1e-9,
+            Self::Micro => 1e-6,
+            Self::Milli => 1e-3,
+            Self::Kilo => 1e3,
+            Self::Mega => 1e6,
+            Self::Giga => 1e9,
+            Self::Tera => 1e12,
+        }
+    }
+}

--- a/src/formatting/value.rs
+++ b/src/formatting/value.rs
@@ -211,7 +211,7 @@ impl Value {
     pub fn from_deque(value: VecDeque<f64>) -> Self {
         Self {
             icon: None,
-            min_width: 1,
+            min_width: 10,
             unit: Unit::None,
             value: InternalValue::BarGraph(value),
         }

--- a/src/formatting/value.rs
+++ b/src/formatting/value.rs
@@ -202,7 +202,7 @@ impl Value {
 
     pub fn format(&self, var: &Placeholder) -> Result<String> {
         // Get user-specified min_width and pad_with values. Use defaults instead
-        let min_width = var.min_width.min_width.unwrap_or(self.min_width);
+        let min_width = var.min_width.value.unwrap_or(self.min_width);
         let pad_with = var.min_width.pad_with;
         // Apply unit override
         let unit = var.unit.unit.unwrap_or(self.unit);

--- a/src/util.rs
+++ b/src/util.rs
@@ -180,7 +180,10 @@ macro_rules! map_to_owned {
     }};
 }
 
-pub fn format_vec_to_bar_graph(content: &[f64], min: Option<f64>, max: Option<f64>) -> String {
+pub fn format_to_bar_graph<'a, T>(content: &'a T, min: Option<f64>, max: Option<f64>) -> String
+where
+    &'a T: IntoIterator<Item = &'a f64>,
+{
     // (x * one eighth block) https://en.wikipedia.org/wiki/Block_Elements
     static BARS: [char; 8] = [
         '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}', '\u{2585}', '\u{2586}', '\u{2587}',
@@ -205,11 +208,11 @@ pub fn format_vec_to_bar_graph(content: &[f64], min: Option<f64>, max: Option<f6
     if extant.is_normal() {
         let length = BARS.len() as f64 - 1.0;
         content
-            .iter()
+            .into_iter()
             .map(|x| BARS[((x.clamp(min, max) - min) / extant * length) as usize])
             .collect()
     } else {
-        (0..content.len()).map(|_| BARS[0]).collect::<_>()
+        content.into_iter().map(|_| BARS[0]).collect::<_>()
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -180,42 +180,6 @@ macro_rules! map_to_owned {
     }};
 }
 
-pub fn format_to_bar_graph<'a, T>(content: &'a T, min: Option<f64>, max: Option<f64>) -> String
-where
-    &'a T: IntoIterator<Item = &'a f64>,
-{
-    // (x * one eighth block) https://en.wikipedia.org/wiki/Block_Elements
-    static BARS: [char; 8] = [
-        '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}', '\u{2585}', '\u{2586}', '\u{2587}',
-        '\u{2588}',
-    ];
-
-    // Find min and max
-    let mut min_v = std::f64::INFINITY;
-    let mut max_v = -std::f64::INFINITY;
-    for v in content {
-        if *v < min_v {
-            min_v = *v;
-        }
-        if *v > max_v {
-            max_v = *v;
-        }
-    }
-
-    let min = min.unwrap_or(min_v);
-    let max = max.unwrap_or(max_v);
-    let extant = max - min;
-    if extant.is_normal() {
-        let length = BARS.len() as f64 - 1.0;
-        content
-            .into_iter()
-            .map(|x| BARS[((x.clamp(min, max) - min) / extant * length) as usize])
-            .collect()
-    } else {
-        content.into_iter().map(|_| BARS[0]).collect::<_>()
-    }
-}
-
 // Convert 2 letter country code to Unicode
 pub fn country_flag_from_iso_code(country_code: &str) -> String {
     if country_code.len() != 2 || !country_code.chars().all(|c| c.is_ascii_uppercase()) {


### PR DESCRIPTION
The documentation gives the following example in for the `net` block:

> Displays ssid, signal strength, ip, down speed and up speed as bits per second. Minimal prefix is set to `K` in order to prevent the block to change its size.
> 
> ```toml
> [[block]]
> block = "net"
> device = "wlp2s0"
> format = "{ssid} {signal_strength} {ip} {speed_down;K*b} {graph_down;K*b}"
> interval = 5
> ```

After seeing the `{graph_down;K*b}` part, I was quite confused, because I've assumed that the format specifier would be interpreted similarly to text based blocks (since the SI prefix part was being used).

This PR implements interpretation of the format specifier for the `net` block. This is useful if there is a desire to change the width of the graph (the previously hard-coded 10 characters are kept as a default value), or for the values to be displayed on an unchanging absolute scale. Consider for example the following placeholder:
`{graph_down:8^12;_M*_b#50}`
`min_width` is 8, so the graph will be represented by 8 characters.
`max_width` is ignored by the code in this PR.
`min_prefix` is mega- and is hidden. This only affects how the `bar_max_val` value is interpreted.
`unit` is bits. This only affects how the `bar_max_val` value is interpreted.
`bar_max_val` is 50 Mb/s. The unit of this value is determined from the `min_prefix` and `unit` fields.
Thus, download at the rate of 25 Mb/s would result in half a bar being drawn even if all the previous values were 0.

If there's any interest in merging this PR, I'm not sure how the documentation needs to be updated, because this is exactly how I've assumed it would work, when I've read it in the current state.