### PR TITLE
Add block for libvirtd/qemu

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get required packages
-        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev pandoc
+        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get required packages
-        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev pandoc
+        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get required packages
-        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev pandoc
+        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get required packages
-        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev pandoc
+        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get required packages
-        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
+        run: sudo apt-get update && sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get required packages
-        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
+        run: sudo apt-get update && sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get required packages
-        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
+        run: sudo apt-get update && sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get required packages
-        run: sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
+        run: sudo apt-get update && sudo apt-get install libdbus-1-dev libpulse-dev libsensors-dev libnotmuch-dev libvirt-dev pandoc
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "signal-hook",
  "swayipc",
  "toml",
+ "virt",
 ]
 
 [[package]]
@@ -1142,6 +1143,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virt"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ce5cd536aa559d1088ddc531bbf3e55edc5db8ec0a5329dfb17f83a5b469ca"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 edition = "2018"
 
 [features]
-default = ["pulseaudio", "virt"]
+default = ["pulseaudio"]
 pulseaudio = ["libpulse-binding"]
 # Make widgets' borders visible. (for debugging purposes)
 debug_borders = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 edition = "2018"
 
 [features]
-default = ["pulseaudio"]
+default = ["pulseaudio", "virt"]
 pulseaudio = ["libpulse-binding"]
 # Make widgets' borders visible. (for debugging purposes)
 debug_borders = []
@@ -63,3 +63,7 @@ features = ["std"]
 
 [dev-dependencies]
 assert_fs = "1.0"
+
+[dependencies.virt]
+version = "0.2.11"
+optional = true

