### PR TITLE
Add wttr.in text block

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -56,6 +56,7 @@ You may find that the block you desire is not in the list below. In that case, f
 - [Uptime](#uptime)
 - [Watson](#watson)
 - [Weather](#weather)
+- [Wttr](#wttr)
 - [Xrandr](#xrandr)
 
 ## Apt
@@ -2116,6 +2117,38 @@ in which case they must be provided in the environment variables
 - `weather_default` (in all other cases)
 
 ###### [↥ back to top](#list-of-available-blocks)
+
+## Wttr
+Simple text block to use the [wttr.in](https://github.com/chubin/wttr.in) service and show simple weather
+information optimized for single line status bar.
+
+#### Examples
+
+Show simple weather in London:
+
+```toml
+[[block]]
+block = "wttr"
+location = "London"
+```
+
+More complex/custom
+
+```toml
+[[block]]
+block = "wttr"
+location = "37.240,-115.811"
+query = "format=%c+%t+%m++%h+%w"
+on_click = "open https://wttr.in/37.240,-115.811"
+```
+
+#### Options
+
+Key | Values | Required | Default
+----|--------|----------|--------
+`interval` | Update interval, in seconds. | No | `900`
+`query` | The wttr.in query parameter to adjust the layout and get additional information. Pleaser refer to this [documentation](https://github.com/chubin/wttr.in#one-line-output).| No | "format=1"
+`location` | The wttr.in location information. Please refer to this [documentation](https://github.com/chubin/wttr.in#one-line-output). | No | None
 
 ## Xrandr
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -40,6 +40,7 @@ pub mod toggle;
 pub mod uptime;
 pub mod watson;
 pub mod weather;
+pub mod wttr;
 pub mod xrandr;
 
 use self::apt::*;
@@ -84,6 +85,7 @@ use self::toggle::*;
 use self::uptime::*;
 use self::watson::*;
 use self::weather::*;
+use self::wttr::*;
 use self::xrandr::*;
 
 use std::process::Command;
@@ -301,6 +303,7 @@ pub fn create_block(
         "uptime" => block!(Uptime, id, block_config, shared_config, update_request),
         "watson" => block!(Watson, id, block_config, shared_config, update_request),
         "weather" => block!(Weather, id, block_config, shared_config, update_request),
+        "wttr" => block!(Wttr, id, block_config, shared_config, update_request),
         "xrandr" => block!(Xrandr, id, block_config, shared_config, update_request),
         other => Err(BlockError(other.to_string(), "Unknown block!".to_string())),
     }

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -218,7 +218,7 @@ define_blocks!(
     watson::Watson,
     weather::Weather,
     wttr::Wttr,
-    xrandr::Xrandr
+    xrandr::Xrandr,
 );
 
 pub fn create_block_typed<B>(

--- a/src/blocks/wttr.rs
+++ b/src/blocks/wttr.rs
@@ -1,0 +1,119 @@
+use std::time::Duration;
+
+use crossbeam_channel::Sender;
+use curl::easy::{Easy, List};
+use regex::Regex;
+use serde_derive::Deserialize;
+
+use crate::blocks::{Block, ConfigBlock, Update};
+use crate::config::SharedConfig;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::protocol::i3bar_event::I3BarEvent;
+use crate::scheduler::Task;
+use crate::widgets::text::TextWidget;
+use crate::widgets::I3BarWidget;
+
+pub struct Wttr {
+    id: usize,
+    text: TextWidget,
+    update_interval: Duration,
+    #[allow(dead_code)]
+    shared_config: SharedConfig,
+    query: String,
+    location: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
+pub struct WttrConfig {
+    #[serde(deserialize_with = "deserialize_duration")]
+    interval: Duration,
+    query: String,
+    location: Option<String>,
+}
+
+impl Default for WttrConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(900),
+            query: String::from("format=1"),
+            location: None,
+        }
+    }
+}
+
+impl ConfigBlock for Wttr {
+    type Config = WttrConfig;
+
+    fn new(
+        id: usize,
+        block_config: Self::Config,
+        shared_config: SharedConfig,
+        _tx_update_request: Sender<Task>,
+    ) -> Result<Self> {
+        let text = TextWidget::new(id, 0, shared_config.clone()).with_text("Wttr");
+
+        Ok(Wttr {
+            id,
+            update_interval: block_config.interval,
+            text,
+            query: block_config.query,
+            location: block_config.location,
+            shared_config,
+        })
+    }
+}
+
+const BASE_URL: &str = "https://wttr.in/";
+
+impl Block for Wttr {
+    fn update(&mut self) -> Result<Option<Update>> {
+        let url = match self.location {
+            Some(ref location) => format!("{}{}?{}", BASE_URL, location, self.query),
+            _ => format!("{}?{}", BASE_URL, self.query),
+        };
+
+        let mut data = Vec::new();
+        let mut handle = Easy::new();
+        let mut list = List::new();
+        list.append("User-Agent: curl/7.81.0").unwrap();
+        handle.http_headers(list).unwrap();
+        handle.url(&url).unwrap();
+        {
+            let mut transfer = handle.transfer();
+            transfer
+                .write_function(|new_data| {
+                    data.extend_from_slice(new_data);
+                    Ok(new_data.len())
+                })
+                .unwrap();
+            transfer.perform().unwrap();
+        }
+
+        let body = String::from_utf8(data).expect("body is not valid UTF8!");
+
+        // Pre-defined formats add a newline ('\n') to the end. Get rid of it.
+        let trimmed = body.trim();
+
+        // I don't know why but there are 3 whitespaces added to condition.
+        // This looks odd so get rid of it.
+        let rg = Regex::new(r"  +").unwrap();
+        let cleansed = rg.replace_all(trimmed, " ");
+
+        self.text.set_text(cleansed.to_string());
+        Ok(Some(self.update_interval.into()))
+    }
+
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
+        vec![&self.text]
+    }
+
+    fn click(&mut self, _: &I3BarEvent) -> Result<()> {
+        Ok(())
+    }
+
+    fn id(&self) -> usize {
+        self.id
+    }
+}


### PR DESCRIPTION
#### Why
I wanted a dead simple to use weather block to know if I need to wear a hat when going outside.
Although the weather block can provide me with the necessary information, I did not want to go through
the setup of an API key and formatting steps.
[wttr.in](https://github.com/chubin/wttr.in) does provide all this out of the box.

#### What
Add a simple text widget with as few configuration options as possible actually, none is required.
All display configuration can be done via the format query parameter of wttr.in.

#### TODO
- [ ] error handling
- [ ] cap minimum update interval to 900sec (IMHO weather data doesn't need to be updated every other second)

I just realized I should have run this through a feature request issue before, sry for that.

Samples:

![image](https://user-images.githubusercontent.com/675206/166147027-82360f6c-0e08-493d-b7b5-aa32c9848c48.png)

![image](https://user-images.githubusercontent.com/675206/166147057-07870bea-1778-4bef-ac60-853ec054d96f.png)
