### PR TITLE
formatting: add binary SI prefixes

### DIFF
--- a/src/blocks/prelude.rs
+++ b/src/blocks/prelude.rs
@@ -2,7 +2,7 @@ pub use super::{BlockEvent::*, CommonApi};
 
 pub use crate::click::MouseButton;
 pub use crate::errors::*;
-pub use crate::formatting::{config::Config as FormatConfig, value::Value};
+pub use crate::formatting::{config::Config as FormatConfig, value::Value, Values};
 pub use crate::util::{default, new_dbus_connection, new_system_dbus_connection};
 pub use crate::widget::{State, Widget};
 pub use crate::wrappers::{Seconds, ShellString};

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -164,7 +164,7 @@ struct WeatherResult {
 }
 
 impl WeatherResult {
-    fn into_values(self) -> HashMap<Cow<'static, str>, Value> {
+    fn into_values(self) -> Values {
         map! {
             "location" => Value::text(self.location),
             "temp" => Value::degrees(self.temp),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -114,7 +114,7 @@ pub trait OptionExt<T> {
     fn error<M: Into<ErrorMsg>>(self, message: M) -> Result<T>;
     fn or_error<M: Into<ErrorMsg>, F: FnOnce() -> M>(self, f: F) -> Result<T>;
     fn config_error(self) -> Result<T>;
-    fn format_error<M: Into<ErrorMsg>>(self, message: M) -> Result<T>;
+    fn or_format_error<M: Into<ErrorMsg>, F: FnOnce() -> M>(self, f: F) -> Result<T>;
 }
 
 impl<T> OptionExt<T> for Option<T> {
@@ -145,10 +145,10 @@ impl<T> OptionExt<T> for Option<T> {
         })
     }
 
-    fn format_error<M: Into<ErrorMsg>>(self, message: M) -> Result<T> {
+    fn or_format_error<M: Into<ErrorMsg>, F: FnOnce() -> M>(self, f: F) -> Result<T> {
         self.ok_or_else(|| Error {
             kind: ErrorKind::Format,
-            message: Some(message.into()),
+            message: Some(f().into()),
             cause: None,
             block: None,
         })

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -83,7 +83,6 @@ pub mod value;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::errors::*;
@@ -93,18 +92,7 @@ use value::Value;
 
 pub type Values = HashMap<Cow<'static, str>, Value>;
 
-#[derive(Debug, Clone)]
-pub struct Format {
-    inner: Arc<FormatInner>,
-}
-
-impl Deref for Format {
-    type Target = FormatInner;
-
-    fn deref(&self) -> &Self::Target {
-        self.inner.as_ref()
-    }
-}
+pub type Format = Arc<FormatInner>;
 
 #[derive(Debug)]
 pub struct FormatInner {
@@ -122,7 +110,7 @@ impl FormatInner {
         self.intervals.clone()
     }
 
-    pub fn render(&self, vars: &Values) -> Result<(Vec<Rendered>, Vec<Rendered>)> {
+    pub fn render(&self, vars: &Values) -> Result<(Vec<Fragment>, Vec<Fragment>)> {
         let full = self.full.render(vars).error("Failed to render full text")?;
         let short = self
             .short
@@ -136,21 +124,12 @@ impl FormatInner {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct Rendered {
+pub struct Fragment {
     pub text: String,
     pub metadata: Metadata,
 }
 
-impl Rendered {
-    pub fn new(text: impl Into<String>) -> Self {
-        Self {
-            text: text.into(),
-            metadata: Default::default(),
-        }
-    }
-}
-
-impl From<String> for Rendered {
+impl From<String> for Fragment {
     fn from(text: String) -> Self {
         Self {
             text,

--- a/src/formatting/config.rs
+++ b/src/formatting/config.rs
@@ -30,13 +30,11 @@ impl Config {
             short.init_intervals(&mut intervals);
         }
 
-        Ok(Format {
-            inner: Arc::new(FormatInner {
-                full,
-                short: self.short,
-                intervals,
-            }),
-        })
+        Ok(Arc::new(FormatInner {
+            full,
+            short: self.short,
+            intervals,
+        }))
     }
 }
 

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -378,7 +378,13 @@ impl Formatter for EngFormatter {
                     None => (Prefix::min_available(), Prefix::max_available()),
                 };
 
-                let prefix = unit.clamp_prefix(Prefix::eng(val).clamp(min_prefix, max_prefix));
+                let prefix = unit
+                    .clamp_prefix(if min_prefix.is_binary() {
+                        Prefix::eng_binary(val)
+                    } else {
+                        Prefix::eng(val)
+                    })
+                    .clamp(min_prefix, max_prefix);
                 val = prefix.apply(val);
 
                 let mut digits = (val.max(1.).log10().floor() + 1.0) as isize;
@@ -393,7 +399,9 @@ impl Formatter for EngFormatter {
                     rest => format!("{:.*}", rest as usize - 1, val),
                 });
 
-                let display_prefix = !self.0.prefix.hidden && prefix != Prefix::One;
+                let display_prefix = !self.0.prefix.hidden
+                    && prefix != Prefix::One
+                    && prefix != Prefix::OneButBinary;
                 let display_unit = !self.0.unit.hidden && unit != Unit::None;
 
                 if display_prefix {

--- a/src/formatting/prefix.rs
+++ b/src/formatting/prefix.rs
@@ -5,18 +5,31 @@ use std::str::FromStr;
 /// SI prefix
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Prefix {
+    /// `n`
     Nano,
+    /// `u`
     Micro,
+    /// `m`
     Milli,
+    /// `1`
     One,
+    /// `1i`
     OneButBinary,
+    /// `K`
     Kilo,
+    /// `Ki`
     Kibi,
+    /// `M`
     Mega,
+    /// `Mi`
     Mebi,
+    /// `G`
     Giga,
+    /// `Gi`
     Gibi,
+    /// `T`
     Tera,
+    /// `Ti`
     Tebi,
 }
 

--- a/src/formatting/template.rs
+++ b/src/formatting/template.rs
@@ -1,9 +1,5 @@
-use super::formatter::{
-    new_formatter, Formatter, DEFAULT_FLAG_FORMATTER, DEFAULT_NUMBER_FORMATTER,
-    DEFAULT_STRING_FORMATTER,
-};
-use super::value::ValueInner;
-use super::{Rendered, Values};
+use super::formatter::{new_formatter, Formatter};
+use super::{Fragment, Values};
 use crate::errors::*;
 
 use std::iter::Peekable;
@@ -19,7 +15,7 @@ pub struct TokenList(pub Vec<Token>);
 pub enum Token {
     Text(String),
     Recursive(FormatTemplate),
-    Var {
+    Placeholder {
         name: String,
         formatter: Option<Box<dyn Formatter>>,
     },
@@ -29,16 +25,16 @@ impl FormatTemplate {
     pub fn contains_key(&self, key: &str) -> bool {
         self.0.iter().any(|token_list| {
             token_list.0.iter().any(|token| match token {
-                Token::Var { name, .. } => name == key,
+                Token::Placeholder { name, .. } => name == key,
                 Token::Recursive(rec) => rec.contains_key(key),
                 _ => false,
             })
         })
     }
 
-    pub fn render(&self, vars: &Values) -> Result<Vec<Rendered>> {
+    pub fn render(&self, values: &Values) -> Result<Vec<Fragment>> {
         for (i, token_list) in self.0.iter().enumerate() {
-            match token_list.render(vars) {
+            match token_list.render(values) {
                 Ok(res) => return Ok(res),
                 Err(e) if e.kind != ErrorKind::Format => return Err(e),
                 Err(e) if i == self.0.len() - 1 => return Err(e),
@@ -53,7 +49,7 @@ impl FormatTemplate {
             for t in &tl.0 {
                 match t {
                     Token::Recursive(r) => r.init_intervals(intervals),
-                    Token::Var {
+                    Token::Placeholder {
                         formatter: Some(f), ..
                     } => {
                         if let Some(i) = f.interval() {
@@ -68,9 +64,9 @@ impl FormatTemplate {
 }
 
 impl TokenList {
-    pub fn render(&self, vars: &Values) -> Result<Vec<Rendered>> {
+    pub fn render(&self, values: &Values) -> Result<Vec<Fragment>> {
         let mut retval = Vec::new();
-        let mut cur = Rendered::default();
+        let mut cur = Fragment::default();
         for token in &self.0 {
             match token {
                 Token::Text(text) => {
@@ -80,37 +76,34 @@ impl TokenList {
                         if !cur.text.is_empty() {
                             retval.push(cur);
                         }
-                        cur = Rendered::new(text.clone());
+                        cur = text.clone().into();
                     }
                 }
                 Token::Recursive(rec) => {
                     if !cur.text.is_empty() {
                         retval.push(cur);
                     }
-                    retval.extend(rec.render(vars)?);
+                    retval.extend(rec.render(values)?);
                     cur = retval.pop().unwrap_or_default();
                 }
-                Token::Var { name, formatter } => {
-                    let var = vars
-                        .get(name.as_str())
-                        .format_error(format!("Placeholder with name '{}' not found", name))?;
-                    let formatter = formatter.as_ref().map(|x| x.as_ref()).unwrap_or_else(|| {
-                        match &var.inner {
-                            ValueInner::Text(_) | ValueInner::Icon(_) => &DEFAULT_STRING_FORMATTER,
-                            ValueInner::Number { .. } => &DEFAULT_NUMBER_FORMATTER,
-                            ValueInner::Flag => &DEFAULT_FLAG_FORMATTER,
-                        }
-                    });
-                    let formatted = formatter.format(&var.inner)?;
-                    if var.metadata == cur.metadata {
+                Token::Placeholder { name, formatter } => {
+                    let value = values.get(name.as_str()).or_format_error(|| {
+                        format!("Placeholder with name '{}' not found", name)
+                    })?;
+                    let formatter = formatter
+                        .as_ref()
+                        .map(Box::as_ref)
+                        .unwrap_or_else(|| value.default_formatter());
+                    let formatted = formatter.format(&value.inner)?;
+                    if value.metadata == cur.metadata {
                         cur.text.push_str(&formatted);
                     } else {
                         if !cur.text.is_empty() {
                             retval.push(cur);
                         }
-                        cur = Rendered {
+                        cur = Fragment {
                             text: formatted,
-                            metadata: var.metadata,
+                            metadata: value.metadata,
                         };
                     }
                 }
@@ -168,7 +161,7 @@ fn read_format_template(it: &mut Peekable<impl Iterator<Item = char>>) -> Result
                     }
                     _ => None,
                 };
-                cur_list.push(Token::Var { name, formatter });
+                cur_list.push(Token::Placeholder { name, formatter });
             }
             _ => {
                 cur_list.push(Token::Text(read_text(it)));

--- a/src/formatting/template.rs
+++ b/src/formatting/template.rs
@@ -197,19 +197,8 @@ fn read_text(it: &mut Peekable<impl Iterator<Item = char>>) -> String {
 
 fn read_placeholder_name(it: &mut Peekable<impl Iterator<Item = char>>) -> String {
     let mut retval = String::new();
-    let mut escaped = false;
     while let Some(&c) = it.peek() {
-        if escaped {
-            escaped = false;
-            retval.push(c);
-            let _ = it.next();
-            continue;
-        }
         match c {
-            '\\' => {
-                let _ = it.next();
-                escaped = true;
-            }
             x if !x.is_alphanumeric() && x != '_' => break,
             x => {
                 let _ = it.next();
@@ -222,15 +211,8 @@ fn read_placeholder_name(it: &mut Peekable<impl Iterator<Item = char>>) -> Strin
 
 fn read_formatter(it: &mut impl Iterator<Item = char>) -> Result<String> {
     let mut retval = String::new();
-    let mut escaped = false;
     for c in it {
-        if escaped {
-            escaped = false;
-            retval.push(c);
-            continue;
-        }
         match c {
-            '\\' => escaped = true,
             '(' => return Ok(retval),
             x => retval.push(x),
         }

--- a/src/formatting/value.rs
+++ b/src/formatting/value.rs
@@ -1,3 +1,4 @@
+use super::formatter;
 use super::unit::Unit;
 use super::Metadata;
 use crate::widget::State;
@@ -105,5 +106,13 @@ impl Value {
     pub fn with_state(mut self, state: State) -> Self {
         self.metadata.state = Some(state);
         self
+    }
+
+    pub fn default_formatter(&self) -> &'static dyn formatter::Formatter {
+        match &self.inner {
+            ValueInner::Text(_) | ValueInner::Icon(_) => &formatter::DEFAULT_STRING_FORMATTER,
+            ValueInner::Number { .. } => &formatter::DEFAULT_NUMBER_FORMATTER,
+            ValueInner::Flag => &formatter::DEFAULT_FLAG_FORMATTER,
+        }
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,7 +1,7 @@
 use crate::config::SharedConfig;
 use crate::errors::*;
 use crate::escape::CollectEscaped;
-use crate::formatting::{Format, Rendered, Values};
+use crate::formatting::{Format, Fragment, Values};
 use crate::protocol::i3bar_block::I3BarBlock;
 use serde::Deserialize;
 
@@ -203,7 +203,7 @@ enum Source {
 }
 
 impl Source {
-    fn render(&self) -> Result<(Vec<Rendered>, Vec<Rendered>)> {
+    fn render(&self) -> Result<(Vec<Fragment>, Vec<Fragment>)> {
         match self {
             Self::Text(text) => Ok((vec![text.clone().into()], vec![])),
             Self::TextWithShort(full, short) => {


### PR DESCRIPTION
fixes #1493

(This commit contains some unrelated renames and refactors)

### Examples

`1i` is a special prefix which means "one but binary". `1i` is to `1` as `Ki` is to `K`.  This hack allows users to enable binary prefixes without setting `min_prefix`. If someone has a better idea, please share.

```toml
[[block]]
block = "disk_space"
format = "$available.eng(3,auto,1i)"
```

```toml
[[block]]
block = "net"
format = "$speed_down.eng(3,auto,Ki)$speed_up.eng(3,auto,Ki)"
```

### TODO
- [ ] Document this