### PR TITLE
click handler: actually update the block when update=true

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -175,7 +175,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         select! {
             update = device.wait_for_change() => update?,
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -140,9 +140,9 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         api.set_widget(&widget).await?;
 
-        select! {
+        tokio::select! {
             _ = sleep(config.interval.0) => (),
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -32,6 +32,17 @@
 //! warning = 15.0
 //! format = "$icon.str() $available.eng(2)"
 //! ```
+//!
+//! Update block on right click:
+//!
+//! ```toml
+//! [[block]]
+//! block = "disk_space"
+//! [[block.click]]
+//! button = "right"
+//! update = true
+//! ```
+//!
 //! # Icons Used
 //! - `disk_drive`
 

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -65,7 +65,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         select! {
             _ = sleep(config.interval.0) => (),
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -158,13 +158,13 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         select! {
             _ = sleep(config.interval.0) => (),
+            _ = api.wait_for_update_request() => (),
             _ = stream.next() => {
                 // avoid too frequent updates
                 let _ = tokio::time::timeout(Duration::from_millis(100), async {
                     loop { let _ = stream.next().await; }
                 }).await;
             }
-            UpdateRequest = api.event() => (),
         }
     }
 }

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -121,7 +121,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         select! {
             _ = interval.tick() => (),
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -130,7 +130,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         select! {
             update = backend.wait_for_chagne() => update?,
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -93,7 +93,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         select! {
             _ = sleep(config.interval.0) => (),
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -78,7 +78,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         select! {
             _ = sleep(config.interval.0) => (),
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -75,7 +75,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         select! {
             _ = sleep(config.interval.0) => (),
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -87,9 +87,9 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         api.set_widget(&widget).await?;
 
-        select! {
+        tokio::select! {
             _ = timer.tick() => (),
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -71,7 +71,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         select! {
             _ = sleep(config.interval.0) => (),
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -186,7 +186,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
         select! {
             _ = sleep(config.interval.0) => (),
-            UpdateRequest = api.event() => (),
+            _ = api.wait_for_update_request() => (),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,8 +322,14 @@ impl BarState {
                 let (block, block_type) = self.blocks.get_mut(event.id).error("Events receiver: ID out of bounds")?;
                 match block {
                     Block::Running(block) => {
-                        if block.click_handler.handle(event.button).await.in_block(*block_type, event.id)? {
+                        match block.click_handler.handle(event.button).await.in_block(*block_type, event.id)? {
+                            click::PostAction::PassThrough => {
                                 let _ = block.event_sender.send(BlockEvent::Click(event)).await;
+                            }
+                            click::PostAction::RequestUpdate => {
+                                let _ = block.event_sender.send(BlockEvent::UpdateRequest).await;
+                            }
+                            click::PostAction::None => (),
                         }
                     }
                     Block::Failed(block) => {


### PR DESCRIPTION
1. Send an update request when `update=true`. Previously, the event
   would be passed through, but not every block updates itself on click
   by default.
2. This heavily used pattern doesn't do what it seems to do:
   ```rust
   tokio::select! {
       _ = timer.tick() => (),
       UpdateRequest = api.event() => (),
   }
   ```
   If `api.event()` returns a click event, it will just get discarded and
   `api.event()` will not be called again until `timer.tick()` completes. In
   other words, if you first click on a block and then ask it to update,
   it... will not update. Use this instead:
   ```rust
   tokio::select! {
       _ = timer.tick() => (),
       _ = api.wait_for_update_request() => (),
   }
   ```

Fixes #1015