### PR TITLE
Fallback to `charge_level` if `capacity` cannot be calculated

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -940,11 +940,11 @@ impl Block for Battery {
             let capacity_level = self.device.capacity_level();
             if let Ok(capacity_level) = &capacity_level {
                 capacity = match capacity_level.as_str() {
-                    "Full" => Ok(100 as u64),
-                    "High" => Ok(75 as u64),
-                    "Normal" => Ok(50 as u64),
-                    "Low" => Ok(25 as u64),
-                    "Critical" => Ok(10 as u64),
+                    "Full" => Ok(100u64),
+                    "High" => Ok(75u64),
+                    "Normal" => Ok(50u64),
+                    "Low" => Ok(25u64),
+                    "Critical" => Ok(10u64),
                     "Unknown" => Err(BlockError("battery".into(), "Unknown charge level".into())),
                     _ => Err(BlockError(
                         "battery".into(),

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -466,7 +466,10 @@ impl BatteryDevice for ApcUpsDevice {
     }
 
     fn capacity_level(&self) -> Result<String> {
-        Err(BlockError("battery".to_string(), "charge_level not supported for apcups devices".into()))
+        Err(BlockError(
+            "battery".to_string(),
+            "charge_level not supported for apcups devices".into(),
+        ))
     }
 
     fn time_remaining(&self) -> Result<u64> {
@@ -678,7 +681,10 @@ impl BatteryDevice for UpowerDevice {
     }
 
     fn capacity_level(&self) -> Result<String> {
-        Err(BlockError("battery".to_string(), "charge_level not supported for upower devices".into()))
+        Err(BlockError(
+            "battery".to_string(),
+            "charge_level not supported for upower devices".into(),
+        ))
     }
 
     fn time_remaining(&self) -> Result<u64> {
@@ -940,7 +946,10 @@ impl Block for Battery {
                     "Low" => Ok(25 as u64),
                     "Critical" => Ok(10 as u64),
                     "Unknown" => Err(BlockError("battery".into(), "Unknown charge level".into())),
-                    _ => Err(BlockError("battery".into(), "unexpected string from capacity_level file".into()))
+                    _ => Err(BlockError(
+                        "battery".into(),
+                        "unexpected string from capacity_level file".into(),
+                    )),
                 };
             }
 

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -50,9 +50,6 @@ pub trait BatteryDevice {
     /// Query the device's current capacity, as a percent.
     fn capacity(&self) -> Result<u64>;
 
-    /// Query the device's current capacity level (for devices that don't report percentages)
-    fn capacity_level(&self) -> Result<String>;
-
     /// Query the estimated time remaining, in minutes, before (dis)charging is
     /// complete.
     fn time_remaining(&self) -> Result<u64>;
@@ -155,6 +152,7 @@ impl BatteryDevice for PowerSupplyDevice {
         let capacity_path = self.device_path.join("capacity");
         let charge_path = self.device_path.join("charge_now");
         let energy_path = self.device_path.join("energy_now");
+        let capacity_level_path = self.device_path.join("capacity_level");
 
         let capacity = if capacity_path.exists() {
             read_file("battery", &capacity_path)?
@@ -170,10 +168,29 @@ impl BatteryDevice for PowerSupplyDevice {
                 .parse::<u64>()
                 .block_error("battery", "failed to parse energy_now")?;
             ((charge as f64 / self.energy_full.unwrap() as f64) * 100.0) as u64
+        } else if capacity_level_path.exists() {
+            let capacity_level = read_file("battery", &capacity_level_path)?;
+            match capacity_level.as_str() {
+                "Full" => 100u64,
+                "High" => 75u64,
+                "Normal" => 50u64,
+                "Low" => 25u64,
+                "Critical" => 5u64,
+                "Unknown" => {
+                    return Err(BlockError("battery".into(), "Unknown charge level".into()));
+                }
+                _ => {
+                    return Err(BlockError(
+                        "battery".into(),
+                        "unexpected string from capacity_level file".into(),
+                    ));
+                }
+            }
         } else {
             return Err(BlockError(
                 "battery".to_string(),
-                "Device does not support reading capacity, charge, or energy".to_string(),
+                "Device does not support reading capacity, charge, energy or capacity_level"
+                    .to_string(),
             ));
         };
 
@@ -183,18 +200,6 @@ impl BatteryDevice for PowerSupplyDevice {
             // charge_now same as charge_full_design when the battery is full,
             // leading to >100% charge.
             _ => Ok(100),
-        }
-    }
-
-    fn capacity_level(&self) -> Result<String> {
-        let capacity_level_path = self.device_path.join("capacity_level");
-        if capacity_level_path.exists() {
-            read_file("battery", &capacity_level_path)
-        } else {
-            Err(BlockError(
-                "battery".to_string(),
-                "Device does not support reading capacity_level".to_string(),
-            ))
         }
     }
 
@@ -465,13 +470,6 @@ impl BatteryDevice for ApcUpsDevice {
         }
     }
 
-    fn capacity_level(&self) -> Result<String> {
-        Err(BlockError(
-            "battery".to_string(),
-            "charge_level not supported for apcups devices".into(),
-        ))
-    }
-
     fn time_remaining(&self) -> Result<u64> {
         Ok(self.time_left as u64)
     }
@@ -678,13 +676,6 @@ impl BatteryDevice for UpowerDevice {
                 capacity as u64
             }
         })
-    }
-
-    fn capacity_level(&self) -> Result<String> {
-        Err(BlockError(
-            "battery".to_string(),
-            "charge_level not supported for upower devices".into(),
-        ))
     }
 
     fn time_remaining(&self) -> Result<u64> {
@@ -936,29 +927,11 @@ impl Block for Battery {
             self.device.refresh_device_info()?;
 
             let status = self.device.status()?;
-            let mut capacity = self.device.capacity();
-
+            let capacity = self.device.capacity();
             let values = map!(
                 "percentage" => match capacity {
                     Ok(capacity) => Value::from_integer(capacity as i64).percents(),
-                    _ => match self.device.capacity_level() {
-                        Ok(capacity_level) => {
-                            capacity = match capacity_level.as_str() {
-                                "Full" => Ok(100u64),
-                                "High" => Ok(75u64),
-                                "Normal" => Ok(50u64),
-                                "Low" => Ok(25u64),
-                                "Critical" => Ok(10u64),
-                                "Unknown" => Err(BlockError("battery".into(), "Unknown charge level".into())),
-                                _ => Err(BlockError(
-                                    "battery".into(),
-                                    "unexpected string from capacity_level file".into(),
-                                )),
-                            };
-                            Value::from_string(capacity_level.into())
-                        },
-                        _ => Value::from_string("×".into()),
-                    }
+                    _ => Value::from_string("×".into()),
                 },
                 "time" => match self.device.time_remaining() {
                     Ok(0) => Value::from_string("".into()),


### PR DESCRIPTION
Some devices report a charge level rather than an accurate percentage.
This let's you specify the {charge_level} in the format string for
those devices.