### PR TITLE
switch to std::sync::mpsc from crossbeam-channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,16 +483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,7 +1060,6 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
- "crossbeam-channel",
  "dirs",
  "env_logger",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ calibright = { version = "0.1", features = ["watch"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "unstable-locales"] }
 chrono-tz = { version = "0.8", features = ["serde"] }
 clap = { version = "4.0", default-features = false, features = ["std", "derive", "help", "usage"] }
-crossbeam-channel = "0.5"
 dirs = "5.0"
 env_logger = "0.10"
 futures = { version = "0.3", default-features = false }


### PR DESCRIPTION
Since Rust 1.72, Sender<T> implements Sync if T: Send, which lets us use it instead of crossbeam-channel - one less dependency.

Bumps MSRV to 1.72.