### PR TITLE
docs(readme): update home-manager options link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install from one of the packages below:
 
 * For Fedora/CentOS, you can install from the [COPR](https://copr.fedorainfracloud.org/coprs/atim/i3status-rust/).
 
-* For NixOS, you can also use [Home Manager](https://github.com/nix-community/home-manager): `programs.i3status-rust.enable = true` [see available options](https://nix-community.github.io/home-manager/options.html#opt-programs.i3status-rust.enable)
+* For NixOS, you can also use [Home Manager](https://github.com/nix-community/home-manager): `programs.i3status-rust.enable = true` [see available options](https://nix-community.github.io/home-manager/options.xhtml#opt-programs.i3status-rust.enable)
 
 * **NOTE:** Installation via `cargo` is not supported.
 


### PR DESCRIPTION
It seems that the link in the `README.md` to the home-manager options is dead.

Looks like maybe [this commit](https://github.com/nix-community/home-manager/commit/6c82b1c9ce4dfb882cf53d1b9a09f01fbc9b0ba1) switched the pages to use `xhtml`.