### PR TITLE
doc/blocks.md - networkmanager - use toml single quotes for regex patterns

### DIFF
--- a/doc/blocks.md
+++ b/doc/blocks.md
@@ -1219,7 +1219,7 @@ Same thing for any compatible player, takes the first active on the bus, but ign
 [[block]]
 block = "music"
 buttons = ["play", "next"]
-interface_name_exclude = [".*kdeconnect.*", "mpd"]
+interface_name_exclude = ['.*kdeconnect.*', 'mpd']
 ```
 
 Start Spotify if the block is clicked whilst it's collapsed:
@@ -1345,7 +1345,7 @@ Creates a block which displays network connection information from NetworkManage
 [[block]]
 block = "networkmanager"
 on_click = "alacritty -e nmtui"
-interface_name_exclude = ["br\\-[0-9a-f]{12}", "docker\\d+"]
+interface_name_exclude = ['br\-[0-9a-f]{12}', 'docker\d+']
 interface_name_include = []
 ```
 
@@ -1355,7 +1355,7 @@ Same as previous, but also limits the length of SSID to 10 characters.
 [[block]]
 block = "networkmanager"
 on_click = "alacritty -e nmtui"
-interface_name_exclude = ["br\\-[0-9a-f]{12}", "docker\\d+"]
+interface_name_exclude = ['br\-[0-9a-f]{12}', 'docker\d+']
 interface_name_include = []
 ap_format = "{ssid^10}"
 ```

--- a/man/i3status-rs.1
+++ b/man/i3status-rs.1
@@ -3386,7 +3386,7 @@ name:
 [[block]]
 block = \[dq]music\[dq]
 buttons = [\[dq]play\[dq], \[dq]next\[dq]]
-interface_name_exclude = [\[dq].*kdeconnect.*\[dq], \[dq]mpd\[dq]]
+interface_name_exclude = [\[aq].*kdeconnect.*\[aq], \[aq]mpd\[aq]]
 \f[R]
 .fi
 .PP
@@ -3863,7 +3863,7 @@ NetworkManager.
 [[block]]
 block = \[dq]networkmanager\[dq]
 on_click = \[dq]alacritty -e nmtui\[dq]
-interface_name_exclude = [\[dq]br\[rs]\[rs]-[0-9a-f]{12}\[dq], \[dq]docker\[rs]\[rs]d+\[dq]]
+interface_name_exclude = [\[aq]br\[rs]-[0-9a-f]{12}\[aq], \[aq]docker\[rs]d+\[aq]]
 interface_name_include = []
 \f[R]
 .fi
@@ -3875,7 +3875,7 @@ Same as previous, but also limits the length of SSID to 10 characters.
 [[block]]
 block = \[dq]networkmanager\[dq]
 on_click = \[dq]alacritty -e nmtui\[dq]
-interface_name_exclude = [\[dq]br\[rs]\[rs]-[0-9a-f]{12}\[dq], \[dq]docker\[rs]\[rs]d+\[dq]]
+interface_name_exclude = [\[aq]br\[rs]-[0-9a-f]{12}\[aq], \[aq]docker\[rs]d+\[aq]]
 interface_name_include = []
 ap_format = \[dq]{ssid\[ha]10}\[dq]
 \f[R]


### PR DESCRIPTION
In TOML single quotes signify literal strings. Literal strings are
better suited for writing regex patterns as they prevent TOML from
processing escape sequences which are also frequently needed by regex
patterns.

Updated `networkmanager` and `music` block documentation to use single
quotes accordingly, to serve as a better example for users.