### PR TITLE
battery: add a special case for formatting of zero watts

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -851,8 +851,10 @@ impl Block for Battery {
                     Ok(time) => Value::from_string(format!("{}:{:02}", std::cmp::min(time / 60, 99), time % 60)),
                     _ => Value::from_string("×".into()),
                 },
-                // convert µW to W for display
+                // convert µW to W for display (the zero value is special-cased:
+                // Value::from_float(0).watts() yields "0.0nW" which looks weird)
                 "power" => match self.device.power_consumption() {
+                    Ok(0) => Value::from_string("0W".into()),
                     Ok(power) => Value::from_float(power as f64 * 1e-6).watts(),
                     _ => Value::from_string("×".into()),
                 },


### PR DESCRIPTION
When a power adapter is connected and the battery is fully charged, there will be no current going in or out of the battery. Therefore the power consumption is reported as 0. Before this commit, `Value::from_float(0).watts()` produces the display string "0.0nW" which looks weird. This change hardcodes "0W" instead.

I considered adding this special case to `struct Value` in general, but that would require some consideration as to what the default prefix should be. (Maybe the default prefix could be something that's configurable via chained builder methods in the same way as the units?)