### PR TITLE
Filter battery selection by model

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -9,6 +9,7 @@
 //! ----|--------|--------
 //! `device` | sysfs/UPower: The device in `/sys/class/power_supply/` to read from (can also be "DisplayDevice" for UPower). apc_ups: IPv4Address:port or hostname:port | sysfs: the first battery device found in /sys/class/power_supply, with "BATx" or "CMBx" entries taking precedence. apc_ups: "localhost:3551". upower: `DisplayDevice`
 //! `driver` | One of `"sysfs"`, `"apc_ups"`, or `"upower"` | `"sysfs"`
+//! `Model` | If present, the contents of `/sys/class/power_supply/.../model_name` must match this value. Typical use is to select by model name on devices that change their path. | N/A
 //! `interval` | Update interval, in seconds. Only relevant for `driver = "sysfs"` \|\| "apc_ups"`. | `10`
 //! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $percentage "`
 //! `full_format` | Same as `format` but for when the battery is full | `" $icon "`

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -77,6 +77,7 @@ mod upower;
 pub struct Config {
     device: Option<String>,
     driver: BatteryDriver,
+    model: Option<String>,
     #[default(10.into())]
     interval: Seconds,
     format: FormatConfig,
@@ -117,9 +118,9 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
 
     let dev_name = DeviceName::new(config.device)?;
     let mut device: Box<dyn BatteryDevice + Send + Sync> = match config.driver {
-        BatteryDriver::Sysfs => Box::new(sysfs::Device::new(dev_name, config.interval)),
+        BatteryDriver::Sysfs => Box::new(sysfs::Device::new(dev_name, config.model, config.interval)),
         BatteryDriver::ApcUps => Box::new(apc_ups::Device::new(dev_name, config.interval).await?),
-        BatteryDriver::Upower => Box::new(upower::Device::new(dev_name).await?),
+        BatteryDriver::Upower => Box::new(upower::Device::new(dev_name, config.model).await?),
     };
 
     loop {

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -9,7 +9,7 @@
 //! ----|--------|--------
 //! `device` | sysfs/UPower: The device in `/sys/class/power_supply/` to read from (can also be "DisplayDevice" for UPower). apc_ups: IPv4Address:port or hostname:port | sysfs: the first battery device found in /sys/class/power_supply, with "BATx" or "CMBx" entries taking precedence. apc_ups: "localhost:3551". upower: `DisplayDevice`
 //! `driver` | One of `"sysfs"`, `"apc_ups"`, or `"upower"` | `"sysfs"`
-//! `Model` | If present, the contents of `/sys/class/power_supply/.../model_name` must match this value. Typical use is to select by model name on devices that change their path. | N/A
+//! `model` | If present, the contents of `/sys/class/power_supply/.../model_name` must match this value. Typical use is to select by model name on devices that change their path. | N/A
 //! `interval` | Update interval, in seconds. Only relevant for `driver = "sysfs"` \|\| "apc_ups"`. | `10`
 //! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $percentage "`
 //! `full_format` | Same as `format` but for when the battery is full | `" $icon "`

--- a/src/blocks/battery/sysfs.rs
+++ b/src/blocks/battery/sysfs.rs
@@ -57,14 +57,16 @@ impl CapacityLevel {
 pub(super) struct Device {
     dev_name: DeviceName,
     dev_path: Option<PathBuf>,
+    dev_model: Option<String>,
     interval: Interval,
 }
 
 impl Device {
-    pub(super) fn new(dev_name: DeviceName, interval: Seconds) -> Self {
+    pub(super) fn new(dev_name: DeviceName, dev_model: Option<String>, interval: Seconds) -> Self {
         Self {
             dev_name,
             dev_path: None,
+            dev_model,
             interval: interval.timer(),
         }
     }
@@ -99,6 +101,15 @@ impl Device {
                 || !Self::device_available(&path).await
             {
                 continue;
+            }
+
+            // Untested
+            debug!("battery '{}', model={:?}", path.display(), Self::read_prop::<String>(&path, "model_name").await.as_deref() );
+            if let Some(dev_model) = &self.dev_model {
+                if Self::read_prop::<String>(&path, "model_name").await.as_deref() != Some(dev_model.as_str())
+                {
+                    continue;
+                }
             }
 
             debug!(

--- a/src/blocks/battery/sysfs.rs
+++ b/src/blocks/battery/sysfs.rs
@@ -103,11 +103,11 @@ impl Device {
                 continue;
             }
 
-            // Untested
             debug!("battery '{}', model={:?}", path.display(), Self::read_prop::<String>(&path, "model_name").await.as_deref() );
             if let Some(dev_model) = &self.dev_model {
                 if Self::read_prop::<String>(&path, "model_name").await.as_deref() != Some(dev_model.as_str())
                 {
+                    debug! ("Skipping based on model.");
                     continue;
                 }
             }

--- a/src/blocks/battery/upower.rs
+++ b/src/blocks/battery/upower.rs
@@ -18,7 +18,7 @@ struct DeviceConnection {
 impl DeviceConnection {
 
     async fn new(dbus_conn: &Connection, device: &DeviceName, expected_model: Option<String>) -> Result<Option<Self>> {
-        let device_proxy = if device.exact().map_or(true, |d| d == "DisplayDevice") {
+        let device_proxy = if device.exact().map_or(true, |d| d == "DisplayDevice") && expected_model.is_none() {
             DeviceProxy::builder(dbus_conn)
                 .path(DISPLAY_DEVICE_PATH)
                 .unwrap()

--- a/src/blocks/battery/upower.rs
+++ b/src/blocks/battery/upower.rs
@@ -52,7 +52,6 @@ impl DeviceConnection {
                 // Verify device type
                 // https://upower.freedesktop.org/docs/Device.html#Device:Type
                 // consider any peripheral, UPS and internal battery
-
                 let device_type = proxy.type_().await.error("Failed to get device's type")?;
                 if device_type == 1 {
                     continue;

--- a/src/blocks/battery/upower.rs
+++ b/src/blocks/battery/upower.rs
@@ -40,9 +40,8 @@ impl DeviceConnection {
                     .build()
                     .await
                     .error("Failed to create DeviceProxy")?;
-                // Verify device type
-                // https://upower.freedesktop.org/docs/Device.html#Device:Type
-                // consider any peripheral, UPS and internal battery
+
+                // Filter by model if needed
                 if let Some(expected_model) = &expected_model {
                     if let Ok(device_model) = proxy.model().await {
                         if !expected_model.eq(&device_model) {
@@ -50,6 +49,10 @@ impl DeviceConnection {
                         }
                     }
                 }
+                // Verify device type
+                // https://upower.freedesktop.org/docs/Device.html#Device:Type
+                // consider any peripheral, UPS and internal battery
+
                 let device_type = proxy.type_().await.error("Failed to get device's type")?;
                 if device_type == 1 {
                     continue;

--- a/src/blocks/battery/upower.rs
+++ b/src/blocks/battery/upower.rs
@@ -19,7 +19,7 @@ impl DeviceConnection {
     async fn new(
         dbus_conn: &Connection,
         device: &DeviceName,
-        expected_model: Option<String>,
+        expected_model: Option<&str>,
     ) -> Result<Option<Self>> {
         let device_proxy =
             if device.exact().map_or(true, |d| d == "DisplayDevice") && expected_model.is_none() {
@@ -107,7 +107,7 @@ impl Device {
     pub(super) async fn new(device: DeviceName, dev_model: Option<String>) -> Result<Self> {
         let dbus_conn = new_system_dbus_connection().await?;
 
-        let device_conn = DeviceConnection::new(&dbus_conn, &device, dev_model.clone()).await?;
+        let device_conn = DeviceConnection::new(&dbus_conn, &device, dev_model.as_deref()).await?;
 
         let upower_proxy = UPowerProxy::new(&dbus_conn)
             .await
@@ -194,7 +194,7 @@ impl BatteryDevice for Device {
                     _ = self.device_removed_stream.next() => {},
                     _ = self.device_added_stream.next() => {
                         if let Some(device_conn) =
-                        DeviceConnection::new(&self.dbus_conn, &self.device, self.dev_model.clone()).await?
+                        DeviceConnection::new(&self.dbus_conn, &self.device, self.dev_model.as_deref()).await?
                         {
                             self.device_conn = Some(device_conn);
                             break;


### PR DESCRIPTION
Add the option to select batteries by model instead of path. Example:

```
[[block]]
block = "battery"
interval = 10
driver = "upower"
model = "MX Ergo Multi-Device Trackball"
format = "🖱 $icon $percentage"

[[block]]
block = "battery"
interval = 10
driver = "sysfs"
model = "Framewor"
format = "$icon $percentage"

```

Testing recovery:

With this block:
```
[[block]]
block = "battery"
interval = 10
driver = "upower"
model = "MX Ergo Multi-Device Trackball"
format = "🖱 $icon $percentage"
missing_format = "🖱Is gone!"
```

Disconnecting the mouse and reconnecting it works fine, with the missing_format being shown for the duration of the mouse disconnection.

```
[{"full_text":"","color":"#458588FF","separator":false,"separator_block_width":0,"markup":"pango"},{"full_text":"🖱  55%","color":"#EBDBB2FF","background":"#458588FF","name":"0","instance":"0:","separator":false,"separator_block_width":0,"markup":"pango"}],
[{"full_text":"","color":"#CC241DFF","separator":false,"separator_block_width":0,"markup":"pango"},{"full_text":"🖱Is gone!","color":"#EBDBB2FF","background":"#CC241DFF","name":"0","instance":"0:","separator":false,"separator_block_width":0,"markup":"pango"}],
[{"full_text":"","color":"#458588FF","separator":false,"separator_block_width":0,"markup":"pango"},{"full_text":"🖱  55%","color":"#EBDBB2FF","background":"#458588FF","name":"0","instance":"0:","separator":false,"separator_block_width":0,"markup":"pango"}],
^C
```

Closes https://github.com/greshake/i3status-rust/issues/1797
