### PR TITLE
config: remove top-level icons and theme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,19 @@ This is a major release which rewrites the core code to be asynchronous.
   button = "left"
   cmd = "random_command"
   ```
+- Top-level `theme` and `icons` config options have been removed. For example,
+  ```toml
+  theme = "solarized-dark"
+  icons = "awesome"
+  ```
+  needs to be changed to:
+  ```toml
+  [theme]
+  theme = "solarized-dark"
+  [icons]
+  icons = "awesome"
+  ```
+- `theme` and `icons`: `name` and `file` options have been merged into `theme`/`icons`. See above for an example.
 
 ### New features and bugfixes
 - When blocks error they no longer take down the entire bar. Instead, they now enter error mode: "X" will be shown and on left click the full error message will be shown in the bar.

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,26 +10,23 @@ This is a major release which rewrites the core code to be asynchronous.
 - Formatting system has been overhauled, introducing some breaking changes. For example, previously you might have had `format = "{percentage}"`, but placeholders are now denoted with a dollar sign rather then enclosed in brackets: `format = "$percentage"`.
 
 - `ibus` block has been removed. Suggested example replacement:
-```toml
-[[block]]
-block = "custom"
-#TODO
-```
-
+  ```toml
+  [[block]]
+  block = "custom"
+  #TODO
+  ```
 - `networkmanager` block has been removed (could be revisited in the future). Suggested example replacement:
-```toml
-[[block]]
-block = "net"
-#TODO
-```
-
+  ```toml
+  [[block]]
+  block = "net"
+  #TODO
+  ```
 - `taskwarrior` block config options `format_singular` and `format_everything_done` have been removed, and instead implemented via the new formatter. Example:
-```toml
-[[block]]
-block = "taskwarrior"
-#TODO
-```
-
+  ```toml
+  [[block]]
+  block = "taskwarrior"
+  #TODO
+  ```
 - `kdeconnect` block only supports kdeconnect v20.11.80 and newer (December 2020 and newer)
 - `battery` now defaults `full_threshold` to `95` as often batteries never fully charge
 - `custom_dbus`: `name` has been renamed to `path` and the DBus object is now at `rs.i3status`/`rs.i3status.custom` rather than `i3.status.rs`
@@ -37,19 +34,19 @@ block = "taskwarrior"
 - `music` block config option `smart_trim` has been removed
 - `pomodoro` interactive configuration ??
 - `on_click` is now implemented as `[[block.click]]`. For example,
-```toml
-[[block]]
-block = "pacman"
-on_click = "random_command"
-```
-needs to be changed to:
-```toml
-[[block]]
-block = "pacman"
-[[block.click]]
-button = "left"
-cmd = "random_command"
-```
+  ```toml
+  [[block]]
+  block = "pacman"
+  on_click = "random_command"
+  ```
+  needs to be changed to:
+  ```toml
+  [[block]]
+  block = "pacman"
+  [[block.click]]
+  button = "left"
+  cmd = "random_command"
+  ```
 
 ### New features and bugfixes
 - When blocks error they no longer take down the entire bar. Instead, they now enter error mode: "X" will be shown and on left click the full error message will be shown in the bar.

--- a/doc/themes.md
+++ b/doc/themes.md
@@ -1,23 +1,17 @@
 ## Choosing your theme and icon set
 To use a theme or icon set other than the default, add them to your configuration file like so:
 ```toml
+[theme]
 theme = "solarized-dark"
+[icons]
 icons = "awesome"
 ```
-NOTE: If you plan on [overriding](https://github.com/greshake/i3status-rust/blob/master/doc/themes.md#overriding-themes-and-icon-sets) parts of the theme/icon set then you will need to change your config file like so:
-```toml
-[theme]
-name = "solarized-dark"
-[icons]
-name = "awesome"
-```
-
 Both the theme and icon set can be loaded from a separate file. 
 ```toml
 [theme]
-file = "<file>"
+theme = "<file>"
 [icons]
-file = "<file_2>"
+icons = "<file>"
 ```
 where `<file>` can be either a filename or a full path and will be checked in this order:
 
@@ -82,13 +76,13 @@ Create a block in the configuration called `theme` or `icons` like so:
 
 ```toml
 [theme]
-name = "solarized-dark"
+theme = "solarized-dark"
 [theme.overrides]
 idle_bg = "#123456"
 idle_fg = "#abcdef"
 
 [icons]
