### PR TITLE
formatting: implement named arguments instead of positional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,6 +881,7 @@ dependencies = [
  "neli",
  "neli-wifi",
  "nix 0.26.2",
+ "nom",
  "notmuch",
  "once_cell",
  "regex",
@@ -1157,6 +1158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1255,16 @@ dependencies = [
  "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ maildir = { version = "0.6", optional = true }
 neli = { version = "0.6", features = ["async"] }
 neli-wifi = { version = "0.4", features = ["async"] }
 nix = "0.26"
+nom = "7.1.2"
 notmuch = { version = "0.8", optional = true }
 once_cell = "1"
 regex = "1.5"

--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -9,9 +9,9 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `interval` | Update interval in seconds. | `600`
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $count.eng(1) "`
-//! `format_singular` | Same as `format`, but for when exactly one update is available. | `" $icon $count.eng(1) "`
-//! `format_up_to_date` | Same as `format`, but for when no updates are available. | `" $icon $count.eng(1) "`
+//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $count.eng(w:1) "`
+//! `format_singular` | Same as `format`, but for when exactly one update is available. | `" $icon $count.eng(w:1) "`
+//! `format_up_to_date` | Same as `format`, but for when no updates are available. | `" $icon $count.eng(w:1) "`
 //! `warning_updates_regex` | Display block as warning if updates matching regex are available. | `None`
 //! `critical_updates_regex` | Display block as critical if updates matching regex are available. | `None`
 //!
@@ -71,9 +71,13 @@ pub struct Config {
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new();
 
-    let format = config.format.with_default(" $icon $count.eng(1) ")?;
-    let format_singular = config.format_singular.with_default("$count.eng(1)")?;
-    let format_up_to_date = config.format_up_to_date.with_default("$count.eng(1)")?;
+    let format = config.format.with_default(" $icon $count.eng(w:1) ")?;
+    let format_singular = config
+        .format_singular
+        .with_default(" $icon $count.eng(w:1) ")?;
+    let format_up_to_date = config
+        .format_up_to_date
+        .with_default(" $icon $count.eng(w:1) ")?;
 
     let warning_updates_regex = config
         .warning_updates_regex

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -12,7 +12,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>"{ $icon&vert;} $text.str(pango:true) "</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>"{ $icon&vert;} $text.pango-str() "</code>
 //! `command` | Shell command to execute & display | `None`
 //! `persistent` | Run command in the background; update display for each output line of the command | `false`
 //! `cycle` | Commands to execute and change when the button is clicked | `None`
@@ -155,8 +155,8 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
         .await?;
 
     let mut widget = Widget::new().with_format(config.format.with_defaults(
-        "{ $icon|} $text.str(pango:true) ",
-        "{ $icon|} $short_text.str(pango:true) |",
+        "{ $icon|} $text.pango-str() ",
+        "{ $icon|} $short_text.pango-str() |",
     )?);
 
     let mut timer = config.interval.timer();

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -12,7 +12,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>"{ $icon&vert;} $text "</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>"{ $icon&vert;} $text.str(pango:true) "</code>
 //! `command` | Shell command to execute & display | `None`
 //! `persistent` | Run command in the background; update display for each output line of the command | `false`
 //! `cycle` | Commands to execute and change when the button is clicked | `None`
@@ -154,11 +154,10 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     api.set_default_actions(&[(MouseButton::Left, None, "cycle")])
         .await?;
 
-    let mut widget = Widget::new().with_format(
-        config
-            .format
-            .with_defaults("{ $icon|} $text ", "{ $icon|} $short_text |")?,
-    );
+    let mut widget = Widget::new().with_format(config.format.with_defaults(
+        "{ $icon|} $text.str(pango:true) ",
+        "{ $icon|} $short_text.str(pango:true) |",
+    )?);
 
     let mut timer = config.interval.timer();
 

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -16,7 +16,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. | <code>"{ $icon&vert;}{ $text&vert;} "</code>
+//! `format` | A string to customise the output of this block. | <code>"{ $icon&vert;}{ $text.str(pango:true)&vert;} "</code>
 //!
 //! Placeholder  | Value                                  | Type   | Unit
 //! -------------|-------------------------------------------------------------------|--------|---------------
@@ -126,11 +126,10 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     // will get blocked while trying to send a new message.
     api.event_receiver.close();
 
-    let widget = Widget::new().with_format(
-        config
-            .format
-            .with_defaults("{ $icon|}{ $text|} ", "{ $icon|} $short_text |")?,
-    );
+    let widget = Widget::new().with_format(config.format.with_defaults(
+        "{ $icon|}{ $text.str(pango:true)|} ",
+        "{ $icon|} $short_text.str(pango:true) |",
+    )?);
 
     let dbus_conn = DBUS_CONNECTION
         .get_or_init(dbus_conn())

--- a/src/blocks/dnf.rs
+++ b/src/blocks/dnf.rs
@@ -6,9 +6,9 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `interval` | Update interval in seconds. | `600`
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $count.eng(1) "`
-//! `format_singular` | Same as `format`, but for when exactly one update is available. | `" $icon $count.eng(1) "`
-//! `format_up_to_date` | Same as `format`, but for when no updates are available. | `" $icon $count.eng(1) "`
+//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $count.eng(w:1) "`
+//! `format_singular` | Same as `format`, but for when exactly one update is available. | `" $icon $count.eng(w:1) "`
+//! `format_up_to_date` | Same as `format`, but for when no updates are available. | `" $icon $count.eng(w:1) "`
 //! `warning_updates_regex` | Display block as warning if updates matching regex are available. | `None`
 //! `critical_updates_regex` | Display block as critical if updates matching regex are available. | `None`
 //!
@@ -58,13 +58,13 @@ pub struct Config {
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new();
 
-    let format = config.format.with_default(" $icon $count.eng(1) ")?;
+    let format = config.format.with_default(" $icon $count.eng(w:1) ")?;
     let format_singular = config
         .format_singular
-        .with_default(" $icon $count.eng(1) ")?;
+        .with_default(" $icon $count.eng(w:1) ")?;
     let format_up_to_date = config
         .format_up_to_date
-        .with_default(" $icon $count.eng(1) ")?;
+        .with_default(" $icon $count.eng(w:1) ")?;
 
     let warning_updates_regex = config
         .warning_updates_regex

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -5,7 +5,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `interval` | Update interval, in seconds. | `5`
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $running.eng(1) "`
+//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $running.eng(w:1) "`
 //! `socket_path` | The path to the docker socket. Supports path expansions e.g. `~`. | `"/var/run/docker.sock"`
 //!
 //! Key       | Value                          | Type   | Unit
@@ -46,7 +46,7 @@ pub struct Config {
 
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget =
-        Widget::new().with_format(config.format.with_default(" $icon $running.eng(1) ")?);
+        Widget::new().with_format(config.format.with_default(" $icon $running.eng(w:1) ")?);
     let socket_path = config.socket_path.expand()?;
 
     loop {

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -8,7 +8,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>" $title.str(0,21) &vert;"</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>" $title.str(max_w:21) &vert;"</code>
 //! `driver` | Which driver to use. Available values: `sway_ipc` - for `i3` and `sway`, `wlr_toplevel_management` - for Wayland compositors that implement [wlr-foreign-toplevel-management-unstable-v1](https://gitlab.freedesktop.org/wlroots/wlr-protocols/-/blob/master/unstable/wlr-foreign-toplevel-management-unstable-v1.xml), `auto` - try to automatically guess which driver to use. | `"auto"`
 //!
 //! Placeholder     | Value                                                                 | Type | Unit
@@ -23,8 +23,8 @@
 //! [[block]]
 //! block = "focused_window"
 //! [block.format]
-//! full = " $title.str(0,15) |"
-//! short = " $title.str(0,10) |"
+//! full = " $title.str(max_w:15) |"
+//! short = " $title.str(max_w:10) |"
 //! ```
 //!
 //! This example instead of hiding block when the window's title is empty displays "Missing"
@@ -59,7 +59,8 @@ enum Driver {
 }
 
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
-    let mut widget = Widget::new().with_format(config.format.with_default(" $title.str(0,21) |")?);
+    let mut widget =
+        Widget::new().with_format(config.format.with_default(" $title.str(max_w:21) |")?);
 
     let mut backend: Box<dyn Backend> = match config.driver {
         Driver::Auto => match SwayIpc::new().await {

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -6,7 +6,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $total.eng(1) "`
+//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $total.eng(w:1) "`
 //! `interval` | Update interval in seconds | `30`
 //! `token` | A GitHub personal access token with the "notifications" scope | `None`
 //! `hide_if_total_is_zero` | Hide this block if the total count of notifications is zero | `false`
@@ -76,7 +76,7 @@ pub struct Config {
 
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget =
-        Widget::new().with_format(config.format.with_default(" $icon $total.eng(1) ")?);
+        Widget::new().with_format(config.format.with_default(" $icon $total.eng(w:1) ")?);
 
     let mut interval = config.interval.timer();
     let token = config

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -4,7 +4,7 @@
 //!
 //! Key        | Values                                                                                | Default
 //! -----------|---------------------------------------------------------------------------------------|--------
-//! `format`   | A string to customise the output of this block. See below for available placeholders. | `" $icon $1m.eng(3) "`
+//! `format`   | A string to customise the output of this block. See below for available placeholders. | `" $icon $1m "`
 //! `interval` | Update interval in seconds                                                            | `3`
 //! `info`     | Minimum load, where state is set to info                                              | `0.3`
 //! `warning`  | Minimum load, where state is set to warning                                           | `0.6`
@@ -47,7 +47,7 @@ pub struct Config {
 }
 
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
-    let mut widget = Widget::new().with_format(config.format.with_default(" $icon $1m.eng(3) ")?);
+    let mut widget = Widget::new().with_format(config.format.with_default(" $icon $1m ")?);
 
     // borrowed from https://docs.rs/cpuinfo/0.1.1/src/cpuinfo/count/logical.rs.html#4-6
     let logical_cores = util::read_file("/proc/cpuinfo")

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -4,7 +4,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block when in "Memory" view. See below for available placeholders. | `" $icon $mem_avail.eng(3,B,M)/$mem_total.eng(3,B,M)($mem_total_used_percents.eng(2)) "`
+//! `format` | A string to customise the output of this block when in "Memory" view. See below for available placeholders. | `" $icon $mem_avail.eng(prefix:M)/$mem_total.eng(prefix:M)($mem_total_used_percents.eng(w:2)) "`
 //! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
 //! `interval` | Update interval in seconds | `5`
 //! `warning_mem` | Percentage of memory usage, where state is set to warning | `80.0`
@@ -87,7 +87,7 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new();
 
     let mut format = config.format.with_default(
-        " $icon $mem_avail.eng(3,B,M)/$mem_total.eng(3,B,M)($mem_total_used_percents.eng(2)) ",
+        " $icon $mem_avail.eng(prefix:M)/$mem_total.eng(prefix:M)($mem_total_used_percents.eng(w:2)) ",
     )?;
     let mut format_alt = match config.format_alt {
         Some(f) => Some(f.with_default("")?),

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -18,7 +18,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>" $icon {$combo.rot-str() $play &vert;}"</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>" $icon {$combo.str(max_w:25,rot_interval:0.5) $play &vert;}"</code>
 //! `player` | Name(s) of the music player(s) MPRIS interface. This can be either a music player name or an array of music player names. Run <code>busctl --user list &vert; grep "org.mpris.MediaPlayer2." &vert; cut -d' ' -f1</code> and the name is the part after "org.mpris.MediaPlayer2.". | `None`
 //! `interface_name_exclude` | A list of regex patterns for player MPRIS interface names to ignore. | `[]`
 //! `separator` | String to insert between artist and title. | `" - "`
@@ -75,7 +75,7 @@
 //! ```toml
 //! [[block]]
 //! block = "music"
-//! format = " $icon {$combo.rot-str(w:20) $play $next |}"
+//! format = " $icon {$combo.str(max_w:20,rot_interval:0.5) $play $next |}"
 //! interface_name_exclude = [".*kdeconnect.*", "mpd"]
 //! ```
 //!
@@ -146,7 +146,7 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new().with_format(
         config
             .format
-            .with_default(" $icon {$combo.rot-str() $play |}")?,
+            .with_default(" $icon {$combo.str(max_w:25,rot_interval:0.5) $play |}")?,
     );
 
     let new_btn = |icon: &str, instance: &'static str, api: &mut CommonApi| -> Result<Value> {

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -57,7 +57,7 @@
 //! ```toml
 //! [[block]]
 //! block = "music"
-//! format = " $icon {$combo.str(0,20) $play $next |}"
+//! format = " $icon {$combo.str(max_w:20) $play $next |}"
 //! player = "spotify"
 //! ```
 //!
@@ -66,7 +66,7 @@
 //! ```toml
 //! [[block]]
 //! block = "music"
-//! format = " $icon {$combo.str(0,20) $play $next |}"
+//! format = " $icon {$combo.str(max_w:20) $play $next |}"
 //! interface_name_exclude = [".*kdeconnect.*", "mpd"]
 //! ```
 //!
@@ -75,7 +75,7 @@
 //! ```toml
 //! [[block]]
 //! block = "music"
-//! format = " $icon {$combo.rot-str(20) $play $next |}"
+//! format = " $icon {$combo.rot-str(w:20) $play $next |}"
 //! interface_name_exclude = [".*kdeconnect.*", "mpd"]
 //! ```
 //!

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -7,7 +7,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `device` | Network interface to monitor (as specified in `/sys/class/net/`). Supports regex. | If not set, device will be automatically selected every `interval`
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon ^icon_net_down $speed_down.eng(3,B,K) ^icon_net_up $speed_up.eng(3,B,K) "`
+//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon ^icon_net_down $speed_down.eng(prefix:K) ^icon_net_up $speed_up.eng(prefix:K) "`
 //! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
 //! `interval` | Update interval in seconds | `2`
 //! `missing_format` | Same as `format` if the interface cannot be connected (or missing). | `" × "`
@@ -79,7 +79,7 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
         .await?;
 
     let mut format = config.format.with_default(
-        " $icon ^icon_net_down $speed_down.eng(3,B,K) ^icon_net_up $speed_up.eng(3,B,K) ",
+        " $icon ^icon_net_down $speed_down.eng(prefix:K) ^icon_net_up $speed_up.eng(prefix:K) ",
     )?;
     let missing_format = config.missing_format.with_default(" × ")?;
     let mut format_alt = match config.format_alt {

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -39,9 +39,9 @@
 //! Key | Values | Default
 //! ----|--------|---------
 //! `interval` | Update interval, in seconds. If setting `aur_command` then set interval appropriately as to not exceed the AUR's daily rate limit. | `600`
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $pacman.eng(1) "`
-//! `format_singular` | Same as `format` but for when exactly one update is available. | `" $icon $pacman.eng(1) "`
-//! `format_up_to_date` | Same as `format` but for when no updates are available. | `" $icon $pacman.eng(1) "`
+//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $pacman.eng(w:1) "`
+//! `format_singular` | Same as `format` but for when exactly one update is available. | `" $icon $pacman.eng(w:1) "`
+//! `format_up_to_date` | Same as `format` but for when no updates are available. | `" $icon $pacman.eng(w:1) "`
 //! `warning_updates_regex` | Display block as warning if updates matching regex are available. | `None`
 //! `critical_updates_regex` | Display block as critical if updates matching regex are available. | `None`
 //! `aur_command` | AUR command to check available updates, which outputs in the same format as pacman. e.g. `yay -Qua` | Required if `$both` or `$aur` are used
@@ -162,13 +162,13 @@ pub struct Config {
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let mut widget = Widget::new();
 
-    let format = config.format.with_default(" $icon $pacman.eng(1) ")?;
+    let format = config.format.with_default(" $icon $pacman.eng(w:1) ")?;
     let format_singular = config
         .format_singular
-        .with_default(" $icon $pacman.eng(1) ")?;
+        .with_default(" $icon $pacman.eng(w:1) ")?;
     let format_up_to_date = config
         .format_up_to_date
-        .with_default(" $icon $pacman.eng(1) ")?;
+        .with_default(" $icon $pacman.eng(w:1) ")?;
 
     macro_rules! any_format_contains {
         ($name:expr) => {

--- a/src/blocks/rofication.rs
+++ b/src/blocks/rofication.rs
@@ -7,7 +7,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `interval` | Refresh rate in seconds. | `1`
-//! `format` | A string to customise the output of this block. See below for placeholders. | `" $icon $num.eng(1) "`
+//! `format` | A string to customise the output of this block. See below for placeholders. | `" $icon $num.eng(w:1) "`
 //! `socket_path` | Socket path for the rofication daemon. Supports path expansions e.g. `~`. | `"/tmp/rofi_notification_daemon"`
 //!
 //!  Placeholder | Value | Type | Unit
@@ -44,7 +44,8 @@ pub struct Config {
 }
 
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
-    let mut widget = Widget::new().with_format(config.format.with_default(" $icon $num.eng(1) ")?);
+    let mut widget =
+        Widget::new().with_format(config.format.with_default(" $icon $num.eng(w:1) ")?);
 
     let path = config.socket_path.expand()?;
     let mut timer = config.interval.timer();

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -46,7 +46,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `driver` | `"auto"`, `"pulseaudio"`, `"alsa"`. | `"auto"` (Pulseaudio with ALSA fallback)
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code> $icon {$volume.eng(2) &vert;}</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code> $icon {$volume.eng(w:2) &vert;}</code>
 //! `name` | PulseAudio device name, or the ALSA control name as found in the output of `amixer -D yourdevice scontrols`. | PulseAudio: `@DEFAULT_SINK@` / ALSA: `Master`
 //! `device` | ALSA device name, usually in the form "hw:X" or "hw:X,Y" where `X` is the card number and `Y` is the device number as found in the output of `aplay -l`. | `default`
 //! `device_kind` | PulseAudio device kind: `source` or `sink`. | `"sink"`
@@ -114,7 +114,7 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     .await?;
 
     let mut widget =
-        Widget::new().with_format(config.format.with_default(" $icon {$volume.eng(2)|} ")?);
+        Widget::new().with_format(config.format.with_default(" $icon {$volume.eng(w:2)|} ")?);
 
     let device_kind = config.device_kind;
     let step_width = config.step_width.clamp(0, 50) as i32;

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -11,7 +11,7 @@
 //! `critical_threshold` | The threshold of pending (or started) tasks when the block turns into a critical state | `20`
 //! `hide_when_zero` | Whethere to hide the block when the number of tasks is zero | `false`
 //! `filters` | A list of tables with the keys `name` and `filter`. `filter` specifies the criteria that must be met for a task to be counted towards this filter. | ```[{name = "pending", filter = "-COMPLETED -DELETED"}]```
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $done\|$count.eng(1) "`
+//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $done\|$count.eng(w:1) "`
 //! `data_location`| Directory in which taskwarrior stores its data files. Supports path expansions e.g. `~`. | `"~/.task"`
 //!
 //! Placeholder   | Value                                       | Type   | Unit
@@ -35,7 +35,7 @@
 //! [[block]]
 //! block = "taskwarrior"
 //! interval = 60
-//! format = " $icon $done{All done}|$single{One task}|Tasks: $count.eng(1) "
+//! format = " $icon $done{All done}|$single{One task}|Tasks: $count.eng(w:1) "
 //! warning_threshold = 10
 //! critical_threshold = 20
 //! [[block.filters]]
@@ -86,8 +86,11 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     api.set_default_actions(&[(MouseButton::Right, None, "next_filter")])
         .await?;
 
-    let mut widget =
-        Widget::new().with_format(config.format.with_default(" $icon $done|$count.eng(1) ")?);
+    let mut widget = Widget::new().with_format(
+        config
+            .format
+            .with_default(" $icon $done|$count.eng(w:1) ")?,
+    );
 
     let mut filters = config.filters.iter().cycle();
     let mut filter = filters.next().error("`filters` is empty")?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,10 +22,10 @@ pub struct Config {
     /// The maximum delay (ms) between two clicks that are considered as doulble click
     pub double_click_delay: u64,
 
-    #[default(" {$short_error_message|X} ".into())]
-    pub error_format: String,
-    #[default(" $full_error_message ".into())]
-    pub error_fullscreen_format: String,
+    #[default(" {$short_error_message|X} ".parse().unwrap())]
+    pub error_format: FormatConfig,
+    #[default(" $full_error_message ".parse().unwrap())]
+    pub error_fullscreen_format: FormatConfig,
 
     #[serde(rename = "block")]
     pub blocks: Vec<BlockConfigEntry>,

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -4,22 +4,22 @@ use std::fmt::Write;
 
 pub trait CollectEscaped {
     /// Write escaped version of `self` to `out`
-    fn collect_pango_into<T: Write>(self, out: &mut T);
+    fn collect_pango_escaped_into<T: Write>(self, out: &mut T);
 
     /// Write escaped version of `self` to a new buffer
     #[inline]
-    fn collect_pango<T: Write + Default>(self) -> T
+    fn collect_pango_escaped<T: Write + Default>(self) -> T
     where
         Self: Sized,
     {
         let mut out = T::default();
-        self.collect_pango_into(&mut out);
+        self.collect_pango_escaped_into(&mut out);
         out
     }
 }
 
 impl<I: Iterator<Item = char>> CollectEscaped for I {
-    fn collect_pango_into<T: Write>(self, out: &mut T) {
+    fn collect_pango_escaped_into<T: Write>(self, out: &mut T) {
         for c in self {
             let _ = match c {
                 '&' => out.write_str("&amp;"),
@@ -39,7 +39,7 @@ mod tests {
     #[test]
     fn pango() {
         let orig = "&my 'text' <>";
-        let escaped: String = orig.chars().collect_pango();
+        let escaped: String = orig.chars().collect_pango_escaped();
         assert_eq!(escaped, "&amp;my &#39;text&#39; &lt;&gt;");
     }
 }

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -33,7 +33,6 @@
 //! -----------------------|---------------------------------------------------|-------------
 //! `min_width` or `min_w` | if text is shorter it will be padded using spaces | `0`
 //! `max_width` or `max_w` | if text is longer it will be truncated            | Infinity
-//! `pango`                | if `true`, text is treated as [pango](https://docs.gtk.org/Pango/pango_markup.html#pango-markup), meaning symbols such as "<", ">" and "&" will not be escaped. Does not work well with `max_width` and 'rot_interval' | `false`
 //! `rot_interval`         | if text is longer than `max_width` it will be rotated every `rot_interval` seconds | `0.5`
 //!
 //! ## `eng` - Format numbers using engineering notation
@@ -55,6 +54,10 @@
 //! -----------------------|---------------------------------------------------------------------------------|-------------
 //! `width` or `w`         | the width of the bar (in characters)                                            | `5`
 //! `max_value`            | which value is treated as "full". For example, for battery level `100` is full. | `100`
+//!
+//! ## `pango-str` - Just display the text without pango markup escaping
+//!
+//! No arguments.
 //!
 //! # Handling missing placeholders and incorrect types
 //!

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -24,36 +24,42 @@
 //!
 //! A formatter is something that converts a value into a text. Because there are many ways to do
 //! this, a number of formatters is available. Formatter can be specified using the syntax similar
-//! to method calls in many programming languages: `<variable>.<formatter>(<args>)`.
+//! to method calls in many programming languages: `<variable>.<formatter>(<args>)`. For example:
+//! `$title.str(min_w:10, max_w:20)`.
 //!
 //! ## `str` - Format text
 //!
-//! Argument | Default value
-//! ---------|--------------
-//! Min width - if text is shorter it will be padded using spaces | `0`
-//! Max width - if text is longer it will be truncated | `inf`
+//! Argument               | Description                                       |Default value
+//! -----------------------|---------------------------------------------------|-------------
+//! `min_width` or `min_w` | if text is shorter it will be padded using spaces | `0`
+//! `max_width` or `max_w` | if text is longer it will be truncated            | Infinity
 //!
 //! ## `rot-str` - Rotating text
 //!
-//! Argument | Default value
-//! ---------|--------------
-//! Width - if text is shorter it will be padded using spaces | `15`
-//! Interval - If text is longer than `width` it will be rotated every `interval` seconds | `1.0`
+//! Argument               | Description                                                                |Default value
+//! -----------------------|----------------------------------------------------------------------------|-------------
+//! `width` or 'w'         | if text is shorter it will be padded using spaces                          | `15`
+//! `interval`             | if text is longer than `width` it will be rotated every `interval` seconds | `0.5`
 //!
 //! ## `eng` - Format numbers using engineering notation
 //!
-//! Argument | Default value
-//! ---------|--------------
-//! Width - the resulting text will be at least `width` characters long | `2`
-//! Unit - some values have a [unit](unit::Unit), and it is possible to convert them by setting this option. Prepend this with a space to split unit from number/prefix. Prepend this with a `_` to hide. | `auto`
-//! Prefix - specifiy this argument if you want to set the minimal [SI prefix](prefix::Prefix). Prepend this with a space to split prefix from number. Prepend this with a `_` to hide. Prepend this with a `!` to force the prefix. | `auto`
+//! Argument        | Description                                                                                      |Default value
+//! ----------------|--------------------------------------------------------------------------------------------------|-------------
+//! `width` or `w`  | the resulting text will be at least `width` characters long                                      | `3`
+//! `unit` or `u`   | some values have a [unit](unit::Unit), and it is possible to convert them by setting this option | N/A
+//! `hide_unit`     | hide the unit symbol                                                                             | `false`
+//! `unit_space`    | have a whitespace before unit symbol                                                             | `false`
+//! `prefix` or `p` | specifiy this argument if you want to set the minimal [SI prefix](prefix::Prefix)                | N/A
+//! `hide_prefix`   | hide the prefix symbol                                                                           | `false`
+//! `prefix_space`  | have a whitespace before prefix symbol                                                           | `false`
+//! `force_prefix`  | force the prefix value instead of setting a "minimal prefix"                                     | `false`
 //!
 //! ## `bar` - Display numbers as progress bars
 //!
-//! Argument | Default value
-//! ---------|--------------
-//! Width - the width of the bar (in characters) | `5`
-//! Max value - which value is treated as "full". For example, for battery level `100` is full. | `100`
+//! Argument               | Description                                                                     |Default value
+//! -----------------------|---------------------------------------------------------------------------------|-------------
+//! `width` or `w`         | the width of the bar (in characters)                                            | `5`
+//! `max_value`            | which value is treated as "full". For example, for battery level `100` is full. | `100`
 //!
 //! # Handling missing placeholders and incorrect types
 //!
@@ -79,6 +85,7 @@
 
 pub mod config;
 pub mod formatter;
+pub mod parse;
 pub mod prefix;
 pub mod scheduling;
 pub mod template;

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -40,7 +40,7 @@
 //!
 //! Argument        | Description                                                                                      |Default value
 //! ----------------|--------------------------------------------------------------------------------------------------|-------------
-//! `width` or `w`  | the resulting text will be at least `width` characters long                                      | `3`
+//! `width` or `w`  | the resulting text will be at least `width` characters long                                      | `2`
 //! `unit` or `u`   | some values have a [unit](unit::Unit), and it is possible to convert them by setting this option | N/A
 //! `hide_unit`     | hide the unit symbol                                                                             | `false`
 //! `unit_space`    | have a whitespace before unit symbol                                                             | `false`

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -33,14 +33,8 @@
 //! -----------------------|---------------------------------------------------|-------------
 //! `min_width` or `min_w` | if text is shorter it will be padded using spaces | `0`
 //! `max_width` or `max_w` | if text is longer it will be truncated            | Infinity
-//! `pango`                | if `true`, text is treated as [pango](https://docs.gtk.org/Pango/pango_markup.html#pango-markup), meaning symbols such as "<", ">" and "&" will not be escaped | `false`
-//!
-//! ## `rot-str` - Rotating text
-//!
-//! Argument               | Description                                                                |Default value
-//! -----------------------|----------------------------------------------------------------------------|-------------
-//! `width` or 'w'         | if text is shorter it will be padded using spaces                          | `15`
-//! `interval`             | if text is longer than `width` it will be rotated every `interval` seconds | `0.5`
+//! `pango`                | if `true`, text is treated as [pango](https://docs.gtk.org/Pango/pango_markup.html#pango-markup), meaning symbols such as "<", ">" and "&" will not be escaped. Does not work well with `max_width` and 'rot_interval' | `false`
+//! `rot_interval`         | if text is longer than `max_width` it will be rotated every `rot_interval` seconds | `0.5`
 //!
 //! ## `eng` - Format numbers using engineering notation
 //!

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -33,6 +33,7 @@
 //! -----------------------|---------------------------------------------------|-------------
 //! `min_width` or `min_w` | if text is shorter it will be padded using spaces | `0`
 //! `max_width` or `max_w` | if text is longer it will be truncated            | Infinity
+//! `pango`                | if `true`, text is treated as [pango](https://docs.gtk.org/Pango/pango_markup.html#pango-markup), meaning symbols such as "<", ">" and "&" will not be escaped | `false`
 //!
 //! ## `rot-str` - Rotating text
 //!

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -101,16 +101,14 @@ use value::Value;
 
 pub type Values = HashMap<Cow<'static, str>, Value>;
 
-pub type Format = Arc<FormatInner>;
-
-#[derive(Debug)]
-pub struct FormatInner {
-    full: FormatTemplate,
-    short: FormatTemplate,
+#[derive(Debug, Clone)]
+pub struct Format {
+    full: Arc<FormatTemplate>,
+    short: Arc<FormatTemplate>,
     intervals: Vec<u64>,
 }
 
-impl FormatInner {
+impl Format {
     pub fn contains_key(&self, key: &str) -> bool {
         self.full.contains_key(key) || self.short.contains_key(key)
     }

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -17,6 +17,8 @@ const DEFAULT_STR_ROT_INTERVAL: Option<f64> = None;
 const DEFAULT_BAR_WIDTH: usize = 5;
 const DEFAULT_BAR_MAX_VAL: f64 = 100.0;
 
+const DEFAULT_NUMBER_WIDTH: usize = 2;
+
 pub const DEFAULT_STRING_FORMATTER: StrFormatter = StrFormatter {
     min_width: DEFAULT_STR_MIN_WIDTH,
     max_width: DEFAULT_STR_MAX_WIDTH,
@@ -27,7 +29,7 @@ pub const DEFAULT_STRING_FORMATTER: StrFormatter = StrFormatter {
 
 // TODO: split those defaults
 pub const DEFAULT_NUMBER_FORMATTER: EngFormatter = EngFormatter(EngFixConfig {
-    width: 3,
+    width: DEFAULT_NUMBER_WIDTH,
     unit: None,
     unit_has_space: false,
     unit_hidden: false,
@@ -227,7 +229,7 @@ struct EngFixConfig {
 
 impl EngFixConfig {
     fn from_args(args: &[Arg]) -> Result<Self> {
-        let mut width = 3;
+        let mut width = DEFAULT_NUMBER_WIDTH;
         let mut unit = None;
         let mut unit_has_space = false;
         let mut unit_hidden = false;

--- a/src/formatting/parse.rs
+++ b/src/formatting/parse.rs
@@ -1,0 +1,342 @@
+use nom::{
+    branch::alt,
+    bytes::complete::{escaped_transform, tag, take_while, take_while1},
+    character::complete::{anychar, char},
+    combinator::{cut, eof, map, not, opt},
+    multi::{many0, separated_list0},
+    sequence::{preceded, separated_pair, terminated, tuple},
+    IResult, Parser,
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Arg<'a> {
+    pub key: &'a str,
+    pub val: &'a str,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Formatter<'a> {
+    pub name: &'a str,
+    pub args: Vec<Arg<'a>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Placeholder<'a> {
+    pub name: &'a str,
+    pub formatter: Option<Formatter<'a>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Token<'a> {
+    Text(String),
+    Placeholder(Placeholder<'a>),
+    Icon(&'a str),
+    Recursive(FormatTemplate<'a>),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TokenList<'a>(pub Vec<Token<'a>>);
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct FormatTemplate<'a>(pub Vec<TokenList<'a>>);
+
+fn spaces(i: &str) -> IResult<&str, &str> {
+    take_while(|x: char| x.is_ascii_whitespace())(i)
+}
+
+fn alphanum1(i: &str) -> IResult<&str, &str> {
+    take_while1(|x: char| x.is_alphanumeric() || x == '_' || x == '-')(i)
+}
+
+fn arg1(i: &str) -> IResult<&str, &str> {
+    take_while1(|x: char| x.is_alphanumeric() || x == '_' || x == '-' || x == '.')(i)
+}
+
+// `key:val`
+fn parse_arg(i: &str) -> IResult<&str, Arg> {
+    map(
+        separated_pair(alphanum1, cut(char(':')), cut(arg1)),
+        |(key, val)| Arg { key, val },
+    )(i)
+}
+
+// `(arg,key:val)`
+// `( arg, key:val , abc)`
+fn parse_args(i: &str) -> IResult<&str, Vec<Arg>> {
+    let inner = separated_list0(preceded(spaces, char(',')), preceded(spaces, parse_arg));
+    preceded(
+        char('('),
+        cut(terminated(inner, preceded(spaces, char(')')))),
+    )(i)
+}
+
+// `.str(width:2)`
+// `.eng(unit:bits,bin)`
+fn parse_formatter(i: &str) -> IResult<&str, Formatter> {
+    preceded(char('.'), cut(tuple((alphanum1, opt(parse_args)))))
+        .map(|(name, args)| Formatter {
+            name,
+            args: args.unwrap_or_default(),
+        })
+        .parse(i)
+}
+
+// `$var`
+// `$key.eng(unit:bits,bin)`
+fn parse_placeholder(i: &str) -> IResult<&str, Placeholder> {
+    preceded(char('$'), cut(tuple((alphanum1, opt(parse_formatter)))))
+        .map(|(name, formatter)| Placeholder { name, formatter })
+        .parse(i)
+}
+
+// `just escaped \| text`
+fn parse_string(i: &str) -> IResult<&str, String> {
+    preceded(
+        not(eof),
+        escaped_transform(
+            take_while1(|x| x != '$' && x != '^' && x != '{' && x != '}' && x != '|' && x != '\\'),
+            '\\',
+            anychar,
+        ),
+    )(i)
+}
+
+// `^icon_name`
+fn parse_icon(i: &str) -> IResult<&str, &str> {
+    preceded(char('^'), cut(preceded(tag("icon_"), alphanum1)))(i)
+}
+
+// `{ a | b | c }`
+fn parse_recursive_template(i: &str) -> IResult<&str, FormatTemplate> {
+    preceded(char('{'), cut(terminated(parse_format_template, char('}'))))(i)
+}
+
+fn parse_token_list(i: &str) -> IResult<&str, TokenList> {
+    map(
+        many0(alt((
+            map(parse_string, Token::Text),
+            map(parse_placeholder, Token::Placeholder),
+            map(parse_icon, Token::Icon),
+            map(parse_recursive_template, Token::Recursive),
+        ))),
+        TokenList,
+    )(i)
+}
+
+pub fn parse_format_template(i: &str) -> IResult<&str, FormatTemplate> {
+    map(separated_list0(char('|'), parse_token_list), FormatTemplate)(i)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arg() {
+        assert_eq!(
+            parse_arg("key:val,"),
+            Ok((
+                ",",
+                Arg {
+                    key: "key",
+                    val: "val"
+                }
+            ))
+        );
+        assert!(parse_arg("key:,").is_err());
+    }
+
+    #[test]
+    fn args() {
+        assert_eq!(
+            parse_args("(key:val)"),
+            Ok((
+                "",
+                vec![Arg {
+                    key: "key",
+                    val: "val"
+                }]
+            ))
+        );
+        assert_eq!(
+            parse_args("( abc:d , key:val )"),
+            Ok((
+                "",
+                vec![
+                    Arg {
+                        key: "abc",
+                        val: "d",
+                    },
+                    Arg {
+                        key: "key",
+                        val: "val"
+                    }
+                ]
+            ))
+        );
+    }
+
+    #[test]
+    fn formatter() {
+        assert_eq!(
+            parse_formatter(".str(key:val)"),
+            Ok((
+                "",
+                Formatter {
+                    name: "str",
+                    args: vec![Arg {
+                        key: "key",
+                        val: "val"
+                    }]
+                }
+            ))
+        );
+        assert_eq!(
+            parse_formatter(".eng(w:3 , bin:true )"),
+            Ok((
+                "",
+                Formatter {
+                    name: "eng",
+                    args: vec![
+                        Arg { key: "w", val: "3" },
+                        Arg {
+                            key: "bin",
+                            val: "true"
+                        }
+                    ]
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn placeholder() {
+        assert_eq!(
+            parse_placeholder("$key"),
+            Ok((
+                "",
+                Placeholder {
+                    name: "key",
+                    formatter: None,
+                }
+            ))
+        );
+        assert_eq!(
+            parse_placeholder("$var.str()"),
+            Ok((
+                "",
+                Placeholder {
+                    name: "var",
+                    formatter: Some(Formatter {
+                        name: "str",
+                        args: vec![]
+                    }),
+                }
+            ))
+        );
+        assert_eq!(
+            parse_placeholder("$var.str(a:b, c:d)"),
+            Ok((
+                "",
+                Placeholder {
+                    name: "var",
+                    formatter: Some(Formatter {
+                        name: "str",
+                        args: vec![Arg { key: "a", val: "b" }, Arg { key: "c", val: "d" }]
+                    }),
+                }
+            ))
+        );
+        assert!(parse_placeholder("$key.").is_err());
+    }
+
+    #[test]
+    fn icon() {
+        assert_eq!(parse_icon("^icon_my_icon"), Ok(("", "my_icon")));
+        assert_eq!(parse_icon("^icon_m"), Ok(("", "m")));
+        assert!(parse_icon("^icon_").is_err());
+        assert!(parse_icon("^2").is_err());
+    }
+
+    #[test]
+    fn token_list() {
+        assert_eq!(
+            parse_token_list(" abc \\$ $var.str(a:b)$x "),
+            Ok((
+                "",
+                TokenList(vec![
+                    Token::Text(" abc $ ".into()),
+                    Token::Placeholder(Placeholder {
+                        name: "var",
+                        formatter: Some(Formatter {
+                            name: "str",
+                            args: vec![Arg { key: "a", val: "b" }]
+                        })
+                    }),
+                    Token::Placeholder(Placeholder {
+                        name: "x",
+                        formatter: None,
+                    }),
+                    Token::Text(" ".into())
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn format_template() {
+        assert_eq!(
+            parse_format_template("simple"),
+            Ok((
+                "",
+                FormatTemplate(vec![TokenList(vec![Token::Text("simple".into())]),])
+            ))
+        );
+        assert_eq!(
+            parse_format_template(" $x.str() | N/A "),
+            Ok((
+                "",
+                FormatTemplate(vec![
+                    TokenList(vec![
+                        Token::Text(" ".into()),
+                        Token::Placeholder(Placeholder {
+                            name: "x",
+                            formatter: Some(Formatter {
+                                name: "str",
+                                args: vec![]
+                            })
+                        }),
+                        Token::Text(" ".into()),
+                    ]),
+                    TokenList(vec![Token::Text(" N/A ".into())]),
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn full() {
+        assert_eq!(
+            parse_format_template(" ^icon_my_icon {$x.str()|N/A} "),
+            Ok((
+                "",
+                FormatTemplate(vec![TokenList(vec![
+                    Token::Text(" ".into()),
+                    Token::Icon("my_icon"),
+                    Token::Text(" ".into()),
+                    Token::Recursive(FormatTemplate(vec![
+                        TokenList(vec![Token::Placeholder(Placeholder {
+                            name: "x",
+                            formatter: Some(Formatter {
+                                name: "str",
+                                args: vec![]
+                            })
+                        })]),
+                        TokenList(vec![Token::Text("N/A".into())]),
+                    ])),
+                    Token::Text(" ".into()),
+                ]),])
+            ))
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn main() {
         });
     if let Err(error) = result {
         let error_widget = Widget::new()
-            .with_text(error.to_string().chars().collect_pango())
+            .with_text(error.to_string().chars().collect_pango_escaped())
             .with_state(State::Critical);
 
         println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,11 +282,11 @@ impl BarState {
         let error_format = block_config
             .common
             .error_format
-            .with_default(&self.config.error_format)?;
+            .with_default_config(&self.config.error_format);
         let error_fullscreen_format = block_config
             .common
             .error_fullscreen_format
-            .with_default(&self.config.error_fullscreen_format)?;
+            .with_default_config(&self.config.error_fullscreen_format);
 
         let block_name = block_config.config.name();
         let (block_fut, abort_handle) = abortable(block_config.config.run(api));


### PR DESCRIPTION
Closes #1605
Closes #1624
Closes #1655

```toml
format = " $speed_down.eng(3,_B,K) $frequency.eng(4) $ssid.rot-str(10,0.2) "
```

Becomes

```toml
format = " $speed_down.eng(w:3,p:K,hide_unit:true) $frequency.eng(w:4) $ssid.str(max_w:10, rot_interval:0.2) "
```

Also use `nom` for parsing. The downside of this is that error messages are even worse now. But this should be fixable.