### PR TITLE
Rofication block: Add required LF to num

### DIFF
--- a/src/blocks/rofication.rs
+++ b/src/blocks/rofication.rs
@@ -81,23 +81,22 @@ async fn rofication_status(socket_path: &str) -> Result<(usize, usize)> {
 
     // Request count
     stream
-        .write_all(b"num")
+        .write_all(b"num:\n")
         .await
         .error("Failed to write to socket")?;
 
-    let mut responce = String::new();
+    let mut response = String::new();
     stream
-        .read_to_string(&mut responce)
+        .read_to_string(&mut response)
         .await
         .error("Failed to read from socket")?;
 
     // Response must be two integers: regular and critical, separated eihter by a comma or a \n
-    let (num, crit) = responce
+    let (num, crit) = response
         .split_once(|x| x == ',' || x == '\n')
-        .error("Incorrect responce")?;
-
+        .error("Incorrect response")?;
     Ok((
-        num.parse().error("Incorrect responce")?,
-        crit.parse().error("Incorrect responce")?,
+        num.parse().error("Incorrect response")?,
+        crit.parse().error("Incorrect response")?,
     ))
 }


### PR DESCRIPTION
The command "num" needs to be LF terminated or the server never responds.

```
#socat - UNIX-CONNECT:/tmp/rofi_notification_daemon
num  => No LF
```
Wait forever
```
#socat - UNIX-CONNECT:/tmp/rofi_notification_daemon
num:
0,0
```
This seems to have been broken during the initial transition to 0.30 ( https://github.com/greshake/i3status-rust/commit/2bd5df75f40eb3d64212c482cab359727a42a95d )



