### PR TITLE
Allow showing or forcing IPv4 in `external_ip`

### DIFF
--- a/src/blocks/prelude.rs
+++ b/src/blocks/prelude.rs
@@ -7,6 +7,7 @@ pub use crate::util::{default, new_dbus_connection, new_system_dbus_connection};
 pub use crate::widget::{State, Widget};
 pub use crate::wrappers::{Seconds, ShellString};
 pub use crate::REQWEST_CLIENT;
+pub use crate::REQWEST_CLIENT_IPV4;
 
 pub use serde::Deserialize;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,11 +50,21 @@ use widget::{State, Widget};
 pub type BoxedFuture<T> = Pin<Box<dyn Future<Output = T>>>;
 pub type BoxedStream<T> = Pin<Box<dyn Stream<Item = T>>>;
 
+const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+const REQWEST_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub static REQWEST_CLIENT: Lazy<reqwest::Client> = Lazy::new(|| {
-    const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
-    const REQWEST_TIMEOUT: Duration = Duration::from_secs(10);
     reqwest::Client::builder()
         .user_agent(APP_USER_AGENT)
+        .timeout(REQWEST_TIMEOUT)
+        .build()
+        .unwrap()
+});
+
+pub static REQWEST_CLIENT_IPV4: Lazy<reqwest::Client> = Lazy::new(|| {
+    reqwest::Client::builder()
+        .user_agent(APP_USER_AGENT)
+        .local_address(Some(std::net::Ipv4Addr::UNSPECIFIED.into()))
         .timeout(REQWEST_TIMEOUT)
         .build()
         .unwrap()


### PR DESCRIPTION
This is a first idea for how we could do IPv4 in `external_ip` to solve #1761.

In the first commit, i just added a `use_ipv4` option that makes the block use IPv4.

But here's where i need some advice: Thinking about it, it might be more useful to have an `$ipv4` placeholder, which would allow showing both at the same time (without requiring 2 blocks).

I implemented this in the second commit. It works, but has the disadvantage of all other info (country, city, ASN, etc.) still belonging to the original (potentially-non-v4) IP. The only alternative i see here would be doubling all format placeholders (`v4_country`, `v4_city`, `v4_asn`), which isn't very nice either. There's also the disadvantage of both requests being made even if only `$ipv4` is used.

Or is it just easier to go with commit 1 and say that if users want both they should use 2 blocks (optionally with `merge_with_next`)?

Feedback appreciated! :)