### PR TITLE
keyboard_layout block: Add support for keyboard layout variant to xkbmap driver

### DIFF
--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -21,7 +21,7 @@
 //!  Key     | Value | Type
 //! ---------|-------|-----
 //! `layout` | Keyboard layout name | String
-//! `variant`| Keyboard variant. Only `localebus`, `sway` and `kbddbus` are supported so far. | String
+//! `variant`| Keyboard variant name or `N/A` if not applicable | String
 //!
 //! # Examples
 //!

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -173,10 +173,24 @@ impl Backend for SetXkbMap {
             .error("Could not find the layout entry from setxkbmap")?
             .split_ascii_whitespace()
             .last()
-            .error("Could not read the layout entry from setxkbmap.")?;
+            .error("Could not read the layout entry from setxkbmap.")?
+            .into();
+        let variant_line = output
+            .lines()
+            // Find the "variant:   xxxx" line if it exists.
+            .find(|line| line.starts_with("variant"));
+        let variant = match variant_line {
+            Some(s) => Some(s
+            .split_ascii_whitespace()
+            .last()
+            .error("Could not read the variant entry from setxkbmap.")?.to_string()),
+            None => None
+        };
+                
+
         Ok(Info {
-            layout: layout.into(),
-            variant: None,
+            layout: layout,
+            variant: variant,
         })
     }
 

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -180,13 +180,14 @@ impl Backend for SetXkbMap {
             // Find the "variant:   xxxx" line if it exists.
             .find(|line| line.starts_with("variant"));
         let variant = match variant_line {
-            Some(s) => Some(s
-            .split_ascii_whitespace()
-            .last()
-            .error("Could not read the variant entry from setxkbmap.")?.to_string()),
-            None => None
+            Some(s) => Some(
+                s.split_ascii_whitespace()
+                    .last()
+                    .error("Could not read the variant entry from setxkbmap.")?
+                    .to_string(),
+            ),
+            None => None,
         };
-                
 
         Ok(Info {
             layout: layout,

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -189,10 +189,7 @@ impl Backend for SetXkbMap {
             None => None,
         };
 
-        Ok(Info {
-            layout: layout,
-            variant: variant,
-        })
+        Ok(Info { layout, variant })
     }
 
     async fn wait_for_change(&mut self) -> Result<()> {


### PR DESCRIPTION
I've done my best to make an idiomatic addition to parse keyboard layout variants in the xkbmap driver for the keyboard_layout block. This means all 4 drivers have support for variants and layouts.
I've been testing with it myself between two "us" layouts with different variants.