### PR TITLE
Add width, w for constant width on formatter

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -38,7 +38,6 @@
 //! Note: width just changes the values of both min_width and max_width to be the same. Use width
 //! if you want the values to be the same, or the other two otherwise. Don't mix width with
 //! min_width or max_width.
-/
 //!
 //! ## `eng` - Format numbers using engineering notation
 //!

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -33,6 +33,8 @@
 //! -----------------------|---------------------------------------------------|-------------
 //! `min_width` or `min_w` | if text is shorter it will be padded using spaces | `0`
 //! `max_width` or `max_w` | if text is longer it will be truncated            | Infinity
+//! `width` or `w`         | Text will be exactly this length by padding or truncating as needed | min_width to
+//! max_width defaults
 //! `rot_interval`         | if text is longer than `max_width` it will be rotated every `rot_interval` seconds | `0.5`
 //!
 //! ## `eng` - Format numbers using engineering notation

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -1,5 +1,4 @@
 //! # Formatting system
-//!
 //! Many blocks have a `format` configuration option, which allows to heavily customize the block's
 //! appearance. In short, each block with `format` option provides a set of values, which are
 //! displayed according to `format`. `format`'s value is just a text with embeded variables.
@@ -33,9 +32,13 @@
 //! -----------------------|---------------------------------------------------|-------------
 //! `min_width` or `min_w` | if text is shorter it will be padded using spaces | `0`
 //! `max_width` or `max_w` | if text is longer it will be truncated            | Infinity
-//! `width` or `w`         | Text will be exactly this length by padding or truncating as needed | min_width to
-//! max_width defaults
+//! `width` or `w`         | Text will be exactly this length by padding or truncating as needed | N/A
 //! `rot_interval`         | if text is longer than `max_width` it will be rotated every `rot_interval` seconds | `0.5`
+//!
+//! Note: width just changes the values of both min_width and max_width to be the same. Use width
+//! if you want the values to be the same, or the other two otherwise. Don't mix width with
+//! min_width or max_width.
+/
 //!
 //! ## `eng` - Format numbers using engineering notation
 //!

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -70,6 +70,10 @@ pub fn new_formatter(name: &str, args: &[Arg]) -> Result<Box<dyn Formatter>> {
                     "max_width" | "max_w" => {
                         max_width = arg.val.parse().error("Width must be a positive integer")?;
                     }
+                    "width" | "w" => {
+                        min_width = arg.val.parse().error("Width must be a positive integer")?;
+                        max_width = min_width;
+                    }
                     "rot_interval" => {
                         rot_interval = Some(
                             arg.val


### PR DESCRIPTION
Instead of having to specify both min_width and max_width to the same value when we want a constant length for a string (so the bar doesn't change, for example because we're now playing a song with a much longer name) we should be able to just specify the width we want.

This diff just adds 'width' or 'w' which is course sets min_width and max_width to the same value.
