### PR TITLE
Allow "theme overrides" colors to link to other colors

### DIFF
--- a/doc/themes.md
+++ b/doc/themes.md
@@ -23,7 +23,6 @@ where `<file>` can be either a filename or a full path and will be checked in th
 Notes:
 - In case with icon sets, the file should be in `icons` subdirectory instead of `themes`.
 - You can omit the `.toml` extension while specifying `file` parameter.
-- `file` parameter is an alias to `name`, they are completely interchangeable.
 - All the predefined themes are provided as files, so you use them as examples of how to write your own themes/icon sets.
 
 # Available themes
@@ -78,8 +77,14 @@ Create a block in the configuration called `theme` or `icons` like so:
 [theme]
 theme = "solarized-dark"
 [theme.overrides]
+# Example: redefine `idle` colors
 idle_bg = "#123456"
 idle_fg = "#abcdef"
+# Example: swap `good` and `warning` colors
+good_fg = { link = "warning_fg" }
+good_bg = { link = "warning_bg" }
+warning_fg = { link = "good_fg" }
+warning_bg = { link = "good_bg" }
 
 [icons]
 icons = "awesome"
@@ -89,8 +94,6 @@ bat_full = " |X| "
 bat_charging = " |^| "
 bat_discharging = " |v| "
 ```
-
-Example configurations can be found as `example_theme.toml` and `example_icon.toml`.
 
 Besides global overrides you may also use per-block overrides using the `theme_overrides`, `icons_overrides` and `icons_format` options available for all blocks.
 For example:

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -3,6 +3,7 @@
 pub mod prelude;
 
 use crate::formatting::config::Config as FormatConfig;
+use crate::themes::ThemeOverrides;
 use crate::BoxedFuture;
 use futures::future::FutureExt;
 use serde::de::{self, Deserializer};
@@ -292,7 +293,7 @@ pub struct CommonConfig {
     #[serde(default)]
     pub icons_format: Option<String>,
     #[serde(default)]
-    pub theme_overrides: Option<HashMap<String, String>>,
+    pub theme_overrides: Option<ThemeOverrides>,
     #[serde(default)]
     pub icons_overrides: Option<HashMap<String, String>>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,7 @@ impl BarState {
             shared_config.icons_format = Arc::new(icons_format);
         }
         if let Some(theme_overrides) = common_config.theme_overrides {
-            Arc::make_mut(&mut shared_config.theme).apply_overrides(&theme_overrides)?;
+            Arc::make_mut(&mut shared_config.theme).apply_overrides(theme_overrides)?;
         }
         if let Some(icons_overrides) = common_config.icons_overrides {
             Arc::make_mut(&mut shared_config.icons).apply_overrides(icons_overrides);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,6 +3,7 @@ pub mod i3bar_event;
 
 use crate::config::SharedConfig;
 use crate::themes::color::Color;
+use crate::themes::separator::Separator;
 
 use i3bar_block::I3BarBlock;
 
@@ -41,7 +42,7 @@ pub fn print_blocks(blocks: &[Vec<I3BarBlock>], config: &SharedConfig) {
             data.name = Some(id.to_string());
         }
 
-        if let Some(separator) = &config.theme.separator {
+        if let Separator::Custom(separator) = &config.theme.separator {
             // The first widget's BG is used to get the FG color for the current separator
             let sep_fg = if config.theme.separator_fg == Color::Auto {
                 widgets.first().unwrap().background
@@ -77,14 +78,13 @@ pub fn print_blocks(blocks: &[Vec<I3BarBlock>], config: &SharedConfig) {
         }
     }
 
-    if let Some(end_separator) = &config.theme.end_separator {
-        let end_separator = I3BarBlock {
+    if let Separator::Custom(end_separator) = &config.theme.end_separator {
+        rendered_blocks.push(I3BarBlock {
             full_text: end_separator.clone(),
             background: Color::None,
             color: last_bg,
             ..Default::default()
-        };
-        rendered_blocks.push(end_separator);
+        });
     }
 
     println!("{},", serde_json::to_string(&rendered_blocks).unwrap());

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,15 +1,16 @@
 pub mod color;
+pub mod separator;
 
 use serde::Deserialize;
-use std::collections::HashMap;
 
 use crate::errors::*;
 use crate::util;
 use crate::widget::State;
 use color::Color;
+use separator::Separator;
 
 #[derive(Deserialize, Debug, Clone, Default)]
-#[serde(try_from = "ThemeConfigRaw")]
+#[serde(deny_unknown_fields, default)]
 pub struct Theme {
     pub idle_bg: Color,
     pub idle_fg: Color,
@@ -21,24 +22,15 @@ pub struct Theme {
     pub warning_fg: Color,
     pub critical_bg: Color,
     pub critical_fg: Color,
-    pub separator: Option<String>,
+    pub separator: Separator,
     pub separator_bg: Color,
     pub separator_fg: Color,
     pub alternating_tint_bg: Color,
     pub alternating_tint_fg: Color,
-    pub end_separator: Option<String>,
+    pub end_separator: Separator,
 }
 
 impl Theme {
-    pub fn from_file(file: &str) -> Result<Theme> {
-        let file = util::find_file(file, Some("themes"), Some("toml"))
-            .or_error(|| format!("Theme '{}' not found", file))?;
-        let map: HashMap<String, String> = util::deserialize_toml_file(&file)?;
-        let mut theme = Self::default();
-        theme.apply_overrides(&map)?;
-        Ok(theme)
-    }
-
     pub fn get_colors(&self, state: State) -> (Color, Color) {
         match state {
             State::Idle => (self.idle_bg, self.idle_fg),
@@ -49,21 +41,20 @@ impl Theme {
         }
     }
 
-    pub fn apply_overrides(&mut self, overrides: &HashMap<String, String>) -> Result<()> {
-        if let Some(separator) = overrides.get("separator") {
-            if separator == "native" {
-                self.separator = None;
-            } else {
-                self.separator = Some(separator.clone());
-            }
+    pub fn apply_overrides(&mut self, overrides: ThemeOverrides) -> Result<()> {
+        let copy = self.clone();
+
+        if let Some(separator) = overrides.separator {
+            self.separator = separator;
         }
-        if let Some(end_separator) = overrides.get("end_separator") {
-            self.end_separator = Some(end_separator.clone());
+        if let Some(end_separator) = overrides.end_separator {
+            self.end_separator = end_separator;
         }
+
         macro_rules! apply {
             ($prop:tt) => {
-                if let Some(val) = overrides.get(stringify!($prop)) {
-                    self.$prop = val.parse()?;
+                if let Some(color) = overrides.$prop {
+                    self.$prop = color.eval(&copy)?;
                 }
             };
         }
@@ -81,25 +72,81 @@ impl Theme {
         apply!(separator_fg);
         apply!(alternating_tint_bg);
         apply!(alternating_tint_fg);
+
         Ok(())
     }
 }
 
 #[derive(Deserialize, Default)]
 #[serde(deny_unknown_fields, default)]
-struct ThemeConfigRaw {
+pub struct ThemeUserConfig {
     theme: Option<String>,
-    overrides: Option<HashMap<String, String>>,
+    overrides: Option<ThemeOverrides>,
 }
 
-impl TryFrom<ThemeConfigRaw> for Theme {
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct ThemeOverrides {
+    idle_bg: Option<ColorOrLink>,
+    idle_fg: Option<ColorOrLink>,
+    info_bg: Option<ColorOrLink>,
+    info_fg: Option<ColorOrLink>,
+    good_bg: Option<ColorOrLink>,
+    good_fg: Option<ColorOrLink>,
+    warning_bg: Option<ColorOrLink>,
+    warning_fg: Option<ColorOrLink>,
+    critical_bg: Option<ColorOrLink>,
+    critical_fg: Option<ColorOrLink>,
+    separator: Option<Separator>,
+    separator_bg: Option<ColorOrLink>,
+    separator_fg: Option<ColorOrLink>,
+    alternating_tint_bg: Option<ColorOrLink>,
+    alternating_tint_fg: Option<ColorOrLink>,
+    end_separator: Option<Separator>,
+}
+
+impl TryFrom<ThemeUserConfig> for Theme {
     type Error = Error;
 
-    fn try_from(raw: ThemeConfigRaw) -> Result<Self, Self::Error> {
-        let mut theme = Self::from_file(raw.theme.as_deref().unwrap_or("plain"))?;
-        if let Some(overrides) = &raw.overrides {
+    fn try_from(user_config: ThemeUserConfig) -> Result<Self, Self::Error> {
+        let name = user_config.theme.as_deref().unwrap_or("plain");
+        let file = util::find_file(name, Some("themes"), Some("toml"))
+            .or_error(|| format!("Theme '{name}' not found"))?;
+        let mut theme: Theme = util::deserialize_toml_file(file)?;
+        if let Some(overrides) = user_config.overrides {
             theme.apply_overrides(overrides)?;
         }
         Ok(theme)
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(untagged)]
+enum ColorOrLink {
+    Color(Color),
+    Link { link: String },
+}
+
+impl ColorOrLink {
+    fn eval(self, theme: &Theme) -> Result<Color> {
+        Ok(match self {
+            Self::Color(c) => c,
+            Self::Link { link } => match link.as_str() {
+                "idle_bg" => theme.idle_bg,
+                "idle_fg" => theme.idle_fg,
+                "info_bg" => theme.info_bg,
+                "info_fg" => theme.info_fg,
+                "good_bg" => theme.good_bg,
+                "good_fg" => theme.good_fg,
+                "warning_bg" => theme.warning_bg,
+                "warning_fg" => theme.warning_fg,
+                "critical_bg" => theme.critical_bg,
+                "critical_fg" => theme.critical_fg,
+                "separator_bg" => theme.separator_bg,
+                "separator_fg" => theme.separator_fg,
+                "alternating_tint_bg" => theme.alternating_tint_bg,
+                "alternating_tint_fg" => theme.alternating_tint_fg,
+                _ => return Err(Error::new(format!("{link} is not a correct theme color"))),
+            },
+        })
     }
 }

--- a/src/themes/separator.rs
+++ b/src/themes/separator.rs
@@ -1,0 +1,51 @@
+use crate::errors::*;
+use serde::de::{self, Deserializer, Visitor};
+use serde::Deserialize;
+use smart_default::SmartDefault;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Eq, SmartDefault)]
+pub enum Separator {
+    #[default]
+    Native,
+    Custom(String),
+}
+
+impl FromStr for Separator {
+    type Err = Error;
+
+    fn from_str(separator: &str) -> Result<Self, Self::Err> {
+        Ok(if separator == "native" {
+            Self::Native
+        } else {
+            Self::Custom(separator.into())
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for Separator {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SeparatorVisitor;
+
+        impl<'de> Visitor<'de> for SeparatorVisitor {
+            type Value = Separator;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a separator string or 'native'")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                s.parse().serde_error()
+            }
+        }
+
+        deserializer.deserialize_any(SeparatorVisitor)
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -94,10 +94,12 @@ pub fn battery_level_icon(level: u8, charging: bool) -> &'static str {
     }
 }
 
-pub fn deserialize_toml_file<T>(path: &Path) -> Result<T>
+pub fn deserialize_toml_file<T, P>(path: P) -> Result<T>
 where
     T: DeserializeOwned,
+    P: AsRef<Path>,
 {
+    let path = path.as_ref();
     let mut contents = String::new();
     let file = File::open(path).or_error(|| format!("Failed to open file: {}", path.display()))?;
     BufReader::new(file)


### PR DESCRIPTION
Example usage (swap idle and warning colors):
```toml
[block.theme_overrides]
idle_fg = { link = "warning_fg" }
idle_bg = { link = "warning_bg" }
warning_fg = { link = "idle_fg" }
warning_bg = { link = "idle_bg" }
```

Fixes #1527

TODO: adjust docs.