### PR TITLE
Add option to add custom ending separator (resolve #1650)

### DIFF
--- a/doc/themes.md
+++ b/doc/themes.md
@@ -114,21 +114,22 @@ The tints are added to every second block counting from the right. They will the
 
 Feel free to take a look at the provided color schemes for reference.
 
-* `alternating_tint_bg`
-* `alternating_tint_fg`
-* `critical_bg`
-* `critical_fg`
-* `good_bg`
-* `good_fg`
 * `idle_bg`
 * `idle_fg`
+* `good_bg`
+* `good_fg`
+* `warning_bg`
+* `warning_fg`
+* `critical_bg`
+* `critical_fg`
 * `info_bg`
 * `info_fg`
+* `alternating_tint_bg`
+* `alternating_tint_fg`
 * `separator_bg`
 * `separator_fg`
 * `separator`
-* `warning_bg`
-* `warning_fg`
+* `end_separator`
 
 # Available icon overrides
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -77,5 +77,15 @@ pub fn print_blocks(blocks: &[Vec<I3BarBlock>], config: &SharedConfig) {
         }
     }
 
+    if let Some(end_separator) = &config.theme.end_separator {
+        let end_separator = I3BarBlock {
+            full_text: end_separator.clone(),
+            background: Color::None,
+            color: last_bg,
+            ..Default::default()
+        };
+        rendered_blocks.push(end_separator);
+    }
+
     println!("{},", serde_json::to_string(&rendered_blocks).unwrap());
 }

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -26,6 +26,7 @@ pub struct Theme {
     pub separator_fg: Color,
     pub alternating_tint_bg: Color,
     pub alternating_tint_fg: Color,
+    pub end_separator: Option<String>,
 }
 
 impl Theme {
@@ -55,6 +56,9 @@ impl Theme {
             } else {
                 self.separator = Some(separator.clone());
             }
+        }
+        if let Some(end_separator) = overrides.get("end_separator") {
+            self.end_separator = Some(end_separator.clone());
         }
         macro_rules! apply {
             ($prop:tt) => {


### PR DESCRIPTION
Thought i'd add this because it's such a simple change.

Should fulfill the given usecase. Maybe a bit simple/inflexible?

Always uses last widget's background color as foreground color and has no background color (bar color)

![image](https://user-images.githubusercontent.com/9497832/198984746-2e5c8fa1-ac5a-4e72-bd07-143039194405.png)

```
[theme]
theme = "gruvbox-light"
[theme.overrides]
separator = "<span font='15'></span>"
end_separator = "<span font='15'></span>"
```

Does this need documenting anywhere else? Not sure, didn't find other theming docs