### PR TITLE
Fix a race condition with kernel driver

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -890,6 +890,7 @@ impl Block for Battery {
         let mut available_before = self.device.is_available();
         let mut refresh;
         let mut status;
+        let mut capacity;
         // loop until available status before and after is the same
         // to prevent race conditions between is_available() and status()
         loop {
@@ -897,6 +898,7 @@ impl Block for Battery {
             // It may be a different battery now, thereby refresh the device specs.
             refresh = self.device.refresh_device_info();
             status = self.device.status();
+            capacity = self.device.capacity();
             let available_after = self.device.is_available();
             if available_before == available_after {
                 break;
@@ -923,7 +925,6 @@ impl Block for Battery {
                 return Err(e);
             }
             let status = status?;
-            let capacity = self.device.capacity();
             let values = map!(
                 "percentage" => match capacity {
                     Ok(capacity) => Value::from_integer(capacity as i64).percents(),

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -887,6 +887,8 @@ impl Block for Battery {
     fn update(&mut self) -> Result<Option<Update>> {
         // TODO: Maybe use dbus to immediately signal when the battery state changes.
 
+        // The device may have gone missing
+        // It may be a different battery now, thereby refresh the device specs.
         let refresh = self.device.refresh_device_info();
         let status = self.device.status();
 
@@ -909,8 +911,6 @@ impl Block for Battery {
                 return Err(e);
             }
             let status = status?;
-            // The device may have gone missing
-            // It may be a different battery now, thereby refresh the device specs.
             let capacity = self.device.capacity();
             let values = map!(
                 "percentage" => match capacity {

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -908,7 +908,7 @@ impl Block for Battery {
 
         // Exit early, if the battery device went missing, but the user
         // allows this device to go missing.
-        if !self.device.is_available() && self.allow_missing {
+        if !available_before && self.allow_missing {
             // Respect the original format string, even if the battery
             // cannot be found right now.
             let values = map!(


### PR DESCRIPTION
Since #1456 it is possible for status() and refresh_device_info() to
fail in case the device is not available.

If the device gets removed just after checking if it is available but
before checking for it's status this could crash i3status-rs.

So in order to prevent this I swapped the order so that we first check for the
device status and refresh the device info and then check if the device is available.

Now it's guaranteed that the device was available when we checked status() or
called refresh_device_info() before throwing an error.