-name = "awesome"
+icons = "awesome"
 [icons.overrides]
 bat = " | | "
 bat_full = " |X| "

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,11 +1,11 @@
 [theme]
-name = "solarized-dark"
+theme = "solarized-dark"
 [theme.overrides]
 idle_bg = "#123456"
 idle_fg = "#abcdef"
 
 [icons]
-name = "awesome"
+icons = "awesome"
 [icons.overrides]
 bat = " | | "
 bat_full = " |X| "

--- a/gen-screenshots/screenshot_config.toml
+++ b/gen-screenshots/screenshot_config.toml
@@ -1,4 +1,6 @@
+[theme]
 theme = "srcery"
+[icons]
 icons = "awesome6"
 
 [[block]]

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,10 +1,10 @@
+use crate::errors::*;
 use crate::util;
-use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::fmt;
 
-#[derive(Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(try_from = "IconsConfigRaw")]
 pub struct Icons(pub HashMap<String, String>);
 
 impl Default for Icons {
@@ -110,12 +110,13 @@ impl Default for Icons {
 }
 
 impl Icons {
-    pub fn from_file(file: &str) -> Option<Self> {
+    pub fn from_file(file: &str) -> Result<Self> {
         if file == "none" {
-            Some(Icons::default())
+            Ok(Icons::default())
         } else {
-            let file = util::find_file(file, Some("icons"), Some("toml"))?;
-            Some(Icons(util::deserialize_toml_file(&file).ok()?))
+            let file = util::find_file(file, Some("icons"), Some("toml"))
+                .or_error(|| format!("Icon set '{}' not found", file))?;
+            Ok(Icons(util::deserialize_toml_file(&file)?))
         }
     }
 
@@ -124,86 +125,22 @@ impl Icons {
     }
 }
 
-impl<'de> Deserialize<'de> for Icons {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(field_identifier, rename_all = "lowercase")]
-        enum Field {
-            Name,
-            File,
-            Overrides,
-        }
+#[derive(Deserialize)]
+struct IconsConfigRaw {
+    icons: Option<String>,
+    overrides: Option<HashMap<String, String>>,
+}
 
-        struct IconsVisitor;
+impl TryFrom<IconsConfigRaw> for Icons {
+    type Error = Error;
 
-        impl<'de> Visitor<'de> for IconsVisitor {
-            type Value = Icons;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct Icons")
-            }
-
-            /// Handle configs like:
-            ///
-            /// ```toml
-            /// icons = "awesome"
-            /// ```
-            fn visit_str<E>(self, file: &str) -> Result<Icons, E>
-            where
-                E: de::Error,
-            {
-                Icons::from_file(file)
-                    .ok_or_else(|| de::Error::custom(format!("Icon set '{}' not found.", file)))
-            }
-
-            /// Handle configs like:
-            ///
-            /// ```toml
-            /// [icons]
-            /// name = "awesome"
-            /// ```
-            fn visit_map<V>(self, mut map: V) -> Result<Icons, V::Error>
-            where
-                V: MapAccess<'de>,
-            {
-                let mut icons: Option<&str> = None;
-                let mut overrides: Option<HashMap<String, String>> = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Name | Field::File => {
-                            if icons.is_some() {
-                                return Err(de::Error::duplicate_field("name or file"));
-                            }
-                            icons = Some(map.next_value()?);
-                        }
-                        Field::Overrides => {
-                            if overrides.is_some() {
-                                return Err(de::Error::duplicate_field("overrides"));
-                            }
-                            overrides = Some(map.next_value()?);
-                        }
-                    }
-                }
-
-                let mut icons = match icons {
-                    Some(icons) => Icons::from_file(icons).ok_or_else(|| {
-                        de::Error::custom(format!("Icon set '{}' not found", icons))
-                    })?,
-                    None => Icons::default(),
-                };
-
-                if let Some(overrides) = overrides {
-                    for icon in overrides {
-                        icons.0.insert(icon.0, icon.1);
-                    }
-                }
-                Ok(icons)
+    fn try_from(raw: IconsConfigRaw) -> Result<Self, Self::Error> {
+        let mut icons = Self::from_file(raw.icons.as_deref().unwrap_or("none"))?;
+        if let Some(overrides) = raw.overrides {
+            for icon in overrides {
+                icons.0.insert(icon.0, icon.1);
             }
         }
-
-        deserializer.deserialize_any(IconsVisitor)
+        Ok(icons)
     }
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -125,7 +125,8 @@ impl Icons {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
+#[serde(deny_unknown_fields, default)]
 struct IconsConfigRaw {
     icons: Option<String>,
     overrides: Option<HashMap<String, String>>,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -2,7 +2,7 @@ pub mod i3bar_block;
 pub mod i3bar_event;
 
 use crate::config::SharedConfig;
-use crate::themes::Color;
+use crate::themes::color::Color;
 
 use i3bar_block::I3BarBlock;
 

--- a/src/protocol/i3bar_block.rs
+++ b/src/protocol/i3bar_block.rs
@@ -1,4 +1,4 @@
-use crate::themes::Color;
+use crate::themes::color::Color;
 use serde::Serialize;
 
 /// Represent block as described in <https://i3wm.org/docs/i3bar-protocol.html>

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,150 +1,15 @@
-use std::collections::HashMap;
-use std::fmt;
-use std::ops::Add;
-use std::str::FromStr;
+pub mod color;
 
-use color_space::{Hsv, Rgb};
-use serde::de::{self, Deserializer, MapAccess, Visitor};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::Deserialize;
+use std::collections::HashMap;
 
 use crate::errors::*;
 use crate::util;
 use crate::widget::State;
+use color::Color;
 
-// TODO docs
-// TODO tests
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Color {
-    None,
-    Auto,
-    Rgba(Rgb, u8),
-    Hsva(Hsv, u8),
-}
-
-impl Serialize for Color {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let format_rgb = |rgb: Rgb, a: u8| {
-            format!(
-                "#{:02X}{:02X}{:02X}{:02X}",
-                rgb.r as u8, rgb.g as u8, rgb.b as u8, a
-            )
-        };
-        match *self {
-            Self::None | Self::Auto => serializer.serialize_none(),
-            Self::Rgba(rgb, a) => serializer.serialize_str(&format_rgb(rgb, a)),
-            Self::Hsva(hsv, a) => serializer.serialize_str(&format_rgb(hsv.into(), a)),
-        }
-    }
-}
-
-impl Color {
-    pub fn skip_ser(&self) -> bool {
-        matches!(self, Self::None | Self::Auto)
-    }
-}
-
-impl Default for Color {
-    fn default() -> Self {
-        Self::None
-    }
-}
-
-impl Add for Color {
-    type Output = Color;
-    fn add(self, rhs: Self) -> Self::Output {
-        let add_hsv = |a: Hsv, b: Hsv| {
-            Hsv::new(
-                (a.h + b.h) % 360.,
-                (a.s + b.s).clamp(0., 1.),
-                (a.v + b.v).clamp(0., 1.),
-            )
-        };
-
-        match (self, rhs) {
-            // Do nothing
-            (x, Self::None | Self::Auto) | (Self::None | Self::Auto, x) => x,
-            // Hsv + Hsv => Hsv
-            (Color::Hsva(hsv1, a1), Color::Hsva(hsv2, a2)) => {
-                Color::Hsva(add_hsv(hsv1, hsv2), a1.saturating_add(a2))
-            }
-            // Rgb + Rgb => Rgb
-            (Color::Rgba(rgb1, a1), Color::Rgba(rgb2, a2)) => Color::Rgba(
-                Rgb::new(
-                    (rgb1.r + rgb2.r).clamp(0., 255.),
-                    (rgb1.g + rgb2.g).clamp(0., 255.),
-                    (rgb1.b + rgb2.b).clamp(0., 255.),
-                ),
-                a1.saturating_add(a2),
-            ),
-            // Hsv + Rgb => Hsv
-            // Rgb + Hsv => Hsv
-            (Color::Hsva(hsv, a1), Color::Rgba(rgb, a2))
-            | (Color::Rgba(rgb, a1), Color::Hsva(hsv, a2)) => {
-                Color::Hsva(add_hsv(hsv, rgb.into()), a1.saturating_add(a2))
-            }
-        }
-    }
-}
-
-impl FromStr for Color {
-    type Err = Error;
-
-    fn from_str(color: &str) -> Result<Self, Self::Err> {
-        Ok(if color == "none" || color.is_empty() {
-            Color::None
-        } else if color == "auto" {
-            Color::Auto
-        } else if color.starts_with("hsv:") {
-            let err_msg = || format!("'{}' is not a vaild HSVA color", color);
-            let color = color.split_at(4).1;
-            let mut components = color.split(':').map(|x| x.parse::<f64>().or_error(err_msg));
-            let h = components.next().or_error(err_msg)??;
-            let s = components.next().or_error(err_msg)??;
-            let v = components.next().or_error(err_msg)??;
-            let a = components.next().unwrap_or(Ok(100.))?;
-            Color::Hsva(Hsv::new(h, s / 100., v / 100.), (a / 100. * 255.) as u8)
-        } else {
-            let err_msg = || format!("'{}' is not a vaild RGBA color", color);
-            let rgb = color.get(1..7).or_error(err_msg)?;
-            let a = color.get(7..9).unwrap_or("FF");
-            Color::Rgba(
-                Rgb::from_hex(u32::from_str_radix(rgb, 16).or_error(err_msg)?),
-                u8::from_str_radix(a, 16).or_error(err_msg)?,
-            )
-        })
-    }
-}
-
-impl<'de> Deserialize<'de> for Color {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct ColorVisitor;
-
-        impl<'de> Visitor<'de> for ColorVisitor {
-            type Value = Color;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("color")
-            }
-
-            fn visit_str<E>(self, s: &str) -> Result<Color, E>
-            where
-                E: de::Error,
-            {
-                s.parse().serde_error()
-            }
-        }
-
-        deserializer.deserialize_any(ColorVisitor)
-    }
-}
-
-#[derive(Debug, Clone, Default)]
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(try_from = "ThemeConfigRaw")]
 pub struct Theme {
     pub idle_bg: Color,
     pub idle_fg: Color,
@@ -216,80 +81,20 @@ impl Theme {
     }
 }
 
