### PR TITLE
Don't break the entire bar when block's config has errors

### DIFF
--- a/src/blocks/amd_gpu.rs
+++ b/src/blocks/amd_gpu.rs
@@ -40,7 +40,7 @@ use super::prelude::*;
 use crate::util::read_file;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     #[default("card0".into())]
     device: String,

--- a/src/blocks/apt.rs
+++ b/src/blocks/apt.rs
@@ -58,7 +58,7 @@ use tokio::process::Command;
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     #[default(600.into())]
     interval: Seconds,

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -85,7 +85,7 @@ use calibright::{CalibrightBuilder, CalibrightConfig, CalibrightError, DeviceCon
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     device: Option<String>,
     format: FormatConfig,

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -75,7 +75,7 @@ mod upower;
 // make_log_macro!(debug, "battery");
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     device: Option<String>,
     driver: BatteryDriver,

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -65,6 +65,7 @@ use crate::wrappers::RangeMap;
 make_log_macro!(debug, "bluetooth");
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     mac: String,
     #[serde(default)]

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -50,7 +50,7 @@ const CPU_BOOST_PATH: &str = "/sys/devices/system/cpu/cpufreq/boost";
 const CPU_NO_TURBO_PATH: &str = "/sys/devices/system/cpu/intel_pstate/no_turbo";
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     format_alt: Option<FormatConfig>,

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -104,7 +104,7 @@ use tokio::io::{self, AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     command: Option<String>,

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -63,6 +63,7 @@ static DBUS_CONNECTION: async_once_cell::OnceCell<Result<zbus::Connection>> =
 const DBUS_NAME: &str = "rs.i3status";
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
     format: FormatConfig,

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -69,7 +69,7 @@ pub enum InfoType {
 }
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     #[default("/".into())]
     path: ShellString,

--- a/src/blocks/dnf.rs
+++ b/src/blocks/dnf.rs
@@ -44,7 +44,7 @@ use regex::Regex;
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     #[default(600.into())]
     interval: Seconds,

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 use tokio::net::UnixStream;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     #[default(5.into())]
     interval: Seconds,

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -68,7 +68,7 @@ use crate::util::{country_flag_from_iso_code, new_system_dbus_connection};
 const API_ENDPOINT: &str = "https://ipapi.co/json/";
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     #[default(300.into())]

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -33,7 +33,6 @@
 //! [[block]]
 //! block = "focused_window"
 //! format = " $title.str(0,21) | Missing "
-//! ```
 
 mod sway_ipc;
 mod wlr_toplevel_management;
@@ -44,7 +43,7 @@ use wlr_toplevel_management::WlrToplevelManagement;
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     driver: Driver,

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -61,7 +61,7 @@
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     #[default(60.into())]
     interval: Seconds,

--- a/src/blocks/hueshift.rs
+++ b/src/blocks/hueshift.rs
@@ -61,7 +61,7 @@ use crate::util::has_command;
 use futures::future::pending;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     // TODO: Document once this option becomes usefull

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -51,7 +51,7 @@ use zbus::dbus_proxy;
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     device_id: Option<String>,
     format: FormatConfig,

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -85,7 +85,7 @@ use tokio::process::Command;
 use zbus::dbus_proxy;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     driver: KeyboardLayoutDriver,

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -33,7 +33,7 @@ use super::prelude::*;
 use crate::util;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     #[default(3.into())]

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -40,7 +40,7 @@ use super::prelude::*;
 use maildir::Maildir;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     #[default(5.into())]

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -64,7 +64,7 @@ use super::prelude::*;
 use crate::util::read_file;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     format_alt: Option<FormatConfig>,

--- a/src/blocks/menu.rs
+++ b/src/blocks/menu.rs
@@ -35,6 +35,7 @@ use super::prelude::*;
 use crate::subprocess::spawn_shell;
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     text: String,
     items: Vec<Item>,

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -141,7 +141,7 @@ const NEXT_BTN: &str = "next_btn";
 const PREV_BTN: &str = "prev_btn";
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     player: PlayerName,

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -64,7 +64,7 @@ use regex::Regex;
 use std::time::Instant;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     device: Option<String>,
     format: FormatConfig,

--- a/src/blocks/notify.rs
+++ b/src/blocks/notify.rs
@@ -65,7 +65,7 @@ const ICON_ON: &str = "bell";
 const ICON_OFF: &str = "bell-slash";
 
 #[derive(Deserialize, Debug, Default)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     driver: DriverType,
     format: FormatConfig,

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -46,7 +46,7 @@
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     #[default(10.into())]

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -69,7 +69,7 @@ const FORMAT: &str = "--format=csv,noheader,nounits";
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     #[default(1.into())]

--- a/src/blocks/pacman.rs
+++ b/src/blocks/pacman.rs
@@ -147,7 +147,7 @@ static PACMAN_DB: Lazy<PathBuf> = Lazy::new(|| {
 });
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     #[default(600.into())]
     interval: Seconds,

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -62,7 +62,7 @@ use crate::subprocess::{spawn_shell, spawn_shell_sync};
 use std::time::Instant;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     #[default("Pomodoro over! Take a break!".into())]

--- a/src/blocks/rofication.rs
+++ b/src/blocks/rofication.rs
@@ -34,7 +34,7 @@ use super::prelude::*;
 use tokio::net::UnixStream;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     #[default(1.into())]
     interval: Seconds,

--- a/src/blocks/service_status.rs
+++ b/src/blocks/service_status.rs
@@ -46,7 +46,7 @@ use zbus::dbus_proxy;
 use zbus::PropertyStream;
 
 #[derive(Deserialize, Debug, Default)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     driver: DriverType,
     service: String,

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -109,7 +109,7 @@ serde_conv!(
 
 #[serde_as]
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     driver: SoundDriver,
     name: Option<String>,

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -44,7 +44,7 @@ use super::prelude::*;
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     #[default(1800.into())]

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -54,7 +54,7 @@ use inotify::{Inotify, WatchMask};
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     interval: Seconds,
     warning_threshold: u32,

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -66,7 +66,7 @@ const DEFAULT_INFO: f64 = 60.0;
 const DEFAULT_WARN: f64 = 80.0;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     format_alt: Option<FormatConfig>,

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -38,7 +38,7 @@ use chrono_tz::Tz;
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     #[default(10.into())]

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -53,6 +53,7 @@ use std::env;
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     format: FormatConfig,
     command_on: String,

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -33,7 +33,7 @@ use super::prelude::*;
 use tokio::fs::read_to_string;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     #[default(60.into())]

--- a/src/blocks/vpn.rs
+++ b/src/blocks/vpn.rs
@@ -80,7 +80,7 @@ enum DriverType {
 }
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     driver: DriverType,
     #[default(10.into())]

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -41,7 +41,7 @@ use tokio::fs::read_to_string;
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     format: FormatConfig,
     state_path: Option<ShellString>,

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -100,6 +100,7 @@ mod open_weather_map;
 const IP_API_URL: &str = "https://ipapi.co/json";
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default = "default_interval")]
     interval: Seconds,

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -46,7 +46,7 @@ use regex::RegexSet;
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     #[default(5.into())]
     interval: Seconds,


### PR DESCRIPTION
Also improve the error message when unknown/disabled block is given.

But, it currently requires `block = "..."` to be the first field of block config, because some necessary structs are in `serde::_private`, so only derived imps can implement proper tagged enum deserialization.