### PR TITLE
Use full_format if battery is in 'Unknown' status

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -863,7 +863,7 @@ impl Block for Battery {
                 _ => false,
             };
 
-            if status == "Full" || status == "Not charging" || capacity_is_above_full_threshold {
+            if status == "Full" || status == "Not charging" || status == "Unknown" || capacity_is_above_full_threshold {
                 self.output.set_icon("bat_full")?;
                 self.output.set_texts(self.full_format.render(&values)?);
                 self.output.set_state(State::Good);


### PR DESCRIPTION
Useful for laptops which have battery conservation mode enabled.

On my laptop (Lenovo Legion 5 2020), the battery reports an 'Unknown' status if the battery is in conservation mode and the capacity is between 50% and 60%. In this state the battery is not charging or discharging, and an extra space is shown in the status bar. This patch makes that space disappear.