### PR TITLE
custom: fix cycle

### DIFF
--- a/src/click.rs
+++ b/src/click.rs
@@ -21,17 +21,16 @@ pub enum MouseButton {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PostAction {
-    PassThrough,
-    RequestUpdate,
-    None,
+pub struct PostActions {
+    pub pass: bool,
+    pub update: bool,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
 pub struct ClickHandler(Vec<ClickConfigEntry>);
 
 impl ClickHandler {
-    pub async fn handle(&self, button: MouseButton) -> Result<PostAction> {
+    pub async fn handle(&self, button: MouseButton) -> Result<PostActions> {
         Ok(match self.0.iter().find(|e| e.button == button) {
             Some(entry) => {
                 if let Some(cmd) = &entry.cmd {
@@ -44,13 +43,15 @@ impl ClickHandler {
                         format!("'{:?}' button handler: Failed to run '{}", button, cmd)
                     })?;
                 }
-                if entry.update {
-                    PostAction::RequestUpdate
-                } else {
-                    PostAction::None
+                PostActions {
+                    pass: entry.pass,
+                    update: entry.update,
                 }
             }
-            None => PostAction::PassThrough,
+            None => PostActions {
+                pass: true,
+                update: false,
+            },
         })
     }
 }
@@ -69,6 +70,13 @@ pub struct ClickConfigEntry {
     /// Whether to update the block on click (default is `false`)
     #[serde(default)]
     update: bool,
+    /// Whether to pass click event to the block (default is `true`)
+    #[serde(default = "return_true")]
+    pass: bool,
+}
+
+fn return_true() -> bool {
+    true
 }
 
 impl<'de> Deserialize<'de> for MouseButton {

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,14 +322,12 @@ impl BarState {
                 let (block, block_type) = self.blocks.get_mut(event.id).error("Events receiver: ID out of bounds")?;
                 match block {
                     Block::Running(block) => {
-                        match block.click_handler.handle(event.button).await.in_block(*block_type, event.id)? {
-                            click::PostAction::PassThrough => {
-                                let _ = block.event_sender.send(BlockEvent::Click(event)).await;
-                            }
-                            click::PostAction::RequestUpdate => {
-                                let _ = block.event_sender.send(BlockEvent::UpdateRequest).await;
-                            }
-                            click::PostAction::None => (),
+                        let post_actions = block.click_handler.handle(event.button).await.in_block(*block_type, event.id)?;
+                        if post_actions.pass {
+                            let _ = block.event_sender.send(BlockEvent::Click(event)).await;
+                        }
+                        if post_actions.update {
+                            let _ = block.event_sender.send(BlockEvent::UpdateRequest).await;
                         }
                     }
                     Block::Failed(block) => {


### PR DESCRIPTION
Do not cycle automatically.

Also I realized that something like
```toml
[[block]]
block = "custom"
shell = "sh"
cycle = ["echo '🐑'", "cat /etc/hostname"]
[[block.click]]
button = "left"
cmd = "<command>"
```
currently will not work because click handler will not pass the event to the block. This can be made configurable, like `pass = true` or something. With `true` as the default.