### PR TITLE
Rework blocks errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,16 @@ Key | Description | Default
 `theme` | The [theme](https://github.com/greshake/i3status-rust/blob/master/doc/themes.md#available-themes) that should be used. | `"plain"`
 `[theme.theme_overrides]` | Refer to `Themes and Icons` below. | None
 `scrolling` | The direction of scrolling, either `natural` or `reverse`. | `"reverse"`
+`error_format` | A string to customise how block errors are displayed. See below for available placeholders. | `$short_error_message|X`
+`error_fullscreen_format` | A string to customise how block errors are displayed when clicked. See below for available placeholders. | `$full_error_message`
 `[[block]]` | All blocks that will exist in your bar. | none
+
+Available `error_format` and `error_fullscreen_format` placeholders:
+
+Placeholder         | Value
+--------------------|------
+full_error_message  | The full error message
+short_error_message | The short error message, if available
 
 There are also some optional block-level configuration variables, common to all blocks:
 
@@ -41,6 +50,8 @@ Key | Description | Default
 `icons_format` | Same as top-level config option, but for this block only. | `" {icon} "`
 `if_command` | Only display the block if the supplied command returns 0 on startup. | None 
 `error_interval` | How long to wait until restarting the block after an error occurred. | `5`
+`error_format` | Overrides global `error_format` | None
+`error_fullscreen_format` | Overrides global `error_fullscreen_format` | None
 `[block.theme_overrides]` | Same as top-level config option, but for this block only. Refer to `Themes and Icons` below. | None
 `[block.icons_overrides]` | Same as top-level config option, but for this block only. Refer to `Themes and Icons` below. | None
 `[[block.click]]` | Set or override click action for the block. See below for details. | Block default / None

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -2,6 +2,7 @@
 
 pub mod prelude;
 
+use crate::formatting::config::Config as FormatConfig;
 use crate::BoxedFuture;
 use futures::future::FutureExt;
 use serde::de::{self, Deserializer};
@@ -150,7 +151,6 @@ pub struct CommonApi {
     pub request_sender: mpsc::Sender<Request>,
 
     pub error_interval: Duration,
-    pub error_format: Option<String>,
 }
 
 impl CommonApi {
@@ -311,7 +311,9 @@ pub struct CommonConfig {
     #[serde(default = "CommonConfig::default_error_interval")]
     pub error_interval: u64,
     #[serde(default)]
-    pub error_format: Option<String>,
+    pub error_format: FormatConfig,
+    #[serde(default)]
+    pub error_fullscreen_format: FormatConfig,
 
     #[serde(default)]
     pub if_command: Option<String>,
@@ -332,6 +334,7 @@ impl CommonConfig {
             "icons_overrides",
             "error_interval",
             "error_format",
+            "error_fullscreen_format",
             "if_command",
         ];
         let mut common_table = Table::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,7 @@ impl Default for SharedConfig {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug)]
 pub struct Config {
     #[serde(flatten)]
     pub shared: SharedConfig,
@@ -56,6 +56,11 @@ pub struct Config {
     #[serde(default = "Config::default_double_click_delay")]
     pub double_click_delay: u64,
 
+    #[serde(default = "Config::default_error_format")]
+    pub error_format: String,
+    #[serde(default = "Config::default_error_fullscreen_format")]
+    pub error_fullscreen_format: String,
+
     #[serde(rename = "block")]
     pub blocks: Vec<value::Value>,
 }
@@ -67,5 +72,13 @@ impl Config {
 
     fn default_double_click_delay() -> u64 {
         200
+    }
+
+    fn default_error_format() -> String {
+        "$short_error_message|X".into()
+    }
+
+    fn default_error_fullscreen_format() -> String {
+        "$full_error_message".into()
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -52,12 +52,16 @@ pub trait InBlock {
     fn in_block(self, block: BlockType, block_id: usize) -> Self;
 }
 
+impl InBlock for Error {
+    fn in_block(mut self, block: BlockType, block_id: usize) -> Self {
+        self.block = Some((block, block_id));
+        self
+    }
+}
+
 impl<T> InBlock for Result<T> {
     fn in_block(self, block: BlockType, block_id: usize) -> Self {
-        self.map_err(|mut e| {
-            e.block = Some((block, block_id));
-            e
-        })
+        self.map_err(|e| e.in_block(block, block_id))
     }
 }
 

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -106,12 +106,6 @@ impl Deref for Format {
     }
 }
 
-impl Format {
-    pub fn intervals(&self) -> Vec<u64> {
-        self.inner.intervals.clone()
-    }
-}
-
 #[derive(Debug)]
 pub struct FormatInner {
     full: FormatTemplate,
@@ -122,6 +116,10 @@ pub struct FormatInner {
 impl FormatInner {
     pub fn contains_key(&self, key: &str) -> bool {
         self.full.contains_key(key) || self.short.as_ref().map_or(false, |x| x.contains_key(key))
+    }
+
+    pub fn intervals(&self) -> Vec<u64> {
+        self.intervals.clone()
     }
 
     pub fn render(&self, vars: &Values) -> Result<(Vec<Rendered>, Vec<Rendered>)> {


### PR DESCRIPTION
Implement a way for blocks to report (clickable) errors while still
being functional via `api.set_error()`.

`api.recoverable()` now uses `api.set_error()`.

Errors reported with `api.set_error()` provide the name of the block in
it's message, without the need for an explicit argument, just like
unrecoverable errors.

This makes it trivial to implement [this TODO](https://github.com/greshake/i3status-rust/blob/3eba9745309cd6261d4f7d51c1ee15e300ef674d/src/blocks/custom.rs#L128).