### PR TITLE
formatting: try to fix rounding in .eng()

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -101,6 +101,7 @@ words:
   - pomodoros
   - posix
   - powf
+  - powi
   - recip
   - repr
   - reqwest


### PR DESCRIPTION
Fixes #1857

Prior to this PR `9.999` would display as `10.0` (for width = 3) instead of expected ` 10`. Note: `999.99` is currently displayed as `999`. This PR does not fix it.