### PR TITLE
manual_install.md: optional notmuch block depends upon libnotmuch.so

### DIFF
--- a/doc/manual_install.md
+++ b/doc/manual_install.md
@@ -4,6 +4,7 @@
 - `libssl-dev`
 - `libsensors-dev`
 - `libpulse-dev` (required for `pulseaudio` driver of sound block, compile with `--no-default-features` to opt-out)
+- `libnotmuch-dev` (required for optional `notmuch` block, compile with `--features notmuch` to opt-in)
 
 Compilation is only tested with very recent stable versions of `rustc`. If you use a distro with older Rust packages, consider using [rustup](https://rustup.rs/) to install a newer toolchain.
 


### PR DESCRIPTION
Otherwise, compilation fails at link time with:
`ld: cannot find -lnotmuch: No such file or directory`

Steps to reproduce:
`cargo build --release --features notmuch`