### PR TITLE
Make the backlight icons consistent

### DIFF
--- a/files/icons/awesome4.toml
+++ b/files/icons/awesome4.toml
@@ -1,10 +1,10 @@
 # FontAwesome 4: https://fontawesome.com/v4.7.0/cheatsheet/
 backlight = [
-    "\U0001f315",
-    "\U0001f314",
-    "\U0001f313",
-    "\U0001f312",
     "\U0001f311",
+    "\U0001f318",
+    "\U0001f317",
+    "\U0001f316",
+    "\U0001f315",
 ]
 bat_charging = "\uf1e6" # fa-plug
 bat = [

--- a/files/icons/awesome5.toml
+++ b/files/icons/awesome5.toml
@@ -1,10 +1,10 @@
 # FontAwesome 5: https://fontawesome.com/icons?d=gallery&p=2&m=free
 backlight = [
-    "\U0001f315",
-    "\U0001f314",
-    "\U0001f313",
-    "\U0001f312",
     "\U0001f311",
+    "\U0001f318",
+    "\U0001f317",
+    "\U0001f316",
+    "\U0001f315",
 ]
 bat_charging = "\uf1e6"
 bat_not_available = "\uf244"

--- a/files/icons/awesome6.toml
+++ b/files/icons/awesome6.toml
@@ -1,10 +1,10 @@
 # FontAwesome 6: https://fontawesome.com/v6/search?m=free
 backlight = [
-    "\U0001f315",
-    "\U0001f314",
-    "\U0001f313",
-    "\U0001f312",
     "\U0001f311",
+    "\U0001f318",
+    "\U0001f317",
+    "\U0001f316",
+    "\U0001f315",
 ]
 bat_charging = "\uf1e6"
 bat_not_available = "\uf244"


### PR DESCRIPTION
Make it so that the moon is filling in from left to right as the brightness increases. This matches what emoji and material-nf does too.