### PR TITLE
Install: Update dev.md

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -1,6 +1,6 @@
 ## Requirements for Compilation
 
-The Rust compiler `rustc`, `cargo` package manager, C compiler `gcc` and `libssl-dev` packages are required to build the binary.
+The Rust compiler `rustc`, `cargo` package manager, C compiler `gcc` and `libssl-dev`, `libsensors-dev` packages are required to build the binary.
 
 We also require Libdbus 1.6 or higher. On some older systems this may require installing `libdbus-1-dev`. 
 


### PR DESCRIPTION
`libsensors-dev` package is required to build the project.

Description:
Can't build i3status-rust on fresh ubuntu22 system because of lack of sensors library.
![image](https://user-images.githubusercontent.com/108528301/205166988-f03b3cdb-1f19-43a8-9fad-e87efa307dda.png)
