### PR TITLE
backlight: Add regex device name matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "calibright"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5fc8eb867a90df14dfb16a73010f06cdf089669bb52a9c2adae37776d9f1db"
+dependencies = [
+ "dirs",
+ "env_logger",
+ "futures",
+ "log",
+ "notify",
+ "regex",
+ "serde",
+ "smart-default",
+ "thiserror",
+ "tokio",
+ "toml",
+ "zbus",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +574,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +644,7 @@ checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -633,6 +666,17 @@ name = "futures-core"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -673,9 +717,12 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -847,6 +894,7 @@ version = "0.30.5"
 dependencies = [
  "async-once-cell",
  "async-trait",
+ "calibright",
  "chrono",
  "chrono-tz",
  "clap",
@@ -855,7 +903,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hyper",
- "inotify",
+ "inotify 0.10.0",
  "libc",
  "libpulse-binding",
  "log",
@@ -932,6 +980,17 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1015,6 +1074,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8fc60ba15bf51257aa9807a48a61013db043fcf3a78cb0d916e8e396dcad98"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -1245,6 +1324,22 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "inotify 0.9.6",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1672,6 +1767,15 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2203,6 +2307,17 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-once-cell = "0.4"
 async-trait = "0.1"
+calibright = { version = "0.1", features = ["watch"] }
 crossbeam-channel = "0.5"
 dirs = "4.0"
 env_logger = "0.10"

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -13,7 +13,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `device` | The `/sys/class/backlight` device to read brightness information from.  When there is no `device` specified, this block will display information from the first device found in the `/sys/class/backlight` directory. If you only have one display, this approach should find it correctly.| Default device
+//! `device` | A regex to match against `/sys/class/backlight` devices to read brightness information from (can match 1 or more devices). When there is no `device` specified, this block will display information for all devices found in the `/sys/class/backlight` directory. | Default device
 //! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $brightness "`
 //! `step_width` | The brightness increment to use when scrolling, in percent | `5`
 //! `minimum` | The minimum brightness that can be scrolled down to | `5`
@@ -43,6 +43,12 @@
 //! device = "intel_backlight"
 //! ```
 //!
+//! # calibright
+//!
+//! Additional display brightness calibration can be set in `$XDG_CONFIG_HOME/calibright/config.toml`
+//! See [https://github.com/bim9262/calibright] for more details.
+//! This block will override any global config set in `$XDG_CONFIG_HOME/calibright/config.toml`
+//!
 //! # D-Bus Fallback
 //!
 //! If you don't use `systemd-logind` i3status-rust will attempt to set the brightness
@@ -63,67 +69,27 @@
 //! # Icons Used
 //! - `backlight` (as a progression)
 
-use std::cmp::max;
-use std::ops::Range;
-use std::path::{Path, PathBuf};
-
-use inotify::{Inotify, WatchMask};
-use tokio::fs::{read_dir, OpenOptions};
-use tokio::io::AsyncWriteExt;
+use calibright::{CalibrightBuilder, CalibrightConfig, DeviceConfig};
 
 use super::prelude::*;
-use crate::util::read_file;
-
-make_log_macro!(debug, "backlight");
-
-#[zbus::dbus_proxy(
-    interface = "org.freedesktop.login1.Session",
-    default_service = "org.freedesktop.login1",
-    default_path = "/org/freedesktop/login1/session/auto"
-)]
-trait Session {
-    fn set_brightness(&self, subsystem: &str, name: &str, brightness: u32) -> zbus::Result<()>;
-}
-
-/// Location of backlight devices
-const DEVICES_PATH: &str = "/sys/class/backlight";
-
-/// Filename for device's max brightness
-const FILE_MAX_BRIGHTNESS: &str = "max_brightness";
-
-/// Filename for current brightness.
-const FILE_BRIGHTNESS: &str = "actual_brightness";
-
-/// amdgpu drivers set the actual_brightness in a different scale than
-/// [0, max_brightness], so we have to use the 'brightness' file instead.
-/// This may be fixed in the new 5.7 kernel?
-const FILE_BRIGHTNESS_AMD: &str = "brightness";
-
-/// set the requested brightness level
-const FILE_BRIGHTNESS_WRITE: &str = "brightness";
-
-/// Range of valid values for `root_scaling`
-const ROOT_SCALDING_RANGE: Range<f64> = 0.1..10.;
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(default)]
 pub struct Config {
     device: Option<String>,
     format: FormatConfig,
-    #[default(5)]
-    step_width: u8,
-    #[default(5)]
-    minimum: u8,
-    #[default(100)]
-    maximum: u8,
-    cycle: Option<Vec<u8>>,
-    #[default(1.0)]
-    root_scaling: f64,
+    #[default(5.0)]
+    step_width: f64,
+    #[default(5.0)]
+    minimum: f64,
+    #[default(100.0)]
+    maximum: f64,
+    cycle: Option<Vec<f64>>,
     invert_icons: bool,
-    #[default(1.0)]
-    ddcci_sleep_multiplier: f64,
-    #[default(10)]
-    ddcci_max_tries_write_read: u8,
+    //Calibright config settings
+    root_scaling: Option<f64>,
+    ddcci_sleep_multiplier: Option<f64>,
+    ddcci_max_tries_write_read: Option<u8>,
 }
 
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
@@ -140,238 +106,111 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
         .cycle
         .unwrap_or_else(|| vec![config.minimum, config.maximum])
         .into_iter()