--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -54,6 +54,7 @@ You may find that the block you desire is not in the list below. In that case, f
 - [Time](#time)
 - [Toggle](#toggle)
 - [Uptime](#uptime)
+- [Virt](#virt)
 - [Watson](#watson)
 - [Weather](#weather)
 - [Xrandr](#xrandr)
@@ -2014,6 +2015,38 @@ Key | Values | Required | Default
 #### Used Icons
 
 - `uptime`
+
+###### [↥ back to top](#list-of-available-blocks)
+
+## Virt
+
+[Libvirt](https://libvirt.org/) is a virtualisation API wrapping QEMU and LXC, this block supports listing the number of active VMs, paused VMs, stopped VMs, and the number of images in your image stores
+
+#### Options
+
+Key        | Values                      | Required | Default
+-----------|-----------------------------|----------|--------
+`format`   | Display formatting          | No       | `{running}`
+`qemu_url` | Connection to libvirt       | No       | `qemu:///system`
+`interval` | Update interval in seconds. | No       | `5`
+
+#### Examples
+
+Display all availbale values:
+
+```toml
+[[block]]
+block = "virt"
+format = "Running VMS: {running}, Paused: {paused}, Stopped/Destroyed: {stopped}, Total: {total}, VirtualDisks/ISOs: {images}"
+```
+
+You can also connect to an external host (via any compatible libvirt URL, such as QEMU+SSH).
+
+```toml
+[[block]]
+block = "virt"
+qemu_url = "qemu+ssh://user@ip/system"
+```
 
 ###### [↥ back to top](#list-of-available-blocks)
 

--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -2032,7 +2032,7 @@ Key        | Values                      | Required | Default
 
 #### Examples
 
-Display all availbale values:
+Display all available values:
 
 ```toml
 [[block]]

--- a/files/icons/awesome.toml
+++ b/files/icons/awesome.toml
@@ -89,6 +89,7 @@ microphone_empty = "\uf130" # fa-microphone
 microphone_full = "\uf130" # fa-microphone
 microphone_half = "\uf130" # fa-microphone
 microphone_muted = "\uf131" # fa-microphone-slash
+virtual-machine = "\uf24d" # fa-clone
 weather_clouds = "\uf0c2" # fa-cloud
 weather_default = "\uf0c2" # fa-cloud
 weather_rain = "\uf043" # fa-tint

--- a/files/icons/awesome5.toml
+++ b/files/icons/awesome5.toml
@@ -89,6 +89,7 @@ microphone_full = "\uf3c9"
 microphone_half = "\uf3c9"
 microphone_empty = "\uf3c9"
 microphone_muted = "\uf539"
+virtual-machine = "\uf24d"        # fa-clone
 weather_clouds = "\uf0c2"
 weather_default = "\uf0c2"        # Cloud symbol as default
 weather_rain = "\uf043"

--- a/files/icons/awesome6.toml
+++ b/files/icons/awesome6.toml
@@ -89,6 +89,7 @@ microphone_full = "\uf3c9"
 microphone_half = "\uf3c9"
 microphone_empty = "\uf3c9"
 microphone_muted = "\uf539"
+virtual-machine = "\uf24d"        # fa-clone
 weather_clouds = "\uf0c2"
 weather_default = "\uf0c2"        # Cloud symbol as default
 weather_rain = "\uf043"

--- a/files/icons/material-nf.toml
+++ b/files/icons/material-nf.toml
@@ -94,6 +94,7 @@ microphone_full = "\uf86b" # nf-mdi-microphone
 microphone_half = "\uf86b" # nf-mdi-microphone
 microphone_empty = "\uf86d" # nf-mdi-microphone_outline
 microphone_muted = "\uf86c" # nf-mdi-microphone_off
+virtual-machine = "\ue14d" # nf-content_copy
 weather_clouds = "\ufa8f" # nf-mdi-weather_cloudy
 weather_default = "\ufa8f" # Cloud symbol as default
 weather_rain = "\ufa95" # nf-mdi-weather_pouring

--- a/files/icons/material.toml
+++ b/files/icons/material.toml
@@ -71,6 +71,7 @@ microphone_full = "\ue029" # mic
 microphone_half = "\ue029" # mic
 microphone_empty = "\ue02a" # mic_none
 microphone_muted = "\ue02b" # mic_off
+virtual-machine = "\ue14d" # content_copy
 weather_clouds = "\ue42d" # wb_cloudy
 weather_default = "\ue42d" # wb_cloudy
 weather_sun = "\ue430" # wb_sunny

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -1,5 +1,95 @@
+pub mod apt;
+pub mod backlight;
+pub mod battery;
+pub mod bluetooth;
+pub mod cpu;
+pub mod custom;
+pub mod custom_dbus;
+pub mod disk_space;
+pub mod dnf;
+pub mod docker;
+pub mod external_ip;
+pub mod focused_window;
+pub mod github;
+pub mod hueshift;
+pub mod ibus;
+pub mod kdeconnect;
+pub mod keyboard_layout;
+pub mod load;
+#[cfg(feature = "maildir")]
+pub mod maildir;
+pub mod memory;
+pub mod music;
+pub mod net;
+pub mod networkmanager;
+pub mod notify;
+#[cfg(feature = "notmuch")]
+pub mod notmuch;
+pub mod nvidia_gpu;
+pub mod pacman;
+pub mod pomodoro;
+pub mod rofication;
+pub mod sound;
+pub mod speedtest;
+pub mod taskwarrior;
+pub mod temperature;
+pub mod template;
+pub mod time;
+pub mod toggle;
+pub mod uptime;
+#[cfg(feature = "virt")]
+pub mod libvirt;
+pub mod watson;
+pub mod weather;
+pub mod xrandr;
+
 mod base_block;
 use base_block::*;
+
+use self::apt::*;
+use self::backlight::*;
+use self::battery::*;
+use self::bluetooth::*;
+use self::cpu::*;
+use self::custom::*;
+use self::custom_dbus::*;
+use self::disk_space::*;
+use self::dnf::*;
+use self::docker::*;
+use self::external_ip::*;
+use self::focused_window::*;
+use self::github::*;
+use self::hueshift::*;
+use self::ibus::*;
+use self::kdeconnect::*;
+use self::keyboard_layout::*;
+use self::load::*;
+#[cfg(feature = "maildir")]
+use self::maildir::*;
+use self::memory::*;
+use self::music::*;
+use self::net::*;
+use self::networkmanager::*;
+use self::notify::*;
+#[cfg(feature = "notmuch")]
+use self::notmuch::*;
+use self::nvidia_gpu::*;
+use self::pacman::*;
+use self::pomodoro::*;
+use self::rofication::*;
+use self::sound::*;
+use self::speedtest::*;
+use self::taskwarrior::*;
+use self::temperature::*;
+use self::template::*;
+use self::time::*;
+use self::toggle::*;
+use self::uptime::*;
+#[cfg(feature = "virt")]
+use self::libvirt::Libvirt;
+use self::watson::*;
+use self::weather::*;
+use self::xrandr::*;
 
 use std::process::Command;
 use std::time::Duration;
@@ -225,6 +315,7 @@ pub fn create_block_typed<B>(
     mut block_config: Value,
     mut shared_config: SharedConfig,
     update_request: Sender<Task>,
+<<<<<<< HEAD
 ) -> Result<Option<Box<dyn Block>>>
 where
     B: Block + ConfigBlock + 'static,
@@ -244,6 +335,74 @@ where
         {
             return Ok(None);
         }
+=======
+) -> Result<Option<Box<dyn Block>>> {
+    match name {
+        // Please keep these in alphabetical order.
+        "apt" => block!(Apt, id, block_config, shared_config, update_request),
+        "backlight" => block!(Backlight, id, block_config, shared_config, update_request),
+        "battery" => block!(Battery, id, block_config, shared_config, update_request),
+        "bluetooth" => block!(Bluetooth, id, block_config, shared_config, update_request),
+        "cpu" => block!(Cpu, id, block_config, shared_config, update_request),
+        "custom" => block!(Custom, id, block_config, shared_config, update_request),
+        "custom_dbus" => block!(CustomDBus, id, block_config, shared_config, update_request),
+        "disk_space" => block!(DiskSpace, id, block_config, shared_config, update_request),
+        "dnf" => block!(Dnf, id, block_config, shared_config, update_request),
+        "docker" => block!(Docker, id, block_config, shared_config, update_request), ///////
+        "external_ip" => block!(ExternalIP, id, block_config, shared_config, update_request),
+        "focused_window" => block!(
+            FocusedWindow,
+            id,
+            block_config,
+            shared_config,
+            update_request
+        ),
+        "github" => block!(Github, id, block_config, shared_config, update_request),
+        "hueshift" => block!(Hueshift, id, block_config, shared_config, update_request),
+        "ibus" => block!(IBus, id, block_config, shared_config, update_request),
+        "kdeconnect" => block!(KDEConnect, id, block_config, shared_config, update_request),
+        "keyboard_layout" => block!(
+            KeyboardLayout,
+            id,
+            block_config,
+            shared_config,
+            update_request
+        ),
+        "load" => block!(Load, id, block_config, shared_config, update_request),
+        #[cfg(feature = "maildir")]
+        "maildir" => block!(Maildir, id, block_config, shared_config, update_request),
+        "memory" => block!(Memory, id, block_config, shared_config, update_request),
+        "music" => block!(Music, id, block_config, shared_config, update_request),
+        "net" => block!(Net, id, block_config, shared_config, update_request),
+        "networkmanager" => block!(
+            NetworkManager,
+            id,
+            block_config,
+            shared_config,
+            update_request
+        ),
+        "notify" => block!(Notify, id, block_config, shared_config, update_request),
+        #[cfg(feature = "notmuch")]
+        "notmuch" => block!(Notmuch, id, block_config, shared_config, update_request),
+        "nvidia_gpu" => block!(NvidiaGpu, id, block_config, shared_config, update_request),
+        "pacman" => block!(Pacman, id, block_config, shared_config, update_request),
+        "pomodoro" => block!(Pomodoro, id, block_config, shared_config, update_request),
+        "rofication" => block!(Rofication, id, block_config, shared_config, update_request),
+        "sound" => block!(Sound, id, block_config, shared_config, update_request),
+        "speedtest" => block!(SpeedTest, id, block_config, shared_config, update_request),
+        "taskwarrior" => block!(Taskwarrior, id, block_config, shared_config, update_request),
+        "temperature" => block!(Temperature, id, block_config, shared_config, update_request),
+        "template" => block!(Template, id, block_config, shared_config, update_request),
+        "time" => block!(Time, id, block_config, shared_config, update_request), /////////
+        "toggle" => block!(Toggle, id, block_config, shared_config, update_request),
+        "uptime" => block!(Uptime, id, block_config, shared_config, update_request),
+        #[cfg(feature = "virt")]
+        "virt" => block!(Libvirt, id, block_config, shared_config, update_request),
+        "watson" => block!(Watson, id, block_config, shared_config, update_request),
+        "weather" => block!(Weather, id, block_config, shared_config, update_request),
+        "xrandr" => block!(Xrandr, id, block_config, shared_config, update_request),
+        other => Err(BlockError(other.to_string(), "Unknown block!".to_string())),
+>>>>>>> 89b36d9 (feat: add block for libvirtd/qemu)
     }
 
     // Apply theme overrides if presented

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -15,6 +15,8 @@ pub mod hueshift;
 pub mod ibus;
 pub mod kdeconnect;
 pub mod keyboard_layout;
+#[cfg(feature = "virt")]
+pub mod libvirt;
 pub mod load;
 #[cfg(feature = "maildir")]
 pub mod maildir;
@@ -37,8 +39,6 @@ pub mod template;
 pub mod time;
 pub mod toggle;
 pub mod uptime;
-#[cfg(feature = "virt")]
-pub mod libvirt;
 pub mod watson;
 pub mod weather;
 pub mod xrandr;
@@ -63,6 +63,8 @@ use self::hueshift::*;
 use self::ibus::*;
 use self::kdeconnect::*;
 use self::keyboard_layout::*;
+#[cfg(feature = "virt")]
+use self::libvirt::Libvirt;
 use self::load::*;
 #[cfg(feature = "maildir")]
 use self::maildir::*;
@@ -85,8 +87,6 @@ use self::template::*;
 use self::time::*;
 use self::toggle::*;
 use self::uptime::*;
-#[cfg(feature = "virt")]
-use self::libvirt::Libvirt;
 use self::watson::*;
 use self::weather::*;
 use self::xrandr::*;

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -315,7 +315,7 @@ pub fn create_block_typed<B>(
     mut block_config: Value,
     mut shared_config: SharedConfig,
     update_request: Sender<Task>,
-<<<<<<< HEAD
+
 ) -> Result<Option<Box<dyn Block>>>
 where
     B: Block + ConfigBlock + 'static,
@@ -335,74 +335,6 @@ where
         {
             return Ok(None);
         }
-=======
-) -> Result<Option<Box<dyn Block>>> {
-    match name {
-        // Please keep these in alphabetical order.
-        "apt" => block!(Apt, id, block_config, shared_config, update_request),
-        "backlight" => block!(Backlight, id, block_config, shared_config, update_request),
-        "battery" => block!(Battery, id, block_config, shared_config, update_request),
-        "bluetooth" => block!(Bluetooth, id, block_config, shared_config, update_request),
-        "cpu" => block!(Cpu, id, block_config, shared_config, update_request),
-        "custom" => block!(Custom, id, block_config, shared_config, update_request),
-        "custom_dbus" => block!(CustomDBus, id, block_config, shared_config, update_request),
-        "disk_space" => block!(DiskSpace, id, block_config, shared_config, update_request),
-        "dnf" => block!(Dnf, id, block_config, shared_config, update_request),
-        "docker" => block!(Docker, id, block_config, shared_config, update_request), ///////
-        "external_ip" => block!(ExternalIP, id, block_config, shared_config, update_request),
-        "focused_window" => block!(
-            FocusedWindow,
-            id,
-            block_config,
-            shared_config,
-            update_request
-        ),
-        "github" => block!(Github, id, block_config, shared_config, update_request),
-        "hueshift" => block!(Hueshift, id, block_config, shared_config, update_request),
-        "ibus" => block!(IBus, id, block_config, shared_config, update_request),
-        "kdeconnect" => block!(KDEConnect, id, block_config, shared_config, update_request),
-        "keyboard_layout" => block!(
-            KeyboardLayout,
-            id,
-            block_config,
-            shared_config,
-            update_request
-        ),
-        "load" => block!(Load, id, block_config, shared_config, update_request),
-        #[cfg(feature = "maildir")]
-        "maildir" => block!(Maildir, id, block_config, shared_config, update_request),
-        "memory" => block!(Memory, id, block_config, shared_config, update_request),
-        "music" => block!(Music, id, block_config, shared_config, update_request),
-        "net" => block!(Net, id, block_config, shared_config, update_request),
-        "networkmanager" => block!(
-            NetworkManager,
-            id,
-            block_config,
-            shared_config,
-            update_request
-        ),
-        "notify" => block!(Notify, id, block_config, shared_config, update_request),
-        #[cfg(feature = "notmuch")]
-        "notmuch" => block!(Notmuch, id, block_config, shared_config, update_request),
-        "nvidia_gpu" => block!(NvidiaGpu, id, block_config, shared_config, update_request),
-        "pacman" => block!(Pacman, id, block_config, shared_config, update_request),
-        "pomodoro" => block!(Pomodoro, id, block_config, shared_config, update_request),
-        "rofication" => block!(Rofication, id, block_config, shared_config, update_request),
-        "sound" => block!(Sound, id, block_config, shared_config, update_request),
-        "speedtest" => block!(SpeedTest, id, block_config, shared_config, update_request),
-        "taskwarrior" => block!(Taskwarrior, id, block_config, shared_config, update_request),
-        "temperature" => block!(Temperature, id, block_config, shared_config, update_request),
-        "template" => block!(Template, id, block_config, shared_config, update_request),
-        "time" => block!(Time, id, block_config, shared_config, update_request), /////////
-        "toggle" => block!(Toggle, id, block_config, shared_config, update_request),
-        "uptime" => block!(Uptime, id, block_config, shared_config, update_request),
-        #[cfg(feature = "virt")]
-        "virt" => block!(Libvirt, id, block_config, shared_config, update_request),
-        "watson" => block!(Watson, id, block_config, shared_config, update_request),
-        "weather" => block!(Weather, id, block_config, shared_config, update_request),
-        "xrandr" => block!(Xrandr, id, block_config, shared_config, update_request),
-        other => Err(BlockError(other.to_string(), "Unknown block!".to_string())),
->>>>>>> 89b36d9 (feat: add block for libvirtd/qemu)
     }
 
     // Apply theme overrides if presented

--- a/src/blocks/libvirt.rs
+++ b/src/blocks/libvirt.rs
@@ -25,29 +25,6 @@ pub struct Libvirt {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-struct Status {
-    #[allow(dead_code)]
-    #[serde(rename = "VMs")]
-    total: i64,
-
-    #[allow(dead_code)]
-    #[serde(rename = "VMsRunning")]
-    running: i64,
-
-    #[allow(dead_code)]
-    #[serde(rename = "VMsStopped")]
-    stopped: i64,
-
-    #[allow(dead_code)]
-    #[serde(rename = "VMsPaused")]
-    paused: i64,
-
-    #[allow(dead_code)]
-    #[serde(rename = "Images")]
-    images: i64,
-}
-
-#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields, default)]
 pub struct LibvirtConfig {
     /// Update interval in seconds

--- a/src/blocks/libvirt.rs
+++ b/src/blocks/libvirt.rs
@@ -26,7 +26,7 @@ pub struct Libvirt {
 }
 
 impl Libvirt {
-    fn check_and_reconnect(&mut self) -> Result<&mut Self> {
+    fn check_and_reconnect(&mut self) -> Result<()> {
         if !self
             .qemu_conn
             .is_alive()
@@ -35,7 +35,7 @@ impl Libvirt {
             self.qemu_conn = Connect::open_read_only(&self.qemu_uri)
                 .block_error("virt", "error in reconnecting to libvirt socket")?;
         };
-        Ok(self)
+        Ok(())
     }
 }
 

--- a/src/blocks/libvirt.rs
+++ b/src/blocks/libvirt.rs
@@ -1,0 +1,153 @@
+use virt::connect::Connect;
+
+use std::time::Duration;
+
+use crossbeam_channel::Sender;
+use serde_derive::Deserialize;
+
+use crate::blocks::{Block, ConfigBlock, Update};
+use crate::config::SharedConfig;
+use crate::de::deserialize_duration;
+use crate::errors::*;
+use crate::formatting::value::Value;
+use crate::formatting::FormatTemplate;
+use crate::scheduler::Task;
+use crate::widgets::text::TextWidget;
+use crate::widgets::I3BarWidget;
+use crate::widgets::State;
+
+pub struct Libvirt {
+    id: usize,
+    text: TextWidget,
+    format: FormatTemplate,
+    update_interval: Duration,
+    qemu_conn: Connect,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct Status {
+    #[allow(dead_code)]
+    #[serde(rename = "VMs")]
+    total: i64,
+
+    #[allow(dead_code)]
+    #[serde(rename = "VMsRunning")]
+    running: i64,
+
+    #[allow(dead_code)]
+    #[serde(rename = "VMsStopped")]
+    stopped: i64,
+
+    #[allow(dead_code)]
+    #[serde(rename = "VMsPaused")]
+    paused: i64,
+
+    #[allow(dead_code)]
+    #[serde(rename = "Images")]
+    images: i64,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
+pub struct LibvirtConfig {
+    /// Update interval in seconds
+    #[serde(deserialize_with = "deserialize_duration")]
+    pub interval: Duration,
+
+    /// Format override
+    pub format: FormatTemplate,
+
+    /// URL to QEMU
+    pub qemu_url: String,
+}
+
+impl Default for LibvirtConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(5),
+            format: FormatTemplate::default(),
+            qemu_url: "qemu:///system".to_string(),
+        }
+    }
+}
+
+impl ConfigBlock for Libvirt {
+    type Config = LibvirtConfig;
+
+    fn new(
+        id: usize,
+        block_config: Self::Config,
+        shared_config: SharedConfig,
+        _: Sender<Task>,
+    ) -> Result<Self> {
+        let text = TextWidget::new(id, 0, shared_config)
+            .with_text("vms")
+            .with_icon("virtual-machine")?;
+        Ok(Libvirt {
+            id,
+            text,
+            format: block_config.format.with_default("{running}")?,
+            update_interval: block_config.interval,
+            qemu_conn: Connect::open_read_only(&block_config.qemu_url).unwrap(),
+        })
+    }
+}
+
+impl Block for Libvirt {
+    fn update(&mut self) -> Result<Option<Update>> {
+        if !self.qemu_conn.is_alive().unwrap() {
+            self.qemu_conn = Connect::open_read_only(&self.qemu_conn.get_uri().unwrap()).unwrap()
+        };
+
+        let mut paused: i64 = 0;
+        match self.qemu_conn.list_all_domains(1 << 5) {
+            Ok(d) => paused = d.len() as i64,
+            Err(e) => eprintln!("{}", e),
+        }
+
+        let mut stopped: i64 = 0;
+        match self.qemu_conn.num_of_defined_domains() {
+            Ok(d) => stopped = d as i64,
+            Err(e) => eprintln!("{}", e),
+        };
+
+        let mut running = 0;
+        match self.qemu_conn.list_all_domains(1 << 4) {
+            Ok(d) => running = d.len() as i64,
+            Err(e) => eprintln!("{}", e),
+        };
+
+        let total = running + stopped + paused;
+
+        let mut num_images: i64 = 0;
+        match self.qemu_conn.list_all_storage_pools(1 << 1) {
+            Ok(pools) => {
+                for pool in pools {
+                    num_images += pool.num_of_volumes().unwrap() as i64;
+                }
+            }
+            Err(e) => eprintln!("{}", e),
+        };
+
+        let values = map!(
+            "total" =>   Value::from_integer(total),
+            "running" => Value::from_integer(running),
+            "paused" =>  Value::from_integer(paused),
+            "stopped" => Value::from_integer(stopped),
+            "images" =>  Value::from_integer(num_images),
+        );
+
+        self.text.set_texts(self.format.render(&values)?);
+        self.text.set_state(State::Idle);
+
+        Ok(Some(self.update_interval.into()))
+    }
+
+    fn view(&self) -> Vec<&dyn I3BarWidget> {
+        vec![&self.text]
+    }
+
+    fn id(&self) -> usize {
+        self.id
+    }
+}

--- a/src/blocks/libvirt.rs
+++ b/src/blocks/libvirt.rs
@@ -61,21 +61,13 @@ impl ConfigBlock for Libvirt {
             .with_text("vms")
             .with_icon("virtual-machine")?;
 
-        let qemu_conn = match Connect::open_read_only(&block_config.qemu_url)
-            .block_error("virt", "error when connecting to libvirt")
-        {
-            Ok(c) => c,
-            Err(e) => {
-                return Err(e);
-            }
-        };
-
         Ok(Libvirt {
             id,
             text,
             format: block_config.format.with_default("{running}")?,
             update_interval: block_config.interval,
-            qemu_conn,
+            qemu_conn: Connect::open_read_only(&block_config.qemu_url)
+                .block_error("virt", "error when connecting to libvirt")?,
         })
     }
 }

--- a/src/blocks/libvirt.rs
+++ b/src/blocks/libvirt.rs
@@ -22,6 +22,7 @@ pub struct Libvirt {
     format: FormatTemplate,
     update_interval: Duration,
     qemu_conn: Connect,
+    qemu_uri: String,
 }
 
 impl Libvirt {
@@ -31,13 +32,8 @@ impl Libvirt {
             .is_alive()
             .block_error("virt", "error when getting connection status to libvirt")?
         {
-            self.qemu_conn = Connect::open_read_only(
-                &self
-                    .qemu_conn
-                    .get_uri()
-                    .block_error("virt", "error in retrieving URI information from libvirt")?,
-            )
-            .block_error("virt", "error in reconnecting to libvirt socket")?;
+            self.qemu_conn = Connect::open_read_only(&self.qemu_uri)
+                .block_error("virt", "error in reconnecting to libvirt socket")?;
         };
         Ok(self)
     }
@@ -87,6 +83,7 @@ impl ConfigBlock for Libvirt {
             update_interval: block_config.interval,
             qemu_conn: Connect::open_read_only(&block_config.qemu_url)
                 .block_error("virt", "error when connecting to libvirt")?,
+            qemu_uri: block_config.qemu_url,
         })
     }
 }

--- a/src/blocks/libvirt.rs
+++ b/src/blocks/libvirt.rs
@@ -60,13 +60,22 @@ impl ConfigBlock for Libvirt {
         let text = TextWidget::new(id, 0, shared_config)
             .with_text("vms")
             .with_icon("virtual-machine")?;
+
+        let qemu_conn = match Connect::open_read_only(&block_config.qemu_url)
+            .block_error("virt", "error when connecting to libvirt")
+        {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(e);
+            }
+        };
+
         Ok(Libvirt {
             id,
             text,
             format: block_config.format.with_default("{running}")?,
             update_interval: block_config.interval,
-            qemu_conn: Connect::open_read_only(&block_config.qemu_url)
-                .expect("could not connect to libvirtd"),
+            qemu_conn,
         })
     }
 }


### PR DESCRIPTION
*Why*

I find it sometimes useful on my desktop to understand how many VMs I have running or that are paused/stopped at a glance.

*What*

a simple libvirt integration to count the number of running instances; optionally you can use format to display.

* "paused" (suspended)
* "stopped" (destroyed) domains 
* **and** a count of the images in the local disk store (such as virtual harddisks and ISOs, will count all activated storage).

Due to the crate [virt](https://crates.io/crates/virt) using a lot of unsafe, I figure it's best to keep it as an optional include.

I chose the icon 'copy' for the bar, as that closely resembles vmware's iconography.