### PR TITLE
implement merge_with_next option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Key | Description | Default
 `block` | Name of the i3status-rs block you want to use. See `Blocks` below for valid block names. | -
 `signal` | Signal value that causes an update for this block with `0` corresponding to `-SIGRTMIN+0` and the largest value being `-SIGRTMAX` | None
 `if_command` | Only display the block if the supplied command returns 0 on startup. | None
+`merge_with_next` | If true this will group the block with the next one, so rendering such as alternating_tint will apply to the whole group | `false`
 `icons_format` | Overrides global `icons_format` | None 
 `error_format` | Overrides global `error_format` | None
 `error_fullscreen_format` | Overrides global `error_fullscreen_format` | None

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,7 @@ pub struct CommonBlockConfig {
     pub icons_format: Option<String>,
     pub theme_overrides: Option<ThemeOverrides>,
     pub icons_overrides: Option<HashMap<String, String>>,
+    pub merge_with_next: bool,
 
     #[default(5)]
     pub error_interval: u64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,7 +199,7 @@ pub enum RequestCmd {
 #[derive(Debug, Clone)]
 pub struct RenderedBlock {
     segments: Vec<I3BarBlock>,
-    marge_with_next: bool,
+    merge_with_next: bool,
 }
 
 struct BarState {
@@ -323,7 +323,7 @@ impl BarState {
         self.blocks.push((block, block_name));
         self.blocks_render_cache.push(RenderedBlock {
             segments: Vec::new(),
-            marge_with_next: block_config.common.merge_with_next,
+            merge_with_next: block_config.common.merge_with_next,
         });
 
         Ok(())

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -29,7 +29,7 @@ where
     let mut alt = blocks
         .iter()
         .map(|x| x.borrow())
-        .filter(|x| !x.segments.is_empty() && !x.marge_with_next)
+        .filter(|x| !x.segments.is_empty() && !x.merge_with_next)
         .count()
         % 2
         == 0;
@@ -44,7 +44,7 @@ where
     {
         let RenderedBlock {
             mut segments,
-            marge_with_next: merge_with_next,
+            merge_with_next: merge_with_next,
         } = widgets;
 
         for segment in &mut segments {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,9 +1,12 @@
 pub mod i3bar_block;
 pub mod i3bar_event;
 
+use std::borrow::Borrow;
+
 use crate::config::SharedConfig;
 use crate::themes::color::Color;
 use crate::themes::separator::Separator;
+use crate::RenderedBlock;
 
 use i3bar_block::I3BarBlock;
 
@@ -15,57 +18,88 @@ pub fn init(never_pause: bool) {
     }
 }
 
-pub fn print_blocks(blocks: &[Vec<I3BarBlock>], config: &SharedConfig) {
+pub fn print_blocks<B>(blocks: &[B], config: &SharedConfig)
+where
+    B: Borrow<RenderedBlock>,
+{
     let mut last_bg = Color::None;
     let mut rendered_blocks = vec![];
 
     // The right most block should never be alternated
-    let mut alt = blocks.iter().filter(|x| !x.is_empty()).count() % 2 == 0;
+    let mut alt = blocks
+        .iter()
+        .map(|x| x.borrow())
+        .filter(|x| !x.segments.is_empty() && !x.marge_with_next)
+        .count()
+        % 2
+        == 0;
 
-    for mut widgets in blocks.iter().cloned().filter(|x| !x.is_empty()) {
-        // Apply tint for all widgets of every second block
-        // TODO: Allow for other non-additive tints
-        if alt {
-            for data in &mut widgets {
-                data.background = data.background + config.theme.alternating_tint_bg;
-                data.color = data.color + config.theme.alternating_tint_fg;
+    let mut logical_block_i = 0;
+
+    for widgets in blocks
+        .iter()
+        .map(|x| x.borrow())
+        .filter(|x| !x.segments.is_empty())
+        .cloned()
+    {
+        let RenderedBlock {
+            mut segments,
+            marge_with_next: merge_with_next,
+        } = widgets;
+
+        for segment in &mut segments {
+            segment.name = Some(logical_block_i.to_string());
+
+            // Apply tint for all widgets of every second block
+            // TODO: Allow for other non-additive tints
+            if alt {
+                segment.background = segment.background + config.theme.alternating_tint_bg;
+                segment.color = segment.color + config.theme.alternating_tint_fg;
             }
         }
-        alt = !alt;
 
-        if let Separator::Custom(separator) = &config.theme.separator {
-            // The first widget's BG is used to get the FG color for the current separator
-            let sep_fg = if config.theme.separator_fg == Color::Auto {
-                widgets.first().unwrap().background
+        if !merge_with_next {
+            alt = !alt;
+        }
+
+        if !merge_with_next {
+            if let Separator::Custom(separator) = &config.theme.separator {
+                // The first widget's BG is used to get the FG color for the current separator
+                let sep_fg = if config.theme.separator_fg == Color::Auto {
+                    segments.first().unwrap().background
+                } else {
+                    config.theme.separator_fg
+                };
+
+                // The separator's BG is the last block's last widget's BG
+                let sep_bg = if config.theme.separator_bg == Color::Auto {
+                    last_bg
+                } else {
+                    config.theme.separator_bg
+                };
+
+                // The last widget's BG is used to get the BG color for the next separator
+                last_bg = segments.last().unwrap().background;
+
+                let separator = I3BarBlock {
+                    full_text: separator.clone(),
+                    background: sep_bg,
+                    color: sep_fg,
+                    ..Default::default()
+                };
+
+                rendered_blocks.push(separator);
             } else {
-                config.theme.separator_fg
-            };
+                // Re-add native separator on last widget for native theme
+                segments.last_mut().unwrap().separator = None;
+                segments.last_mut().unwrap().separator_block_width = None;
+            }
+        }
 
-            // The separator's BG is the last block's last widget's BG
-            let sep_bg = if config.theme.separator_bg == Color::Auto {
-                last_bg
-            } else {
-                config.theme.separator_bg
-            };
+        rendered_blocks.extend(segments);
 
-            // The last widget's BG is used to get the BG color for the next separator
-            last_bg = widgets.last().unwrap().background;
-
-            let separator = I3BarBlock {
-                full_text: separator.clone(),
-                background: sep_bg,
-                color: sep_fg,
-                ..Default::default()
-            };
-
-            rendered_blocks.push(separator);
-            rendered_blocks.extend(widgets);
-        } else {
-            // Re-add native separator on last widget for native theme
-            widgets.last_mut().unwrap().separator = None;
-            widgets.last_mut().unwrap().separator_block_width = None;
-
-            rendered_blocks.extend(widgets);
+        if !merge_with_next {
+            logical_block_i += 1;
         }
     }
 

--- a/src/protocol/i3bar_block.rs
+++ b/src/protocol/i3bar_block.rs
@@ -25,10 +25,17 @@ pub struct I3BarBlock {
     pub min_width: Option<I3BarBlockMinWidth>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<I3BarBlockAlign>,
+    /// This project uses `name` field to uniquely identify each "logical block". For example two
+    /// "config blocks" merged using `merge_with_next` will have the same `name`. This information
+    /// could be used by some bar frontends (such as `i3bar-river`) and will be ignored by `i3bar`
+    /// and `swaybar`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub instance: Option<String>,
+    /// This project uses `instance` field to uniquely identify each block and optionally a part
+    /// of the block, e.g. a "button". The format is `{block_id}:{optional_widget_name}`. This info
+    /// is used when dispatching click events.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub instance: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub urgent: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -58,7 +65,7 @@ impl Default for I3BarBlock {
             min_width: None,
             align: None,
             name: None,
-            instance: None,
+            instance: String::new(),
             urgent: None,
             separator: Some(false),
             separator_block_width: Some(0),

--- a/src/protocol/i3bar_event.rs
+++ b/src/protocol/i3bar_event.rs
@@ -36,14 +36,21 @@ fn unprocessed_events_stream(invert_scrolling: bool) -> BoxedStream<I3BarEvent> 
 
             #[derive(Deserialize)]
             struct I3BarEventRaw {
-                name: Option<String>,
                 instance: Option<String>,
                 button: MouseButton,
             }
 
             let event: I3BarEventRaw = serde_json::from_str(line).unwrap();
-            let id = match event.name {
-                Some(name) => name.parse().unwrap(),
+            let (id, instance) = match event.instance {
+                Some(name) => {
+                    let (id, instance) = name.split_once(':').unwrap();
+                    let instance = if instance.is_empty() {
+                        None
+                    } else {
+                        Some(instance.to_owned())
+                    };
+                    (id.parse().unwrap(), instance)
+                }
                 None => continue,
             };
 
@@ -56,7 +63,7 @@ fn unprocessed_events_stream(invert_scrolling: bool) -> BoxedStream<I3BarEvent> 
 
             let event = I3BarEvent {
                 id,
-                instance: event.instance,
+                instance,
                 button,
             };
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -73,7 +73,7 @@ impl Widget {
         let (key_bg, key_fg) = shared_config.theme.get_colors(self.state);
         let (full, short) = self.source.render(shared_config)?;
         let mut template = I3BarBlock {
-            name: Some(id.to_string()),
+            instance: format!("{id}:"),
             background: key_bg,
             color: key_fg,
             ..I3BarBlock::default()
@@ -97,7 +97,9 @@ impl Widget {
         parts.extend(full.into_iter().map(|w| {
             let mut data = template.clone();
             data.full_text = w.formated_text();
-            data.instance = w.metadata.instance.map(|i| i.to_string());
+            if let Some(i) = &w.metadata.instance {
+                data.instance.push_str(i);
+            }
             data
         }));
 
@@ -105,7 +107,9 @@ impl Widget {
         parts.extend(short.into_iter().map(|w| {
             let mut data = template.clone();
             data.short_text = w.formated_text();
-            data.instance = w.metadata.instance.map(|i| i.to_string());
+            if let Some(i) = &w.metadata.instance {
+                data.instance.push_str(i);
+            }
             data
         }));
 


### PR DESCRIPTION
Fixes #1539

### Example config

```toml
[[block]]
block = "sound"
driver = "pulseaudio"
format = " $icon {$volume |}"
device_kind = "sink"
merge_with_next = true # <===

[[block]]
block = "sound"
driver = "pulseaudio"
format = " $icon {$volume |}"
device_kind = "source"
[block.theme_overrides]
idle_fg = { link = "warning_fg" }
idle_bg = { link = "warning_bg" }
warning_fg = { link = "idle_fg" }
warning_bg = { link = "idle_bg" }
```

in `i3bar-river`:

![image](https://user-images.githubusercontent.com/34583604/216577300-aeaf6462-2e37-4fec-88de-730f31e3d69a.png)

### TODO

- [ ] Test with `swaybar` and `i3bar`
- [ ] Test with different separators.
- [ ] Docs