### PR TITLE
bluetooth: identify audio-headphones as headphones

### DIFF
--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -41,7 +41,7 @@
 //! ```
 //!
 //! # Icons Used
-//! - `headphones` for bluetooth devices identifying as "audio-card" or "audio-headset"
+//! - `headphones` for bluetooth devices identifying as "audio-card", "audio-headset" or "audio-headphones"
 //! - `joystick` for bluetooth devices identifying as "input-gaming"
 //! - `keyboard` for bluetooth devices identifying as "input-keyboard"
 //! - `mouse` for bluetooth devices identifying as "input-mouse"
@@ -269,7 +269,7 @@ impl DeviceMonitor {
         Some(DeviceInfo {
             connected,
             icon: match icon.as_str() {
-                "audio-card" | "audio-headset" => "headphones",
+                "audio-card" | "audio-headset" | "audio-headphones" => "headphones",
                 "input-gaming" => "joystick",
                 "input-keyboard" => "keyboard",
                 "input-mouse" => "mouse",


### PR DESCRIPTION
I have a Bose QC35 II which has an icon identification of 'audio-headphones'. Added this to the bluetooth module so that it could identify my headset as a headset.

```
[Bose QC35 II]# info
Device 2C:41:A1:83:12:64 (public)
	Name: Bose QC35 II
	Alias: Bose QC35 II
	Class: 0x00240418
	Icon: audio-headphones
	Paired: yes
	Bonded: yes
	Trusted: no
	Blocked: no
	Connected: yes
	LegacyPairing: no
	UUID: Vendor specific           (00000000-deca-fade-deca-deafdecacaff)
	UUID: Serial Port               (00001101-0000-1000-8000-00805f9b34fb)
	UUID: Headset                   (00001108-0000-1000-8000-00805f9b34fb)
	UUID: Audio Sink                (0000110b-0000-1000-8000-00805f9b34fb)
	UUID: A/V Remote Control Target (0000110c-0000-1000-8000-00805f9b34fb)
	UUID: A/V Remote Control        (0000110e-0000-1000-8000-00805f9b34fb)
	UUID: Handsfree                 (0000111e-0000-1000-8000-00805f9b34fb)
	UUID: PnP Information           (00001200-0000-1000-8000-00805f9b34fb)
	UUID: Vendor specific           (81c2e72a-0591-443e-a1ff-05f988593351)
	UUID: Vendor specific           (931c7e8a-540f-4686-b798-e8df0a2ad9f7)
	UUID: Vendor specific           (f8d1fbe4-7966-4334-8024-ff96c9330e15)
	Modalias: bluetooth:v009Ep4020d0318
```