### PR TITLE
Add profile for release binary with debug symbols (#1863)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,5 +104,7 @@ features = ["json"]
 
 [profile.release]
 lto = "thin"
-strip = true
-debug = 1
+
+[profile.release-debug-info]
+inherits = "release"
+debug = true


### PR DESCRIPTION
As of  [Rust 1.57](https://github.com/rust-lang/rust/blob/1.57.0/RELEASES.md#cargo), Cargo allows for  [custom profiles](https://doc.rust-lang.org/cargo/reference/profiles.html#custom-profiles). Shipping unstripped binaries with debug symbols by default makes it easier to create meaningful backtraces downstream without the need to maintain patches.

This patch makes adds an optional `release-debug-info` profile which adds debugging information to the release profile. 