### PR TITLE
music: remove seek_step, add seek_step_secs

### DIFF
--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -22,7 +22,7 @@
 //! `player` | Name(s) of the music player(s) MPRIS interface. This can be either a music player name or an array of music player names. Run <code>busctl --user list &vert; grep "org.mpris.MediaPlayer2." &vert; cut -d' ' -f1</code> and the name is the part after "org.mpris.MediaPlayer2.". | `None`
 //! `interface_name_exclude` | A list of regex patterns for player MPRIS interface names to ignore. | `[]`
 //! `separator` | String to insert between artist and title. | `" - "`
-//! `seek_step` | Number of microseconds to seek forward/backward when scrolling on the bar. | `1000`
+//! `seek_step_secs` | Positive number of seconds to seek forward/backward when scrolling on the bar. Does not need to be an integer. | `1`
 //!
 //! Note: All placeholders exctpt `icon` can be absent. See the examples below to learn how to handle this.
 //!
@@ -119,8 +119,8 @@ pub struct Config {
     interface_name_exclude: Vec<String>,
     #[default(" - ".into())]
     separator: String,
-    #[default(1_000)]
-    seek_step: i64,
+    #[default(1.into())]
+    seek_step_secs: Seconds<false>,
 }
 
 #[derive(Deserialize, Debug, Clone, SmartDefault)]
@@ -346,10 +346,10 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
                                     break;
                                 }
                                 "seek_forward" => {
-                                    player.seek(config.seek_step).await?;
+                                    player.seek(config.seek_step_secs.0.as_micros() as i64).await?;
                                 }
                                 "seek_backward" => {
-                                    player.seek(-config.seek_step).await?;
+                                    player.seek(-(config.seek_step_secs.0.as_micros() as i64)).await?;
                                 }
                                 _ => (),
                             }

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -4,15 +4,15 @@ use std::borrow::Cow;
 use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Seconds(pub Duration);
+pub struct Seconds<const ALLOW_ONCE: bool = true>(pub Duration);
 
-impl From<u64> for Seconds {
+impl<const ALLOW_ONCE: bool> From<u64> for Seconds<ALLOW_ONCE> {
     fn from(v: u64) -> Self {
         Self::new(v)
     }
 }
 
-impl Seconds {
+impl<const ALLOW_ONCE: bool> Seconds<ALLOW_ONCE> {
     pub fn new(value: u64) -> Self {
         Self(Duration::from_secs(value))
     }
@@ -28,15 +28,15 @@ impl Seconds {
     }
 }
 
-impl<'de> Deserialize<'de> for Seconds {
+impl<'de, const ALLOW_ONCE: bool> Deserialize<'de> for Seconds<ALLOW_ONCE> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        struct SecondsVisitor;
+        struct SecondsVisitor<const ALLOW_ONCE: bool>;
 
-        impl<'de> de::Visitor<'de> for SecondsVisitor {
-            type Value = Seconds;
+        impl<'de, const ALLOW_ONCE: bool> de::Visitor<'de> for SecondsVisitor<ALLOW_ONCE> {
+            type Value = Seconds<ALLOW_ONCE>;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("\"once\", i64 or f64")
@@ -46,7 +46,7 @@ impl<'de> Deserialize<'de> for Seconds {
             where
                 E: de::Error,
             {
-                if v == "once" {
+                if ALLOW_ONCE && v == "once" {
                     Ok(Seconds(Duration::from_secs(60 * 60 * 24 * 365)))
                 } else {
                     Err(E::custom(format!("'{v}' is not a valid duration")))


### PR DESCRIPTION
"Number of microseconds to seek..." doesn't seem very user-friendly. In addition, the default value was clearly wrong (0.001 second).

Renamed `seek_step` to `seek_step_secs` not to silently break configs.