### PR TITLE
Battery: Use driver recommended icon when capacity is not reliable (WIP)

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -109,9 +109,9 @@ enum BatteryDriver {
     Upower,
 }
 
-#[derive (Clone,Debug)]
+#[derive(Clone, Debug)]
 enum DriverIcon {
-    Upower(String)
+    Upower(String),
 }
 
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
@@ -168,38 +168,40 @@ pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
                     )
                 });
 
-                // If the driver says that it can't provide a realiable capacity percentage use its recommended icon
-                let (icon_name, icon_value, state) = if info.is_capacity_reliable || info.driver_icon.is_none() {
-                match (info.status, info.capacity) {
-                    (BatteryStatus::Empty, _) => ("bat", 0.0, State::Critical),
-                    (BatteryStatus::Full | BatteryStatus::NotCharging, _) => {
-                        ("bat", 1.0, State::Idle)
-                    }
-                    (status, capacity) => (
-                        if status == BatteryStatus::Charging {
-                            "bat_charging"
-                        } else {
-                            "bat"
-                        },
-                        capacity / 100.0,
-                        if status == BatteryStatus::Charging {
-                            State::Good
-                        } else if capacity <= config.critical {
-                            State::Critical
-                        } else if capacity <= config.warning {
-                            State::Warning
-                        } else if capacity <= config.info {
-                            State::Info
-                        } else if capacity > config.good {
-                            State::Good
-                        } else {
-                            State::Idle
-                        },
-                    ),
-                }} else {
-                    // TODO: icon mapping
-                    ("bat", 0.5, State::Warning)
-                };
+                // If the driver says that it can't provide a reliable capacity percentage use its recommended icon
+                let (icon_name, icon_value, state) =
+                    if info.is_capacity_reliable || info.driver_icon.is_none() {
+                        match (info.status, info.capacity) {
+                            (BatteryStatus::Empty, _) => ("bat", 0.0, State::Critical),
+                            (BatteryStatus::Full | BatteryStatus::NotCharging, _) => {
+                                ("bat", 1.0, State::Idle)
+                            }
+                            (status, capacity) => (
+                                if status == BatteryStatus::Charging {
+                                    "bat_charging"
+                                } else {
+                                    "bat"
+                                },
+                                capacity / 100.0,
+                                if status == BatteryStatus::Charging {
+                                    State::Good
+                                } else if capacity <= config.critical {
+                                    State::Critical
+                                } else if capacity <= config.warning {
+                                    State::Warning
+                                } else if capacity <= config.info {
+                                    State::Info
+                                } else if capacity > config.good {
+                                    State::Good
+                                } else {
+                                    State::Idle
+                                },
+                            ),
+                        }
+                    } else {
+                        // TODO: icon mapping
+                        ("bat", 0.5, State::Warning)
+                    };
 
                 values.insert(
                     "icon".into(),
@@ -274,7 +276,7 @@ struct BatteryInfo {
     /// Is capacity percentage reliable?
     is_capacity_reliable: bool,
     /// Driver recommended icon
-    driver_icon: Option<DriverIcon>
+    driver_icon: Option<DriverIcon>,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, SmartDefault)]

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -109,6 +109,11 @@ enum BatteryDriver {
     Upower,
 }
 
+#[derive (Clone,Debug,Copy)]
+enum DriverIcon {
+
+}
+
 pub async fn run(config: Config, mut api: CommonApi) -> Result<()> {
     let format = config.format.with_default(" $icon $percentage ")?;
     let format_full = config.full_format.with_default(" $icon ")?;
@@ -261,6 +266,10 @@ struct BatteryInfo {
     power: Option<f64>,
     /// Time in seconds
     time_remaining: Option<f64>,
+    /// Is capacity percentage reliable?
+    is_capacity_reliable: bool,
+    /// Driver recommended icon
+    driver_icon: Option<DriverIcon>
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, SmartDefault)]

--- a/src/blocks/battery/apc_ups.rs
+++ b/src/blocks/battery/apc_ups.rs
@@ -182,8 +182,7 @@ impl BatteryDevice for Device {
             capacity,
             power,
             time_remaining,
-            is_capacity_reliable: true,
-            driver_icon: None,
+            battery_level: None,
         }))
     }
 

--- a/src/blocks/battery/apc_ups.rs
+++ b/src/blocks/battery/apc_ups.rs
@@ -183,7 +183,7 @@ impl BatteryDevice for Device {
             power,
             time_remaining,
             is_capacity_reliable: true,
-            driver_icon: None
+            driver_icon: None,
         }))
     }
 

--- a/src/blocks/battery/apc_ups.rs
+++ b/src/blocks/battery/apc_ups.rs
@@ -182,6 +182,8 @@ impl BatteryDevice for Device {
             capacity,
             power,
             time_remaining,
+            is_capacity_reliable: true,
+            driver_icon: None
         }))
     }
 

--- a/src/blocks/battery/sysfs.rs
+++ b/src/blocks/battery/sysfs.rs
@@ -272,8 +272,7 @@ impl BatteryDevice for Device {
             capacity,
             power,
             time_remaining,
-            is_capacity_reliable: true,
-            driver_icon: None,
+            battery_level: None,
         }))
     }
 

--- a/src/blocks/battery/sysfs.rs
+++ b/src/blocks/battery/sysfs.rs
@@ -272,6 +272,8 @@ impl BatteryDevice for Device {
             capacity,
             power,
             time_remaining,
+            is_capacity_reliable: true,
+            driver_icon: None            
         }))
     }
 

--- a/src/blocks/battery/sysfs.rs
+++ b/src/blocks/battery/sysfs.rs
@@ -273,7 +273,7 @@ impl BatteryDevice for Device {
             power,
             time_remaining,
             is_capacity_reliable: true,
-            driver_icon: None            
+            driver_icon: None,
         }))
     }
 


### PR DESCRIPTION
Upower can explicitly say "don't use this charge percentage [we call it capacity], it's unreliable" in some cases. But at least it provides a recommended icon.

This diff [WIP] passes both "capacity is reliable" and "icon to use" from upower upstream so we can display the correct icon.

TO-DO:
- Icon mapping. Don't know if we should just import all the possible icons, or map with what we have (I believe it's not enough though).
- Maybe introduce a new format if the capacity is not reliable? Probably on top of displaying the correct info we don't want to display the capacity value at all.

@MaxVerevkin can you take a look and see if it's reasonably rustic?