### PR TITLE
sound: reconnect to pa

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -29,6 +29,7 @@ words:
   - busctl
   - chrono
   - clippy
+  - CLOEXEC
   - conn
   - conv
   - consts
@@ -41,6 +42,7 @@ words:
   - dmenu
   - dunst
   - execvp
+  - fcntl
   - getaddr
   - getenv
   - gibi


### PR DESCRIPTION
Fixes #334

Ideally this should be reflected in the UI, but for now I suppose it is better than just stalling the block.

Also, apparently there is a bug in `libpulse_binding` as it is possible to segfault w/o `unsafe`.