### PR TITLE
config: allow widget=<regex> in click handlers

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -21,7 +21,7 @@
 //! Key | Description | Default
 //! ----|-------------|----------
 //! `button` | `left`, `middle`, `right`, `up`, `down`, `forward`, `back` or [`double_left`](MouseButton). | -
-//! `widget` | To which part of the block this entry applies | None
+//! `widget` | To which part of the block this entry applies (accepts regex) | `"block"`
 //! `cmd` | Command to run when the mouse button event is detected. | None
 //! `action` | Which block action to trigger | None
 //! `sync` | Whether to wait for command to exit or not. | `false`

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -98,6 +98,7 @@
 //! action = "play_pause"
 //! [[block.click]]
 //! button = "middle"
+//! widget = "."
 //! action = "toggle_format"
 //! ```
 //!

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -192,6 +192,35 @@ where
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct SerdeRegex(pub regex::Regex);
+
+impl<'de> Deserialize<'de> for SerdeRegex {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = SerdeRegex;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a regex")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                regex::Regex::new(v).map(SerdeRegex).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
 /// Display a slice. Similar to Debug impl for slice, but uses Display impl for elements.
 pub struct DisplaySlice<'a, T>(pub &'a [T]);
 


### PR DESCRIPTION
Before:

```toml
[[block.click]]
button = "middle"
action = "toggle_format"
[[block.click]]
button = "middle"
widget = "play_pause_btn"
action = "toggle_format"
```

After:

```toml
[[block.click]]
button = "middle"
widget = "*"
action = "toggle_format"
```