### PR TITLE
Force apt output to be in default language

### DIFF
--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -177,6 +177,7 @@ async fn get_updates_list(config_path: &str) -> Result<String> {
         .await
         .error("Failed to run `apt update`")?;
     let stdout = Command::new("apt")
+        .env("LANG", "C")
         .env("APT_CONFIG", config_path)
         .args(["list", "--upgradable"])
         .output()


### PR DESCRIPTION
If your system language is set to something else than English, then the upgradable package count failes.
E.g. in German the key word ist "aktualisierbar".
Fortunately this is easily fixable by setting the env variable LANG to C.