+        .map(|x| x / 100.0)
         .cycle();
 
-    let device = match &config.device {
-        None => {
-            BacklightDevice::default(
-                config.root_scaling,
-                config.ddcci_sleep_multiplier,
-                config.ddcci_max_tries_write_read,
-            )
-            .await?
-        }
-        Some(path) => {
-            BacklightDevice::from_device(
-                path,
-                config.root_scaling,
-                config.ddcci_sleep_multiplier,
-                config.ddcci_max_tries_write_read,
-            )
-            .await?
-        }
-    };
+    let step_width = config.step_width / 100.0;
+    let minimum = config.minimum / 100.0;
+    let maximum = config.maximum / 100.0;
 
-    // Watch for brightness changes
-    let mut notify = Inotify::init().error("Failed to start inotify")?;
-    notify
-        .add_watch(&device.read_brightness_file, WatchMask::MODIFY)
-        .error("Failed to watch brightness file")?;
-    let mut file_changes = notify
-        .event_stream([0; 1024])
-        .error("Failed to create event stream")?;
+    let mut calibright_defaults = DeviceConfig::default();
+
+    if let Some(root_scaling) = config.root_scaling {
+        calibright_defaults.root_scaling = root_scaling;
+    }
+
+    if let Some(ddcci_sleep_multiplier) = config.ddcci_sleep_multiplier {
+        calibright_defaults.ddcci_sleep_multiplier = ddcci_sleep_multiplier;
+    }
+
+    if let Some(ddcci_max_tries_write_read) = config.ddcci_max_tries_write_read {
+        calibright_defaults.ddcci_max_tries_write_read = ddcci_max_tries_write_read;
+    }
+
+    let calibright_config = CalibrightConfig::new_with_defaults(&calibright_defaults)
+        .await
+        .error("calibright config error")?;
+
+    let mut calibright = CalibrightBuilder::new()
+        .with_device_regex(config.device.as_deref().unwrap_or("."))
+        .with_config(calibright_config)
+        .with_poll_interval(api.error_interval)
+        .build()
+        .await
+        .error("Failed to init calibright")?;
+
+    // This is used to display the error, if there is one
+    let mut block_error: Option<Error> = None;
+
+    let mut brightness = calibright
+        .get_brightness()
+        .await
+        .error("Failed to get brightness")
+        .map_err(|e| block_error = Some(e))
+        .unwrap_or_default();
 
     loop {
-        let brightness = api.recoverable(|| device.brightness()).await?;
+        if let Some(e) = block_error {
+            api.set_error(e).await?;
+        } else {
+            let mut icon_value = brightness;
+            if config.invert_icons {
+                icon_value = 1.0 - icon_value;
+            }
 
-        let mut icon_value = brightness as f64 / 100.0;
-        if config.invert_icons {
-            icon_value = 1.0 - icon_value;
+            widget.set_values(map! {
+                "icon" => Value::icon(api.get_icon_in_progression("backlight", icon_value)?),
+                "brightness" => Value::percents((brightness * 100.0).round())
+            });
+            api.set_widget(&widget).await?;
         }
-
-        widget.set_values(map! {
-            "icon" => Value::icon(api.get_icon_in_progression("backlight", icon_value)?),
-            "brightness" => Value::percents(brightness)
-        });
-        api.set_widget(&widget).await?;
 
         loop {
             select! {
-                _ = file_changes.next() => break,
+                // Calibright can recover from errors, just keep reading the next event.
+                _ = calibright.next() => {
+                    block_error = calibright
+                        .get_brightness()
+                        .await
+                        .map(|new_brightness| {brightness = new_brightness;})
+                        .error("Failed to get brightness")
+                        .err();
+
+                    break;
+                },
                 event = api.event() => match event {
                     Action(a) if a == "cycle" => {
-                        if let Some(brightness) = cycle.next() {
-                            device.set_brightness(brightness).await?;
+                        if let Some(cycle_brightness) = cycle.next() {
+                            brightness = cycle_brightness;
+                            block_error = calibright
+                                .set_brightness(brightness)
+                                .await
+                                .error("Failed to set brightness")
+                                .err();
+                            break;
+
                         }
                     }
                     Action(a) if a == "brightness_up" => {
-                        device.set_brightness(
-                            (brightness + config.step_width) .clamp(config.minimum, config.maximum)
-                        ).await?;
+                            brightness = (brightness + step_width).clamp(minimum, maximum);
+                            block_error = calibright
+                                .set_brightness(brightness)
+                                .await
+                                .error("Failed to set brightness")
+                                .err();
+                            break;
                     }
                     Action(a) if a == "brightness_down" => {
-                        device.set_brightness(
-                            brightness
-                                .saturating_sub(config.step_width)
-                                .clamp(config.minimum, config.maximum)
-                        ).await?;
+                            brightness = (brightness - step_width).clamp(minimum, maximum);
+                            block_error = calibright
+                                .set_brightness(brightness)
+                                .await
+                                .error("Failed to set brightness")
+                                .err();
+                            break;
                     }
                     _ => (),
                 }
-            }
-        }
-    }
-}
-
-/// Read a brightness value from the given path.
-async fn read_brightness_raw(
-    device_file: &Path,
-    ddcci_sleep_multiplier: f64,
-    ddcci_max_tries_write_read: u8,
-) -> Result<u64> {
-    let val = match read_file(device_file).await {
-        Ok(v) => v,
-        Err(_) => 'blk: {
-            for i in 1..ddcci_max_tries_write_read {
-                debug!("retry {i} reading brightness");
-                // See https://glenwing.github.io/docs/VESA-DDCCI-1.1.pdf
-                // Section 4.3 for timing explanation
-                sleep(Duration::from_millis(
-                    (40.0 * ddcci_sleep_multiplier).round() as u64,
-                ))
-                .await;
-                if let Ok(val) = read_file(device_file).await {
-                    break 'blk val;
-                }
-            }
-            return Err(Error::new(
-                "Failed to read brightness file, check your ddcci settings",
-            ));
-        }
-    };
-    val.parse()
-        .error("Failed to read value from brightness file")
-}
-
-/// Represents a physical backlight device whose brightness level can be queried.
-struct BacklightDevice {
-    device_name: String,
-    read_brightness_file: PathBuf,
-    write_brightness_file: PathBuf,
-    max_brightness: u64,
-    root_scaling: f64,
-    dbus_proxy: SessionProxy<'static>,
-    ddcci_sleep_multiplier: f64,
-    ddcci_max_tries_write_read: u8,
-}
-
-impl BacklightDevice {
-    async fn new(
-        device_path: PathBuf,
-        root_scaling: f64,
-        ddcci_sleep_multiplier: f64,
-        ddcci_max_tries_write_read: u8,
-    ) -> Result<Self> {
-        let dbus_conn = new_system_dbus_connection().await?;
-        Ok(Self {
-            read_brightness_file: device_path.join({
-                if device_path.ends_with("amdgpu_bl0") {
-                    FILE_BRIGHTNESS_AMD
-                } else {
-                    FILE_BRIGHTNESS
-                }
-            }),
-            write_brightness_file: device_path.join(FILE_BRIGHTNESS_WRITE),
-            device_name: device_path
-                .file_name()
-                .map(|x| x.to_str().unwrap().into())
-                .error("Malformed device path")?,
-            max_brightness: read_brightness_raw(
-                &device_path.join(FILE_MAX_BRIGHTNESS),
-                ddcci_sleep_multiplier,
-                ddcci_max_tries_write_read,
-            )
-            .await?,
-            root_scaling: root_scaling.clamp(ROOT_SCALDING_RANGE.start, ROOT_SCALDING_RANGE.end),
-            dbus_proxy: SessionProxy::new(&dbus_conn)
-                .await
-                .error("failed to create SessionProxy")?,
-            ddcci_sleep_multiplier,
-            ddcci_max_tries_write_read,
-        })
-    }
-
-    /// Use the default backlight device, i.e. the first one found in the
-    /// `/sys/class/backlight` directory.
-    async fn default(
-        root_scaling: f64,
-        ddcci_sleep_multiplier: f64,
-        ddcci_max_tries_write_read: u8,
-    ) -> Result<Self> {
-        let device = read_dir(DEVICES_PATH)
-            .await
-            .error("Failed to read backlight device directory")?
-            .next_entry()
-            .await
-            .error("No backlight devices found")?
-            .error("Failed to read default device file")?;
-        Self::new(
-            device.path(),
-            root_scaling,
-            ddcci_sleep_multiplier,
-            ddcci_max_tries_write_read,
-        )
-        .await
-    }
-
-    /// Use the backlight device `device`. Returns an error if a directory for
-    /// that device is not found.
-    async fn from_device(
-        device: &str,
-        root_scaling: f64,
-        ddcci_sleep_multiplier: f64,
-        ddcci_max_tries_write_read: u8,
-    ) -> Result<Self> {
-        Self::new(
-            Path::new(DEVICES_PATH).join(device),
-            root_scaling,
-            ddcci_sleep_multiplier,
-            ddcci_max_tries_write_read,
-        )
-        .await
-    }
-
-    /// Query the brightness value for this backlight device, as a percent.
-    async fn brightness(&self) -> Result<u8> {
-        let raw = read_brightness_raw(
-            &self.read_brightness_file,
-            self.ddcci_sleep_multiplier,
-            self.ddcci_max_tries_write_read,
-        )
-        .await?;
-
-        let brightness_ratio =
-            (raw as f64 / self.max_brightness as f64).powf(self.root_scaling.recip());
-
-        ((brightness_ratio * 100.0).round() as i64)
-            .try_into()
-            .ok()
-            .filter(|brightness| (0..=100).contains(brightness))
-            .error("Brightness is not in [0, 100]")
-    }
-
-    /// Set the brightness value for this backlight device, as a percent.
-    async fn set_brightness(&self, value: u8) -> Result<()> {
-        let value = value.clamp(0, 100);
-        let ratio = (value as f64 / 100.0).powf(self.root_scaling);
-        let raw = max(1, (ratio * (self.max_brightness as f64)).round() as u32);
-        match self
-            .dbus_proxy
-            .set_brightness("backlight", &self.device_name, raw)
-            .await
-        {
-            Ok(()) => Ok(()),
-            Err(_) => {
-                // Fall back to writing to sysfs brightness file
-                let mut file = OpenOptions::new()
-                    .write(true)
-                    .truncate(true)
-                    .open(&self.write_brightness_file)
-                    .await
-                    .error("Could not open brightness file to write")?;
-                file.write_all(raw.to_string().as_bytes())
-                    .await
-                    .error("Could not write sysfs brightness")
             }
         }
     }


### PR DESCRIPTION
Fixes #1771

There's still no device rescanning to detect if a device has been removed/added.
I left the default behavior when no device is specified to match only the first device, but would like others thoughts if we should make it match all devices by default (that's what I'd suggest). Most people who didn't specify a device already probably only have a single monitor so matching everything won't make an impact to them.