### PR TITLE
Add better support for empty batteries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,7 @@ block = "net"
 ```
 
 - `kdeconnect` block only supports kdeconnect v20.11.80 and newer (December 2020 and newer)
-
+- `battery` now defaults `full_threshold` to `95` as often batteries never fully charge
 - `custom_dbus`: `name` has been renamed to `path` and the DBus object is now at `rs.i3status`/`rs.i3status.custom` rather than `i3.status.rs`
 - `taskwarrior` block config options `format_singular` and `format_everything_done` have been removed, and instead implemented via the new formatter.
 - `focused_window` block config option `max_width` has been removed, and can instead be implemented via the new formatter, e.g. `max_width = 15; format = "{title}"` would now just be `format = "$title.str(15)"`
@@ -50,6 +50,8 @@ cmd = "random_command"
 - `custom_dbus` block can now be used more than one in your config
 - `custom` block has new config option `"persistent"` which runs a command in the background and updates the block text for each received output line.
 - `focused_window` block now supports the river window manager if ristate (https://gitlab.com/snakedye/ristate) is installed
+- `battery` now supports `empty_threshold` to specify below which percentage the battery is considered empty
+- `battery` now supports `empty_format` to use a custom format when the battery is empty
 
 ### Dependencies that are no longer required
 


### PR DESCRIPTION
Add `empty_threshold` and `empty_format` to `battery`.
Also change `full_threshold` to `95` as batteries often do not go all the way up to 100%.

Should also fix #1431.