### PR TITLE
net: try to fetch ssid from NL80211_BSS_INFORMATION_ELEMENTS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "neli-wifi"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714dd86601f4da56faffa07bc24c684048d01575f064e2256cef45c5722a10b"
+checksum = "bba6803a3cd5cd89aff307e237c0d3f45ee5e3cd7e2980eae0b7f61d22217476"
 dependencies = [
  "neli",
  "neli-proc-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ libpulse-binding = { version = "2.0", default-features = false, optional = true 
 log = "0.4"
 maildir = { version = "0.6", optional = true }
 neli = { version = "0.6", features = ["async"] }
-neli-wifi = { version = "0.4", features = ["async"] }
+neli-wifi = { version = "0.4.1", features = ["async"] }
 nix = "0.26"
 nom = "7.1.2"
 notmuch = { version = "0.8", optional = true }


### PR DESCRIPTION
I don't know what `NL80211_BSS_INFORMATION_ELEMENTS` is, but on my machine the first two bytes don't make sense, then goes SSID up to byte 1.

Fixes #1607