### PR TITLE
blocks/watson: Avoid error on race condition while reading state

### DIFF
--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -90,7 +90,7 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
         let state = read_to_string(&state_path)
             .await
             .error("Failed to read state file")?;
-        let state = serde_json::from_str(&state).error("Unable to deserialize state")?;
+        let state = serde_json::from_str(&state).unwrap_or(WatsonState::Idle {});
         match state {
             state @ WatsonState::Active { .. } => {
                 widget.state = State::Good;


### PR DESCRIPTION
While reading state, neither we nor watson seem to perfom locking of the state file. Thus, parsing the state file can fail unexpectedly. This would lead to an error in the block, making it unusable until i3status-rust is restartet. This change introduces the empty state as a default to avoid this behavior.

fixes #1775