-impl<'de> Deserialize<'de> for Theme {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(field_identifier, rename_all = "lowercase")]
-        enum Field {
-            Name,
-            File,
-            Overrides,
+#[derive(Deserialize)]
+struct ThemeConfigRaw {
+    theme: Option<String>,
+    overrides: Option<HashMap<String, String>>,
+}
+
+impl TryFrom<ThemeConfigRaw> for Theme {
+    type Error = Error;
+
+    fn try_from(raw: ThemeConfigRaw) -> Result<Self, Self::Error> {
+        let mut theme = Self::from_file(raw.theme.as_deref().unwrap_or("plain"))?;
+        if let Some(overrides) = &raw.overrides {
+            theme.apply_overrides(overrides)?;
         }
-
-        struct ThemeVisitor;
-
-        impl<'de> Visitor<'de> for ThemeVisitor {
-            type Value = Theme;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct Theme")
-            }
-
-            /// Handle configs like:
-            ///
-            /// ```toml
-            /// theme = "slick"
-            /// ```
-            fn visit_str<E>(self, file: &str) -> Result<Theme, E>
-            where
-                E: de::Error,
-            {
-                Theme::from_file(file).serde_error()
-            }
-
-            /// Handle configs like:
-            ///
-            /// ```toml
-            /// [theme]
-            /// name = "modern"
-            /// ```
-            fn visit_map<V>(self, mut map: V) -> Result<Theme, V::Error>
-            where
-                V: MapAccess<'de>,
-            {
-                let mut theme: Option<String> = None;
-                let mut overrides: Option<HashMap<String, String>> = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Name | Field::File => {
-                            if theme.is_some() {
-                                return Err(de::Error::duplicate_field("name or file"));
-                            }
-                            theme = Some(map.next_value()?);
-                        }
-                        Field::Overrides => {
-                            if overrides.is_some() {
-                                return Err(de::Error::duplicate_field("overrides"));
-                            }
-                            overrides = Some(map.next_value()?);
-                        }
-                    }
-                }
-
-                let theme = theme.unwrap_or_else(|| "plain".into());
-                let mut theme = Theme::from_file(&theme).serde_error()?;
-
-                if let Some(ref overrides) = overrides {
-                    theme.apply_overrides(overrides).serde_error()?;
-                }
-
-                Ok(theme)
-            }
-        }
-
-        deserializer.deserialize_any(ThemeVisitor)
+        Ok(theme)
     }
 }

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -81,7 +81,8 @@ impl Theme {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
+#[serde(deny_unknown_fields, default)]
 struct ThemeConfigRaw {
     theme: Option<String>,
     overrides: Option<HashMap<String, String>>,

--- a/src/themes/color.rs
+++ b/src/themes/color.rs
@@ -1,0 +1,134 @@
+use crate::errors::*;
+use color_space::{Hsv, Rgb};
+use serde::de::{self, Deserializer, Visitor};
+use serde::{Deserialize, Serialize, Serializer};
+use smart_default::SmartDefault;
+use std::fmt;
+use std::ops::Add;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, SmartDefault)]
+pub enum Color {
+    #[default]
+    None,
+    Auto,
+    Rgba(Rgb, u8),
+    Hsva(Hsv, u8),
+}
+
+impl Color {
+    pub fn skip_ser(&self) -> bool {
+        matches!(self, Self::None | Self::Auto)
+    }
+}
+
+impl Add for Color {
+    type Output = Color;
+    fn add(self, rhs: Self) -> Self::Output {
+        let add_hsv = |a: Hsv, b: Hsv| {
+            Hsv::new(
+                (a.h + b.h) % 360.,
+                (a.s + b.s).clamp(0., 1.),
+                (a.v + b.v).clamp(0., 1.),
+            )
+        };
+
+        match (self, rhs) {
+            // Do nothing
+            (x, Self::None | Self::Auto) | (Self::None | Self::Auto, x) => x,
+            // Hsv + Hsv => Hsv
+            (Color::Hsva(hsv1, a1), Color::Hsva(hsv2, a2)) => {
+                Color::Hsva(add_hsv(hsv1, hsv2), a1.saturating_add(a2))
+            }
+            // Rgb + Rgb => Rgb
+            (Color::Rgba(rgb1, a1), Color::Rgba(rgb2, a2)) => Color::Rgba(
+                Rgb::new(
+                    (rgb1.r + rgb2.r).clamp(0., 255.),
+                    (rgb1.g + rgb2.g).clamp(0., 255.),
+                    (rgb1.b + rgb2.b).clamp(0., 255.),
+                ),
+                a1.saturating_add(a2),
+            ),
+            // Hsv + Rgb => Hsv
+            // Rgb + Hsv => Hsv
+            (Color::Hsva(hsv, a1), Color::Rgba(rgb, a2))
+            | (Color::Rgba(rgb, a1), Color::Hsva(hsv, a2)) => {
+                Color::Hsva(add_hsv(hsv, rgb.into()), a1.saturating_add(a2))
+            }
+        }
+    }
+}
+
+impl FromStr for Color {
+    type Err = Error;
+
+    fn from_str(color: &str) -> Result<Self, Self::Err> {
+        Ok(if color == "none" || color.is_empty() {
+            Color::None
+        } else if color == "auto" {
+            Color::Auto
+        } else if color.starts_with("hsv:") {
+            let err_msg = || format!("'{}' is not a vaild HSVA color", color);
+            let color = color.split_at(4).1;
+            let mut components = color.split(':').map(|x| x.parse::<f64>().or_error(err_msg));
+            let h = components.next().or_error(err_msg)??;
+            let s = components.next().or_error(err_msg)??;
+            let v = components.next().or_error(err_msg)??;
+            let a = components.next().unwrap_or(Ok(100.))?;
+            Color::Hsva(Hsv::new(h, s / 100., v / 100.), (a / 100. * 255.) as u8)
+        } else {
+            let err_msg = || format!("'{}' is not a vaild RGBA color", color);
+            let rgb = color.get(1..7).or_error(err_msg)?;
+            let a = color.get(7..9).unwrap_or("FF");
+            Color::Rgba(
+                Rgb::from_hex(u32::from_str_radix(rgb, 16).or_error(err_msg)?),
+                u8::from_str_radix(a, 16).or_error(err_msg)?,
+            )
+        })
+    }
+}
+
+impl Serialize for Color {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let format_rgb = |rgb: Rgb, a: u8| {
+            format!(
+                "#{:02X}{:02X}{:02X}{:02X}",
+                rgb.r as u8, rgb.g as u8, rgb.b as u8, a
+            )
+        };
+        match *self {
+            Self::None | Self::Auto => serializer.serialize_none(),
+            Self::Rgba(rgb, a) => serializer.serialize_str(&format_rgb(rgb, a)),
+            Self::Hsva(hsv, a) => serializer.serialize_str(&format_rgb(hsv.into(), a)),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Color {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ColorVisitor;
+
+        impl<'de> Visitor<'de> for ColorVisitor {
+            type Value = Color;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("color")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Color, E>
+            where
+                E: de::Error,
+            {
+                s.parse().serde_error()
+            }
+        }
+
+        deserializer.deserialize_any(ColorVisitor)
+    }
+}


### PR DESCRIPTION
Fixes #1578

Also merges `name` & `file` options into `theme`/`icons`. For example:
```toml
[theme]
theme = "solarized-dark"
[icons]
icons = "awesome"
```

### TODO
- [x] Adjust documentation
- [x] Mention this in NEWS.md