### PR TITLE
Block focused_window: init on load

### DIFF
--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -71,6 +71,14 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
         Driver::WlrToplevelManagement => Box::new(WlrToplevelManagement::new().await?),
     };
 
+                    widget.set_values(map! {
+                        "title" => Value::text("".to_string()),
+                        "marks" => Value::text("".to_string()),
+                        "visible_marks" => Value::text("".to_string())
+                    });
+
+    api.set_widget(&widget).await?;
+
     loop {
         select! {
             _ = api.event() => (),

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -71,11 +71,11 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
         Driver::WlrToplevelManagement => Box::new(WlrToplevelManagement::new().await?),
     };
 
-                    widget.set_values(map! {
-                        "title" => Value::text("".to_string()),
-                        "marks" => Value::text("".to_string()),
-                        "visible_marks" => Value::text("".to_string())
-                    });
+    widget.set_values(map! {
+        "title" => Value::text("".to_string()),
+        "marks" => Value::text("".to_string()),
+        "visible_marks" => Value::text("".to_string())
+    });
 
     api.set_widget(&widget).await?;
 


### PR DESCRIPTION
focused_window doesn't take its space on the bar until the first time it gets information about a window; in practice this means the first time the bar is loaded, the widget is not there, and the first time we switch to window the bar layout changes.

This can be trivially seen by reloading i3 from a terminal, or more trivially by running it with a base config like this:

```
[icons]
icons = "awesome5"

[theme]
theme = "gruvbox-dark"

[[block]]
block = "focused_window"
format = "$title.str(min_w:50, max_w:100)"
```

```
/i3status-rs /tmp/rego.toml
{"version": 1, "click_events": true}
[
```
(no output until we switch to a different window, and then:

```
[{"full_text":"","color":"#282828FF","separator":false,"separator_block_width":0,"markup":"pango"},{"full_text":"Comparing greshake:master...cfsmp3:init_focused_window · greshake/i3status-rust - Google Chrome","color":"#EBDBB2FF","background":"#282828FF","name":"0","instance":"0:","separator":false,"separator_block_width":0,"markup":"pango"}],
```

With this diff, we get an empty block from the start, so the bar layout doesn't need to change.
