### PR TITLE
refactor: avoid toml::Value manipulation

### DIFF
--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -52,8 +52,8 @@ use tokio::process::Command;
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct AptConfig {
+#[serde(default)]
+pub struct Config {
     #[default(600.into())]
     interval: Seconds,
     format: FormatConfig,
@@ -63,8 +63,7 @@ struct AptConfig {
     critical_updates_regex: Option<String>,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = AptConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new();
 
     let format = config.format.with_default(" $icon $count.eng(1) ")?;

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -110,8 +110,8 @@ const BACKLIGHT_ICONS: &[&str] = &[
 ];
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct BacklightConfig {
+#[serde(default)]
+pub struct Config {
     device: Option<String>,
     format: FormatConfig,
     #[default(5)]
@@ -126,8 +126,7 @@ struct BacklightConfig {
     invert_icons: bool,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = BacklightConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $icon $brightness ")?);
 
     let mut cycle = config

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -74,8 +74,8 @@ mod upower;
 // make_log_macro!(debug, "battery");
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct BatteryConfig {
+#[serde(default)]
+pub struct Config {
     device: Option<String>,
     driver: BatteryDriver,
     #[default(10.into())]
@@ -107,8 +107,7 @@ enum BatteryDriver {
     Upower,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = BatteryConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let format = config.format.with_default(" $icon $percentage ")?;
     let format_full = config.full_format.with_default(" $icon ")?;
     let format_empty = config.empty_format.with_default(" $icon ")?;

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -49,8 +49,7 @@ use zbus::fdo::{ObjectManagerProxy, PropertiesProxy};
 make_log_macro!(debug, "bluetooth");
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
-struct BluetoothConfig {
+pub struct Config {
     mac: String,
     #[serde(default)]
     adapter_mac: Option<String>,
@@ -60,8 +59,7 @@ struct BluetoothConfig {
     disconnected_format: FormatConfig,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = BluetoothConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let format = config.format.with_default(" $icon $name{ $percentage|} ")?;
     let disconnected_format = config
         .disconnected_format

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -45,17 +45,15 @@ const CPU_BOOST_PATH: &str = "/sys/devices/system/cpu/cpufreq/boost";
 const CPU_NO_TURBO_PATH: &str = "/sys/devices/system/cpu/intel_pstate/no_turbo";
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct CpuConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     format_alt: Option<FormatConfig>,
     #[default(5.into())]
     interval: Seconds,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = CpuConfig::deserialize(config).config_error()?;
-
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut format = config.format.with_default(" $icon $utilization ")?;
     let mut format_alt = match config.format_alt {
         Some(f) => Some(f.with_default("")?),

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -98,8 +98,8 @@ use tokio::io::{self, AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct CustomConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     command: Option<String>,
     persistent: bool,
@@ -146,8 +146,7 @@ async fn update_bar(
     }
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = CustomConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(
         config
             .format

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -63,8 +63,7 @@ static DBUS_CONNECTION: async_once_cell::OnceCell<Result<zbus::Connection>> =
 const DBUS_NAME: &str = "rs.i3status";
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
-struct CustomDBusConfig {
+pub struct Config {
     #[serde(default)]
     format: FormatConfig,
     path: String,
@@ -121,13 +120,12 @@ impl Block {
     }
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     // This block doesn't listen for any events. Closing the channel is necessary, because channels
     // are bounded by the number of pending messages, and if we don't close it now, main thread
     // will get blocked while trying to send a new message.
     api.event_receiver.close();
 
-    let config = CustomDBusConfig::deserialize(config).config_error()?;
     let widget = Widget::new().with_format(
         config
             .format

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -65,8 +65,8 @@ pub enum InfoType {
 }
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct DiskSpaceConfig {
+#[serde(default)]
+pub struct Config {
     #[default("/".into())]
     path: ShellString,
     info_type: InfoType,
@@ -81,9 +81,7 @@ struct DiskSpaceConfig {
     alert: f64,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = DiskSpaceConfig::deserialize(config).config_error()?;
-
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut format = config.format.with_default(" $icon $available ")?;
     let mut format_alt = match config.format_alt {
         Some(f) => Some(f.with_default("")?),

--- a/src/blocks/dnf.rs
+++ b/src/blocks/dnf.rs
@@ -44,8 +44,8 @@ use regex::Regex;
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct DnfConfig {
+#[serde(default)]
+pub struct Config {
     #[default(600.into())]
     interval: Seconds,
     format: FormatConfig,
@@ -55,8 +55,7 @@ struct DnfConfig {
     critical_updates_regex: Option<String>,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = DnfConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new();
 
     let format = config.format.with_default(" $icon $count.eng(1) ")?;

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -35,8 +35,8 @@ use std::path::Path;
 use tokio::net::UnixStream;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct DockerConfig {
+#[serde(default)]
+pub struct Config {
     #[default(5.into())]
     interval: Seconds,
     format: FormatConfig,
@@ -44,8 +44,7 @@ struct DockerConfig {
     socket_path: ShellString,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = DockerConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget =
         Widget::new().with_format(config.format.with_default(" $icon $running.eng(1) ")?);
     let socket_path = config.socket_path.expand()?;

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -65,8 +65,8 @@ use crate::util::{country_flag_from_iso_code, new_system_dbus_connection};
 const API_ENDPOINT: &str = "https://ipapi.co/json/";
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct ExternalIpConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     #[default(300.into())]
     interval: Seconds,
@@ -74,8 +74,7 @@ struct ExternalIpConfig {
     with_network_manager: bool,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = ExternalIpConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $ip $country_flag ")?);
 
     type UpdatesStream = Pin<Box<dyn Stream<Item = ()>>>;

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -43,8 +43,8 @@ use tokio::{
 };
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct FocusedWindowConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     driver: Driver,
 }
@@ -58,8 +58,7 @@ enum Driver {
     Ristate,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = FocusedWindowConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $title.str(0,21) |")?);
 
     let mut backend: Box<dyn Backend> = match config.driver {

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -61,8 +61,8 @@
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct GithubConfig {
+#[serde(default)]
+pub struct Config {
     #[default(60.into())]
     interval: Seconds,
     format: FormatConfig,
@@ -74,8 +74,7 @@ struct GithubConfig {
     critical: Option<Vec<String>>,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = GithubConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget =
         Widget::new().with_format(config.format.with_default(" $icon $total.eng(1) ")?);
 

--- a/src/blocks/hueshift.rs
+++ b/src/blocks/hueshift.rs
@@ -54,8 +54,8 @@ use crate::util::has_command;
 use futures::future::pending;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct HueshiftConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     #[default(5.into())]
     interval: Seconds,
@@ -73,8 +73,7 @@ struct HueshiftConfig {
     click_temp: u16,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = HueshiftConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $temperature ")?);
 
     // limit too big steps at 500K to avoid too brutal changes

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -61,8 +61,8 @@ use super::prelude::*;
 use crate::util::battery_level_icon;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct Config {
+#[serde(default)]
+pub struct Config {
     device_id: Option<String>,
     format: FormatConfig,
     #[default(60)]
@@ -77,8 +77,7 @@ struct Config {
     hide_disconnected: bool,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = Config::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(
         config
             .format

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -85,8 +85,8 @@ use tokio::process::Command;
 use zbus::dbus_proxy;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default, deny_unknown_fields)]
-struct KeyboardLayoutConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     driver: KeyboardLayoutDriver,
     #[default(60.into())]
@@ -105,8 +105,7 @@ enum KeyboardLayoutDriver {
     Sway,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = KeyboardLayoutConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $layout ")?);
 
     let mut backend: Box<dyn Backend> = match config.driver {

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -33,8 +33,8 @@ use super::prelude::*;
 use crate::util;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct LoadConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     #[default(3.into())]
     interval: Seconds,
@@ -46,8 +46,7 @@ struct LoadConfig {
     critical: f64,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = LoadConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $icon $1m.eng(3) ")?);
 
     // borrowed from https://docs.rs/cpuinfo/0.1.1/src/cpuinfo/count/logical.rs.html#4-6

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -40,8 +40,8 @@ use super::prelude::*;
 use maildir::Maildir;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct MaildirConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     #[default(5.into())]
     interval: Seconds,
@@ -54,8 +54,7 @@ struct MaildirConfig {
     display_type: MailType,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let mut config = MaildirConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $icon $status ")?);
 
     for inbox in &mut config.inboxes {

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -59,8 +59,8 @@ use super::prelude::*;
 use crate::util::read_file;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct MemoryConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     format_alt: Option<FormatConfig>,
     #[default(5.into())]
@@ -75,8 +75,7 @@ struct MemoryConfig {
     critical_swap: f64,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = MemoryConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new();
 
     let mut format = config.format.with_default(

--- a/src/blocks/menu.rs
+++ b/src/blocks/menu.rs
@@ -35,8 +35,7 @@ use super::prelude::*;
 use crate::subprocess::spawn_shell;
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
-struct Config {
+pub struct Config {
     text: String,
     items: Vec<Item>,
 }
@@ -104,9 +103,7 @@ impl Block {
     }
 }
 
-pub async fn run(config: toml::Value, api: CommonApi) -> Result<()> {
-    let config = Config::deserialize(config).config_error()?;
-
+pub async fn run(config: Config, api: CommonApi) -> Result<()> {
     let mut block = Block {
         widget: Widget::new(),
         api,

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -95,8 +95,8 @@ const NEXT_BTN: usize = 2;
 const PREV_BTN: usize = 3;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct MusicConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     player: PlayerName,
     interface_name_exclude: Vec<String>,
@@ -129,8 +129,7 @@ struct OwnerChange {
     pub new_owner: Optional<String>,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = MusicConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let dbus_conn = new_dbus_connection().await?;
     let mut widget = Widget::new().with_format(
         config

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -60,8 +60,8 @@ use regex::Regex;
 use std::time::Instant;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct NetConfig {
+#[serde(default)]
+pub struct Config {
     device: Option<String>,
     format: FormatConfig,
     format_alt: Option<FormatConfig>,
@@ -70,9 +70,7 @@ struct NetConfig {
     interval: Seconds,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = NetConfig::deserialize(config).config_error()?;
-
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut format = config.format.with_default(
         " $icon ^icon_net_down $speed_down.eng(3,B,K) ^icon_net_up $speed_up.eng(3,B,K) ",
     )?;

--- a/src/blocks/notify.rs
+++ b/src/blocks/notify.rs
@@ -38,8 +38,8 @@ const ICON_ON: &str = "bell";
 const ICON_OFF: &str = "bell-slash";
 
 #[derive(Deserialize, Debug, Default)]
-#[serde(deny_unknown_fields, default)]
-struct NotifyConfig {
+#[serde(default)]
+pub struct Config {
     driver: DriverType,
     format: FormatConfig,
 }
@@ -51,8 +51,7 @@ enum DriverType {
     Dunst,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = NotifyConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $icon ")?);
 
     let mut driver: Box<dyn Driver + Send + Sync> = match config.driver {

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -43,8 +43,8 @@
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct NotmuchConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     #[default(10.into())]
     interval: Seconds,
@@ -61,8 +61,7 @@ struct NotmuchConfig {
     threshold_good: u32,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = NotmuchConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $icon $count ")?);
 
     let db = config.maildir.expand()?;

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -62,8 +62,8 @@ const FORMAT: &str = "--format=csv,noheader,nounits";
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct NvidiaGpuConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     #[default(1.into())]
     interval: Seconds,
@@ -79,8 +79,7 @@ struct NvidiaGpuConfig {
     warning: u32,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = NvidiaGpuConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(
         config
             .format

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -144,8 +144,8 @@ static PACMAN_DB: Lazy<PathBuf> = Lazy::new(|| {
 });
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct PacmanConfig {
+#[serde(default)]
+pub struct Config {
     #[default(600.into())]
     interval: Seconds,
     format: FormatConfig,
@@ -156,8 +156,7 @@ struct PacmanConfig {
     aur_command: Option<String>,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = PacmanConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new();
 
     let format = config.format.with_default(" $icon $pacman.eng(1) ")?;

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -62,8 +62,8 @@ use crate::subprocess::{spawn_shell, spawn_shell_sync};
 use std::time::Instant;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct PomodoroConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     #[default("Pomodoro over! Take a break!".into())]
     message: String,
@@ -76,7 +76,7 @@ struct PomodoroConfig {
 struct Block {
     widget: Widget,
     api: CommonApi,
-    block_config: PomodoroConfig,
+    block_config: Config,
 }
 
 impl Block {
@@ -228,8 +228,7 @@ impl Block {
     }
 }
 
-pub async fn run(block_config: toml::Value, api: CommonApi) -> Result<()> {
-    let block_config = PomodoroConfig::deserialize(block_config).config_error()?;
+pub async fn run(block_config: Config, api: CommonApi) -> Result<()> {
     let format = FormatConfig::default().with_default(" $icon{ $message|} ")?;
     let widget = Widget::new().with_format(format);
 

--- a/src/blocks/rofication.rs
+++ b/src/blocks/rofication.rs
@@ -33,8 +33,8 @@ use super::prelude::*;
 use crate::subprocess::spawn_shell;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct RoficationConfig {
+#[serde(default)]
+pub struct Config {
     #[default(1.into())]
     interval: Seconds,
     #[default("/tmp/rofi_notification_daemon".into())]
@@ -42,8 +42,7 @@ struct RoficationConfig {
     format: FormatConfig,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = RoficationConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $icon $num.eng(1) ")?);
 
     let path = config.socket_path.expand()?;

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -73,8 +73,8 @@ mod pulseaudio;
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct SoundConfig {
+#[serde(default)]
+pub struct Config {
     driver: SoundDriver,
     name: Option<String>,
     device: Option<String>,
@@ -89,8 +89,7 @@ struct SoundConfig {
     max_vol: Option<u32>,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = SoundConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget =
         Widget::new().with_format(config.format.with_default(" $icon {$volume.eng(2)|} ")?);
 

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -44,15 +44,14 @@ use super::prelude::*;
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct SpeedtestConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     #[default(1800.into())]
     interval: Seconds,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = SpeedtestConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget =
         Widget::new().with_format(config.format.with_default(
             " ^icon_ping $ping ^icon_net_down $speed_down ^icon_net_up $speed_up ",

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -50,8 +50,8 @@ use inotify::{Inotify, WatchMask};
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields, default)]
-struct TaskwarriorConfig {
+#[serde(default)]
+pub struct Config {
     interval: Seconds,
     warning_threshold: u32,
     critical_threshold: u32,
@@ -61,7 +61,7 @@ struct TaskwarriorConfig {
     data_location: ShellString,
 }
 
-impl Default for TaskwarriorConfig {
+impl Default for Config {
     fn default() -> Self {
         Self {
             interval: Seconds::new(600),
@@ -78,8 +78,7 @@ impl Default for TaskwarriorConfig {
     }
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = TaskwarriorConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget =
         Widget::new().with_format(config.format.with_default(" $icon $done|$count.eng(1) ")?);
 

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -62,8 +62,8 @@ const DEFAULT_INFO: f64 = 60.0;
 const DEFAULT_WARN: f64 = 80.0;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct TemperatureConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     format_alt: Option<FormatConfig>,
     #[default(5.into())]
@@ -95,9 +95,7 @@ impl TemperatureScale {
     }
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = TemperatureConfig::deserialize(config).config_error()?;
-
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut format = config
         .format
         .with_default(" $icon $average avg, $max max ")?;

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -36,8 +36,8 @@ use super::prelude::*;
 use crate::formatting::config::DummyConfig;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct TimeConfig {
+#[serde(default)]
+pub struct Config {
     format: DummyConfig,
     #[default(1.into())]
     interval: Seconds,
@@ -45,8 +45,7 @@ struct TimeConfig {
     locale: Option<String>,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = TimeConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new();
 
     let format = config

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -49,8 +49,7 @@ use std::env;
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
-pub struct ToggleConfig {
+pub struct Config {
     format: FormatConfig,
     command_on: String,
     command_off: String,
@@ -63,8 +62,7 @@ pub struct ToggleConfig {
     interval: Option<u64>,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = ToggleConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let interval = config.interval.map(Duration::from_secs);
     let mut widget = Widget::new().with_format(config.format.with_default(" $icon ")?);
 

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -33,15 +33,14 @@ use super::prelude::*;
 use tokio::fs::read_to_string;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct UptimeConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     #[default(60.into())]
     interval: Seconds,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = UptimeConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $icon $text ")?);
 
     loop {

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -37,8 +37,8 @@ use tokio::fs::read_to_string;
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct WatsonConfig {
+#[serde(default)]
+pub struct Config {
     format: FormatConfig,
     state_path: Option<ShellString>,
     #[default(60.into())]
@@ -46,8 +46,7 @@ struct WatsonConfig {
     show_time: bool,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = WatsonConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $text |")?);
 
     let mut show_time = config.show_time;

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -99,9 +99,8 @@ mod open_weather_map;
 
 const IP_API_URL: &str = "https://ipapi.co/json";
 
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct WeatherConfig {
+#[derive(Deserialize, Debug)]
+pub struct Config {
     #[serde(default = "default_interval")]
     interval: Seconds,
     #[serde(default)]
@@ -122,7 +121,7 @@ trait WeatherProvider {
         -> Result<WeatherResult>;
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(tag = "name", rename_all = "lowercase")]
 enum WeatherService {
     OpenWeatherMap(open_weather_map::Config),
@@ -181,8 +180,7 @@ impl WeatherResult {
     }
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = WeatherConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget =
         Widget::new().with_format(config.format.with_default(" $icon $weather $temp ")?);
 

--- a/src/blocks/weather/met_no.rs
+++ b/src/blocks/weather/met_no.rs
@@ -2,7 +2,7 @@ use super::*;
 
 type LegendsStore = HashMap<String, LegendsResult>;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(tag = "name", rename_all = "lowercase")]
 pub(super) struct Config {
     coordinates: Option<(String, String)>,

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -40,8 +40,8 @@ use regex::RegexSet;
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
-struct XrandrConfig {
+#[serde(default)]
+pub struct Config {
     #[default(5.into())]
     interval: Seconds,
     format: FormatConfig,
@@ -49,8 +49,7 @@ struct XrandrConfig {
     step_width: u32,
 }
 
-pub async fn run(config: toml::Value, mut api: CommonApi) -> Result<()> {
-    let config = XrandrConfig::deserialize(config).config_error()?;
+pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(
         config
             .format

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
 
-use crate::blocks::BlockType;
-
 pub use std::error::Error as StdError;
 
 /// Result type returned from functions that can have our `Error`s.
@@ -17,7 +15,7 @@ pub struct Error {
     pub kind: ErrorKind,
     pub message: Option<ErrorMsg>,
     pub cause: Option<Arc<dyn StdError + Send + Sync + 'static>>,
-    pub block: Option<(BlockType, usize)>,
+    pub block: Option<(&'static str, usize)>,
 }
 
 /// A set of errors that can occur during the runtime
@@ -49,18 +47,18 @@ impl Error {
 }
 
 pub trait InBlock {
-    fn in_block(self, block: BlockType, block_id: usize) -> Self;
+    fn in_block(self, block: &'static str, block_id: usize) -> Self;
 }
 
 impl InBlock for Error {
-    fn in_block(mut self, block: BlockType, block_id: usize) -> Self {
+    fn in_block(mut self, block: &'static str, block_id: usize) -> Self {
         self.block = Some((block, block_id));
         self
     }
 }
 
 impl<T> InBlock for Result<T> {
-    fn in_block(self, block: BlockType, block_id: usize) -> Self {
+    fn in_block(self, block: &'static str, block_id: usize) -> Self {
         self.map_err(|e| e.in_block(block, block_id))
     }
 }
@@ -164,7 +162,7 @@ impl fmt::Display for Error {
                     ErrorKind::Other => f.write_str("Error")?,
                 }
 
-                write!(f, " in {:?}", block.0)?;
+                write!(f, " in {}", block.0)?;
 
                 if let Some(message) = &self.message {
                     write!(f, ": {}", message)?;


### PR DESCRIPTION
Now each block's `run` function directly accepts a config struct instead of `toml::Value`. Might help with #1328