### PR TITLE
blocks/focused_window: Close code block in markdown doc

### DIFF
--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -33,6 +33,7 @@
 //! [[block]]
 //! block = "focused_window"
 //! format = " $title.str(0,21) | Missing "
+//! ```
 
 mod sway_ipc;
 mod wlr_toplevel_management;


### PR DESCRIPTION
This problem manifests in the man page when looking at the *next* block's documentation. Currently that is the `github` block, which is almost entirely subsumed into this `focus_window` Example toml.