### PR TITLE
Restore support for kbdd keyboard driver

### DIFF
--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -396,11 +396,9 @@ impl Backend for KbddBus {
     }
 
     async fn wait_for_chagne(&mut self) -> Result<()> {
-        select! {
-            Some(event) = self.stream.next() => {
-                let args = event.args().error("Failed to get the args from kbdd message")?;
-                self.current_layout = args.layout().trim().to_string();
-            }
+        if let Some(event) = self.stream.next().await {
+            let args = event.args().error("Failed to get the args from kbdd message")?;
+            self.current_layout = args.layout().trim().to_string();
         }
         Ok(())
     }


### PR DESCRIPTION
In the process of migration to async I saw that implementation for the kbdd keyboard driver is missing, so I decided to bring it back using zbus. This implementation is slightly different (and simpler) than the previous one, because before the layouts were parsed from setxkbmap -query command, mainly to save space and avoid the long names which kbdd provides. Now, with the option to map the output of a block to whatever the user wants, I've decided to use the strings from kbdd and to relay on the custom mappings for shorter names as the sway driver.

Also the widget was not added in the bar, so I've fixed that too in this PR.
