### PR TITLE
Simplify some error handling and make it more structured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
  "signal-hook-tokio",
  "smart-default",
  "swayipc-async",
+ "thiserror",
  "tokio",
  "toml 0.8.0",
  "unicode-segmentation",
@@ -2308,18 +2309,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ signal-hook = "0.3"
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 smart-default = "0.7"
 swayipc-async = "2.0"
+thiserror = "1.0"
 toml = "0.8"
 unicode-segmentation = "1.10.1"
 wayrs-client = { version = "0.12", features = ["tokio"] }

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -175,10 +175,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             }
             Some(e) => {
                 api.set_error(Error {
-                    kind: ErrorKind::Other,
                     message: None,
                     cause: Some(Arc::new(e)),
-                    block: None,
                 })?;
             }
             None => {

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -292,10 +292,8 @@ async fn find_ip_location(interval: Duration) -> Result<Coordinates> {
 
     let location = if response.error {
         return Err(Error {
-            kind: ErrorKind::Other,
             message: Some("ipapi.co error".into()),
             cause: Some(Arc::new(response.reason)),
-            block: None,
         });
     } else {
         response

--- a/src/click.rs
+++ b/src/click.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use serde::de::{self, Deserializer, Visitor};
 use serde::Deserialize;
 
-use crate::errors::{Result, ResultExt};
+use crate::errors::{ErrorContext, Result};
 use crate::protocol::i3bar_event::I3BarEvent;
 use crate::subprocess::{spawn_shell, spawn_shell_sync};
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,172 +12,62 @@ type ErrorMsg = Cow<'static, str>;
 /// Error type
 #[derive(Debug, Clone)]
 pub struct Error {
-    pub kind: ErrorKind,
     pub message: Option<ErrorMsg>,
     pub cause: Option<Arc<dyn StdError + Send + Sync + 'static>>,
-    pub block: Option<(&'static str, usize)>,
-}
-
-/// A set of errors that can occur during the runtime
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ErrorKind {
-    Config,
-    Format,
-    Other,
 }
 
 impl Error {
     pub fn new<T: Into<ErrorMsg>>(message: T) -> Self {
         Self {
-            kind: ErrorKind::Other,
             message: Some(message.into()),
             cause: None,
-            block: None,
-        }
-    }
-
-    pub fn new_format<T: Into<ErrorMsg>>(message: T) -> Self {
-        Self {
-            kind: ErrorKind::Format,
-            message: Some(message.into()),
-            cause: None,
-            block: None,
         }
     }
 }
 
-pub trait InBlock {
-    fn in_block(self, block: &'static str, block_id: usize) -> Self;
-}
-
-impl InBlock for Error {
-    fn in_block(mut self, block: &'static str, block_id: usize) -> Self {
-        self.block = Some((block, block_id));
-        self
-    }
-}
-
-impl<T> InBlock for Result<T> {
-    fn in_block(self, block: &'static str, block_id: usize) -> Self {
-        self.map_err(|e| e.in_block(block, block_id))
-    }
-}
-
-pub trait ResultExt<T> {
+pub trait ErrorContext<T> {
     fn error<M: Into<ErrorMsg>>(self, message: M) -> Result<T>;
     fn or_error<M: Into<ErrorMsg>, F: FnOnce() -> M>(self, f: F) -> Result<T>;
-    fn config_error(self) -> Result<T>;
-    fn format_error<M: Into<ErrorMsg>>(self, message: M) -> Result<T>;
 }
 
-impl<T, E: StdError + Send + Sync + 'static> ResultExt<T> for Result<T, E> {
+impl<T, E: StdError + Send + Sync + 'static> ErrorContext<T> for Result<T, E> {
     fn error<M: Into<ErrorMsg>>(self, message: M) -> Result<T> {
         self.map_err(|e| Error {
-            kind: ErrorKind::Other,
             message: Some(message.into()),
             cause: Some(Arc::new(e)),
-            block: None,
         })
     }
 
     fn or_error<M: Into<ErrorMsg>, F: FnOnce() -> M>(self, f: F) -> Result<T> {
         self.map_err(|e| Error {
-            kind: ErrorKind::Other,
             message: Some(f().into()),
             cause: Some(Arc::new(e)),
-            block: None,
-        })
-    }
-
-    fn config_error(self) -> Result<T> {
-        self.map_err(|e| Error {
-            kind: ErrorKind::Config,
-            message: None,
-            cause: Some(Arc::new(e)),
-            block: None,
-        })
-    }
-
-    fn format_error<M: Into<ErrorMsg>>(self, message: M) -> Result<T> {
-        self.map_err(|e| Error {
-            kind: ErrorKind::Format,
-            message: Some(message.into()),
-            cause: Some(Arc::new(e)),
-            block: None,
         })
     }
 }
 
-pub trait OptionExt<T> {
-    fn error<M: Into<ErrorMsg>>(self, message: M) -> Result<T>;
-    fn or_error<M: Into<ErrorMsg>, F: FnOnce() -> M>(self, f: F) -> Result<T>;
-    fn config_error(self) -> Result<T>;
-    fn or_format_error<M: Into<ErrorMsg>, F: FnOnce() -> M>(self, f: F) -> Result<T>;
-}
-
-impl<T> OptionExt<T> for Option<T> {
+impl<T> ErrorContext<T> for Option<T> {
     fn error<M: Into<ErrorMsg>>(self, message: M) -> Result<T> {
         self.ok_or_else(|| Error {
-            kind: ErrorKind::Other,
             message: Some(message.into()),
             cause: None,
-            block: None,
         })
     }
 
     fn or_error<M: Into<ErrorMsg>, F: FnOnce() -> M>(self, f: F) -> Result<T> {
         self.ok_or_else(|| Error {
-            kind: ErrorKind::Other,
             message: Some(f().into()),
             cause: None,
-            block: None,
-        })
-    }
-
-    fn config_error(self) -> Result<T> {
-        self.ok_or(Error {
-            kind: ErrorKind::Config,
-            message: None,
-            cause: None,
-            block: None,
-        })
-    }
-
-    fn or_format_error<M: Into<ErrorMsg>, F: FnOnce() -> M>(self, f: F) -> Result<T> {
-        self.ok_or_else(|| Error {
-            kind: ErrorKind::Format,
-            message: Some(f().into()),
-            cause: None,
-            block: None,
         })
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.block {
-            Some(block) => {
-                match self.kind {
-                    ErrorKind::Config | ErrorKind::Format => f.write_str("Configuration error")?,
-                    ErrorKind::Other => f.write_str("Error")?,
-                }
+        f.write_str(self.message.as_deref().unwrap_or("Error"))?;
 
-                write!(f, " in {}", block.0)?;
-
-                if let Some(message) = &self.message {
-                    write!(f, ": {message}")?;
-                }
-
-                if let Some(cause) = &self.cause {
-                    write!(f, ". (Cause: {cause})")?;
-                }
-            }
-            None => {
-                f.write_str(self.message.as_deref().unwrap_or("Error"))?;
-                if let Some(cause) = &self.cause {
-                    write!(f, ". (Cause: {cause})")?;
-                }
-            }
+        if let Some(cause) = &self.cause {
+            write!(f, ". Cause: {cause}")?;
         }
 
         Ok(())

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -115,6 +115,16 @@ use value::Value;
 
 pub type Values = HashMap<Cow<'static, str>, Value>;
 
+#[derive(Debug, thiserror::Error)]
+pub enum FormatError {
+    #[error("Placeholder '{0}' not found")]
+    PlaceholderNotFound(String),
+    #[error("{} cannot be formatted with '{}' formatter", .ty, .fmt)]
+    IncompatibleFormatter { ty: &'static str, fmt: &'static str },
+    #[error(transparent)]
+    Other(#[from] Error),
+}
+
 #[derive(Debug, Clone)]
 pub struct Format {
     full: Arc<FormatTemplate>,


### PR DESCRIPTION
- Remove `kind` and `block` fields from `Error`.
- Removed `block` field is replaced by `BlockError` struct.
- Represent formatting errors (such as "placeholder not found") as an enum with thiserror macro.
- Merge `ResultExt` and `OptionExt` into `ErrorContext`.