### PR TITLE
formatting: embed icons using ^icon syntax

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -259,7 +259,9 @@ impl CommonApi {
     }
 
     pub fn get_icon(&self, icon: &str) -> Result<String> {
-        self.shared_config.get_icon(icon)
+        self.shared_config
+            .get_icon(icon)
+            .or_error(|| format!("Icon '{}' not found", icon))
     }
 
     /// Repeatedly call provided async function until it succeeds.

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -7,7 +7,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `device` | Network interface to monitor (as specified in `/sys/class/net/`). Supports regex. | If not set, device will be automatically selected every `interval`
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `"$speed_down.eng(3,B,K)$speed_up.eng(3,B,K)"`
+//! `format` | A string to customise the output of this block. See below for available placeholders. | `"^net_down$speed_down.eng(3,B,K)^net_up$speed_up.eng(3,B,K)"`
 //! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
 //! `interval` | Update interval in seconds | `2`
 //! `hide_missing` | Whether to hide interfaces that don't exist on the system. | `false`
@@ -76,7 +76,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
     let mut format = config
         .format
-        .with_default("$speed_down.eng(3,B,K)$speed_up.eng(3,B,K)")?;
+        .with_default("^net_down$speed_down.eng(3,B,K)^net_up$speed_up.eng(3,B,K)")?;
     let mut format_alt = match config.format_alt {
         Some(f) => Some(f.with_default("")?),
         None => None,
@@ -142,8 +142,8 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
                 push_to_hist(&mut tx_hist, speed_up);
 
                 let values = map! {
-                    "speed_down" => Value::bytes(speed_down).with_icon(api.get_icon("net_down")?),
-                    "speed_up" => Value::bytes(speed_up).with_icon(api.get_icon("net_up")?),
+                    "speed_down" => Value::bytes(speed_down),
+                    "speed_up" => Value::bytes(speed_up),
                     "graph_down" => Value::text(util::format_bar_graph(&rx_hist)),
                     "graph_up" => Value::text(util::format_bar_graph(&tx_hist)),
                     [if let Some(v) = device.ip] "ip" => Value::text(v.to_string()),

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -7,7 +7,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `device` | Network interface to monitor (as specified in `/sys/class/net/`). Supports regex. | If not set, device will be automatically selected every `interval`
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `"^net_down$speed_down.eng(3,B,K)^net_up$speed_up.eng(3,B,K)"`
+//! `format` | A string to customise the output of this block. See below for available placeholders. | `"^icon_net_down$speed_down.eng(3,B,K)^icon_net_up$speed_up.eng(3,B,K)"`
 //! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
 //! `interval` | Update interval in seconds | `2`
 //! `hide_missing` | Whether to hide interfaces that don't exist on the system. | `false`
@@ -76,7 +76,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
 
     let mut format = config
         .format
-        .with_default("^net_down$speed_down.eng(3,B,K)^net_up$speed_up.eng(3,B,K)")?;
+        .with_default("^icon_net_down$speed_down.eng(3,B,K)^icon_net_up$speed_up.eng(3,B,K)")?;
     let mut format_alt = match config.format_alt {
         Some(f) => Some(f.with_default("")?),
         None => None,

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -6,7 +6,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `"^ping$ping^net_down$speed_down^net_up$speed_up"`
+//! `format` | A string to customise the output of this block. See below for available placeholders. | `"^icon_ping$ping^icon_net_down$speed_down^icon_net_up$speed_up"`
 //! `interval` | Update interval in seconds | `1800`
 //!
 //! Placeholder  | Value          | Type   | Unit
@@ -23,7 +23,7 @@
 //! [[block]]
 //! block = "speedtest"
 //! interval = 1800
-//! format = "^ping$ping"
+//! format = "^icon_ping$ping"
 //! ```
 //!
 //! Hide ping and display speed in bytes per second each using 4 characters (without icons)
@@ -56,7 +56,7 @@ pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
     let mut widget = api.new_widget().with_format(
         config
             .format
-            .with_default("^ping$ping^net_down$speed_down^net_up$speed_up")?,
+            .with_default("^icon_ping$ping^icon_net_down$speed_down^icon_net_up$speed_up")?,
     );
 
     let mut command = Command::new("speedtest-cli");

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,6 @@ use serde::Deserialize;
 use std::sync::Arc;
 use toml::value;
 
-use crate::errors::*;
 use crate::icons::Icons;
 use crate::themes::Theme;
 use crate::util::default;
@@ -18,17 +17,11 @@ pub struct SharedConfig {
 }
 
 impl SharedConfig {
-    pub fn get_icon(&self, icon: &str) -> Result<String> {
+    pub fn get_icon(&self, icon: &str) -> Option<String> {
         if icon.is_empty() {
-            Ok(String::new())
+            Some(String::new())
         } else {
-            Ok(self.icons_format.replace(
-                "{icon}",
-                self.icons
-                    .0
-                    .get(icon)
-                    .or_error(|| format!("Icon '{icon}' not found: please check your icons file or open a new issue on GitHub if you use precompiled icons"))?,
-            ))
+            Some(self.icons_format.replace("{icon}", self.icons.0.get(icon)?))
         }
     }
 }

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -85,6 +85,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::config::SharedConfig;
 use crate::errors::*;
 use crate::widget::State;
 use template::FormatTemplate;
@@ -110,12 +111,19 @@ impl FormatInner {
         self.intervals.clone()
     }
 
-    pub fn render(&self, vars: &Values) -> Result<(Vec<Fragment>, Vec<Fragment>)> {
-        let full = self.full.render(vars).error("Failed to render full text")?;
+    pub fn render(
+        &self,
+        values: &Values,
+        config: &SharedConfig,
+    ) -> Result<(Vec<Fragment>, Vec<Fragment>)> {
+        let full = self
+            .full
+            .render(values, config)
+            .error("Failed to render full text")?;
         let short = self
             .short
             .as_ref()
-            .map(|s| s.render(vars))
+            .map(|s| s.render(values, config))
             .transpose()
             .error("Failed to render short text")?
             .unwrap_or_default();

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -362,11 +362,7 @@ pub struct EngFormatter(EngFixConfig);
 impl Formatter for EngFormatter {
     fn format(&self, val: &Value) -> Result<String> {
         match val {
-            Value::Number {
-                mut val,
-                mut unit,
-                icon,
-            } => {
+            Value::Number { mut val, mut unit } => {
                 if let Some(new_unit) = self.0.unit.unit {
                     val = unit.convert(val, new_unit)?;
                     unit = new_unit;
@@ -392,12 +388,11 @@ impl Formatter for EngFormatter {
                     digits += 1;
                 }
 
-                let mut retval = icon.clone();
-                retval.push_str(&match self.0.width as isize - digits {
+                let mut retval = match self.0.width as isize - digits {
                     isize::MIN..=0 => format!("{}", val.floor()),
                     1 => format!(" {}", val.floor() as i64),
                     rest => format!("{:.*}", rest as usize - 1, val),
-                });
+                };
 
                 let display_prefix = !self.0.prefix.hidden
                     && prefix != Prefix::One

--- a/src/formatting/template.rs
+++ b/src/formatting/template.rs
@@ -1,5 +1,6 @@
 use super::formatter::{new_formatter, Formatter};
 use super::{Fragment, Values};
+use crate::config::SharedConfig;
 use crate::errors::*;
 
 use std::iter::Peekable;
@@ -19,6 +20,9 @@ pub enum Token {
         name: String,
         formatter: Option<Box<dyn Formatter>>,
     },
+    Icon {
+        name: String,
+    },
 }
 
 impl FormatTemplate {
@@ -32,9 +36,9 @@ impl FormatTemplate {
         })
     }
 
-    pub fn render(&self, values: &Values) -> Result<Vec<Fragment>> {
+    pub fn render(&self, values: &Values, config: &SharedConfig) -> Result<Vec<Fragment>> {
         for (i, token_list) in self.0.iter().enumerate() {
-            match token_list.render(values) {
+            match token_list.render(values, config) {
                 Ok(res) => return Ok(res),
                 Err(e) if e.kind != ErrorKind::Format => return Err(e),
                 Err(e) if i == self.0.len() - 1 => return Err(e),
@@ -64,7 +68,7 @@ impl FormatTemplate {
 }
 
 impl TokenList {
-    pub fn render(&self, values: &Values) -> Result<Vec<Fragment>> {
+    pub fn render(&self, values: &Values, config: &SharedConfig) -> Result<Vec<Fragment>> {
         let mut retval = Vec::new();
         let mut cur = Fragment::default();
         for token in &self.0 {
@@ -83,13 +87,13 @@ impl TokenList {
                     if !cur.text.is_empty() {
                         retval.push(cur);
                     }
-                    retval.extend(rec.render(values)?);
+                    retval.extend(rec.render(values, config)?);
                     cur = retval.pop().unwrap_or_default();
                 }
                 Token::Placeholder { name, formatter } => {
-                    let value = values.get(name.as_str()).or_format_error(|| {
-                        format!("Placeholder with name '{}' not found", name)
-                    })?;
+                    let value = values
+                        .get(name.as_str())
+                        .or_format_error(|| format!("Placeholder '{}' not found", name))?;
                     let formatter = formatter
                         .as_ref()
                         .map(Box::as_ref)
@@ -105,6 +109,19 @@ impl TokenList {
                             text: formatted,
                             metadata: value.metadata,
                         };
+                    }
+                }
+                Token::Icon { name } => {
+                    let icon = config
+                        .get_icon(name)
+                        .or_format_error(|| format!("Icon '{}' not found", name))?;
+                    if cur.metadata.is_default() {
+                        cur.text.push_str(&icon);
+                    } else {
+                        if !cur.text.is_empty() {
+                            retval.push(cur);
+                        }
+                        cur = icon.into();
                     }
                 }
             }
@@ -153,7 +170,7 @@ fn read_format_template(it: &mut Peekable<impl Iterator<Item = char>>) -> Result
             }
             '$' => {
                 let _ = it.next();
-                let name = read_placeholder_name(it);
+                let name = read_ident(it);
                 let formatter = match it.peek() {
                     Some('.') => {
                         let _ = it.next();
@@ -162,6 +179,11 @@ fn read_format_template(it: &mut Peekable<impl Iterator<Item = char>>) -> Result
                     _ => None,
                 };
                 cur_list.push(Token::Placeholder { name, formatter });
+            }
+            '^' => {
+                let _ = it.next();
+                let name = read_ident(it);
+                cur_list.push(Token::Icon { name });
             }
             _ => {
                 cur_list.push(Token::Text(read_text(it)));
@@ -185,7 +207,7 @@ fn read_text(it: &mut Peekable<impl Iterator<Item = char>>) -> String {
                 let _ = it.next();
                 escaped = true;
             }
-            '{' | '}' | '$' | '|' => break,
+            '{' | '}' | '$' | '^' | '|' => break,
             x => {
                 let _ = it.next();
                 retval.push(x);
@@ -195,7 +217,7 @@ fn read_text(it: &mut Peekable<impl Iterator<Item = char>>) -> String {
     retval
 }
 
-fn read_placeholder_name(it: &mut Peekable<impl Iterator<Item = char>>) -> String {
+fn read_ident(it: &mut Peekable<impl Iterator<Item = char>>) -> String {
     let mut retval = String::new();
     while let Some(&c) = it.peek() {
         match c {

--- a/src/formatting/template.rs
+++ b/src/formatting/template.rs
@@ -182,6 +182,9 @@ fn read_format_template(it: &mut Peekable<impl Iterator<Item = char>>) -> Result
             }
             '^' => {
                 let _ = it.next();
+                if !consume_exact(it, "icon_") {
+                    return Err(Error::new("^ should be followed by 'icon_<name>'"));
+                }
                 let name = read_ident(it);
                 cur_list.push(Token::Icon { name });
             }
@@ -268,4 +271,13 @@ fn read_args(it: &mut impl Iterator<Item = char>) -> Result<Vec<String>> {
         }
     }
     Err(Error::new("Missing ')'"))
+}
+
+fn consume_exact(it: &mut impl Iterator<Item = char>, tag: &str) -> bool {
+    for c in tag.chars() {
+        if it.next() != Some(c) {
+            return false;
+        }
+    }
+    true
 }

--- a/src/formatting/value.rs
+++ b/src/formatting/value.rs
@@ -13,7 +13,7 @@ pub struct Value {
 pub enum ValueInner {
     Text(String),
     Icon(String),
-    Number { val: f64, unit: Unit, icon: String },
+    Number { val: f64, unit: Unit },
     Flag,
 }
 
@@ -59,7 +59,6 @@ impl Value {
         Self::new(ValueInner::Number {
             val: val.into_f64(),
             unit,
-            icon: String::new(),
         })
     }
 
@@ -91,13 +90,6 @@ impl Value {
 
 /// Set options
 impl Value {
-    pub fn with_icon(mut self, i: String) -> Self {
-        if let ValueInner::Number { icon, .. } = &mut self.inner {
-            *icon = i;
-        }
-        self
-    }
-
     pub fn with_instance(mut self, instance: usize) -> Self {
         self.metadata.instance = Some(instance);
         self

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -41,7 +41,10 @@ impl Widget {
     }
 
     pub fn with_icon(mut self, icon: &str) -> Result<Self> {
-        self.icon = self.shared_config.get_icon(icon)?;
+        self.icon = self
+            .shared_config
+            .get_icon(icon)
+            .or_error(|| format!("Icon '{}' not found", icon))?;
         Ok(self)
     }
 
@@ -72,7 +75,10 @@ impl Widget {
     }
 
     pub fn set_icon(&mut self, icon: &str) -> Result<()> {
-        self.icon = self.shared_config.get_icon(icon)?;
+        self.icon = self
+            .shared_config
+            .get_icon(icon)
+            .or_error(|| format!("Icon {icon} not found"))?;
         Ok(())
     }
 
@@ -100,7 +106,7 @@ impl Widget {
     pub fn get_data(&self) -> Result<Vec<I3BarBlock>> {
         // Create a "template" block
         let (key_bg, key_fg) = self.shared_config.theme.get_colors(self.state);
-        let (full, short) = self.source.render()?;
+        let (full, short) = self.source.render(&self.shared_config)?;
         let mut template = I3BarBlock {
             name: Some(self.id.to_string()),
             background: key_bg,
@@ -203,13 +209,13 @@ enum Source {
 }
 
 impl Source {
-    fn render(&self) -> Result<(Vec<Fragment>, Vec<Fragment>)> {
+    fn render(&self, config: &SharedConfig) -> Result<(Vec<Fragment>, Vec<Fragment>)> {
         match self {
             Self::Text(text) => Ok((vec![text.clone().into()], vec![])),
             Self::TextWithShort(full, short) => {
                 Ok((vec![full.clone().into()], vec![short.clone().into()]))
             }
-            Self::Format(format, Some(values)) => format.render(values),
+            Self::Format(format, Some(values)) => format.render(values, config),
             Self::None | Self::Format(_, None) => Ok((vec![], vec![])),
         }
     }


### PR DESCRIPTION
Resolves #1527

Will work nicely with #1618

Not documented yet. See `net` and `speedtest` for examples.