### PR TITLE
Stop find_files requiring a specific extension

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -17,13 +17,7 @@ use crate::errors::*;
 ///
 /// Automatically append an extension if not presented.
 pub fn find_file(file: &str, subdir: Option<&str>, extension: Option<&str>) -> Option<PathBuf> {
-    // Set (or update) the extension
-    let mut file = PathBuf::from(file);
-    if let Some(extension) = extension {
-        file.set_extension(extension);
-    }
-
-    // Try full path
+    let file = PathBuf::from(file);
     if file.exists() {
         return Some(file);
     }
@@ -35,8 +29,8 @@ pub fn find_file(file: &str, subdir: Option<&str>, extension: Option<&str>) -> O
             xdg_config.push(subdir);
         }
         xdg_config.push(&file);
-        if xdg_config.exists() {
-            return Some(xdg_config);
+        if let Some(file) = exists_with_opt_extension(&xdg_config, extension) {
+            return Some(file);
         }
     }
 
@@ -47,8 +41,8 @@ pub fn find_file(file: &str, subdir: Option<&str>, extension: Option<&str>) -> O
             xdg_data.push(subdir);
         }
         xdg_data.push(&file);
-        if xdg_data.exists() {
-            return Some(xdg_data);
+        if let Some(file) = exists_with_opt_extension(&xdg_data, extension) {
+            return Some(file);
         }
     }
 
@@ -58,10 +52,25 @@ pub fn find_file(file: &str, subdir: Option<&str>, extension: Option<&str>) -> O
         usr_share_path.push(subdir);
     }
     usr_share_path.push(&file);
-    if usr_share_path.exists() {
-        return Some(usr_share_path);
+    if let Some(file) = exists_with_opt_extension(&usr_share_path, extension) {
+        return Some(file);
     }
 
+    None
+}
+
+fn exists_with_opt_extension(file: &Path, extension: Option<&str>) -> Option<PathBuf> {
+    if file.exists() {
+        return Some(file.into());
+    }
+    // If file has no extension, test with given extension
+    if let (None, Some(extension)) = (file.extension(), extension) {
+        let file = file.with_extension(extension);
+        // Check again with extension added
+        if file.exists() {
+            return Some(file);
+        }
+    }
     None
 }
 


### PR DESCRIPTION
I have my config in `~/.config/i3/status` next to i3 config and the latest upgrade fails with `Configuration file '~/.config/i3/status' not found`, and it took a while to track down the cause. It looks like a recent change forces all files to have a `'.toml` extension even if they exist without it or have a different extension. 