### PR TITLE
Fix change in maildir caused by #1652

### DIFF
--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -54,7 +54,7 @@ pub struct Config {
     display_type: MailType,
 }
 
-pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
+pub async fn run(mut config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(config.format.with_default(" $icon $status ")?);
 
     for inbox in &mut config.inboxes {


### PR DESCRIPTION
```
cargo build --release --features 'pulseaudio maildir'
   Compiling i3status-rs v0.30.0 (/home/bmalyn/Documents/Code/rust/i3status-rust)
error[E0596]: cannot borrow `config.inboxes` as mutable, as `config` is not declared as mutable
  --> src/blocks/maildir.rs:60:18
   |
57 | pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
   |                  ------ help: consider changing this to be mutable: `mut config`
...
60 |     for inbox in &mut config.inboxes {
   |                  ^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable

For more information about this error, try `rustc --explain E0596`.
error: could not compile `i3status-rs` due to previous error
```