### PR TITLE
Add Wireguard support to vpn block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ log = "0.4"
 maildir = { version = "0.6", optional = true }
 neli = { version = "0.6", features = ["async"] }
 neli-wifi = { version = "0.6", features = ["async"] }
-nix = { version = "0.27", features = ["fs", "process"] }
+nix = { version = "0.27", features = ["fs", "process", "user"] }
 nom = "7.1.2"
 notmuch = { version = "0.8", optional = true }
 once_cell = "1"

--- a/src/blocks/vpn/wireguard.rs
+++ b/src/blocks/vpn/wireguard.rs
@@ -1,0 +1,95 @@
+use std::process::Stdio;
+
+use async_trait::async_trait;
+use nix::unistd::getuid;
+use tokio::process::Command;
+
+use crate::blocks::prelude::*;
+
+use super::{Driver, Status};
+
+pub struct WireguardDriver {
+    interface: String,
+}
+
+impl WireguardDriver {
+    pub async fn new(interface: String) -> WireguardDriver {
+        WireguardDriver { interface }
+    }
+}
+
+const SUDO_CMD: &'static str = "/usr/bin/sudo";
+const WG_QUICK_CMD: &'static str = "/usr/bin/wg-quick";
+const WG_CMD: &'static str = "/usr/bin/wg";
+
+#[async_trait]
+impl Driver for WireguardDriver {
+    async fn get_status(&self) -> Result<Status> {
+        let status = run_wg(vec!["show", self.interface.as_str()]).await;
+
+        match status {
+            Ok(status) => {
+                if status.contains(format!("interface: {}", self.interface).as_str()) {
+                    Ok(Status::Connected {
+                        country: "".to_owned(),
+                        country_flag: "".to_owned(),
+                    })
+                } else {
+                    Ok(Status::Disconnected)
+                }
+            }
+            Err(_) => Ok(Status::Error),
+        }
+    }
+
+    async fn toggle_connection(&self, status: &Status) -> Result<()> {
+        match status {
+            Status::Connected { .. } => {
+                run_wg_quick(vec!["down", self.interface.as_str()]).await?;
+            }
+            Status::Disconnected => {
+                run_wg_quick(vec!["up", self.interface.as_str()]).await?;
+            }
+            Status::Error => (),
+        }
+        Ok(())
+    }
+}
+
+async fn run_wg(args: Vec<&str>) -> Result<String> {
+    let stdout = make_command(should_use_sudo(), WG_CMD)
+        .args(&args)
+        .output()
+        .await
+        .error(format!("Problem running wg command: {args:?}"))?
+        .stdout;
+    let stdout =
+        String::from_utf8(stdout).error(format!("wg produced non-UTF8 output: {args:?}"))?;
+    Ok(stdout)
+}
+
+async fn run_wg_quick(args: Vec<&str>) -> Result<()> {
+    make_command(should_use_sudo(), WG_QUICK_CMD)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .spawn()
+        .error(format!("Problem running wg-quick command: {args:?}"))?
+        .wait()
+        .await
+        .error(format!("Problem running wg-quick command: {args:?}"))?;
+    Ok(())
+}
+
+fn make_command(use_sudo: bool, cmd: &str) -> Command {
+    let mut command = Command::new(if use_sudo { SUDO_CMD } else { cmd });
+
+    if use_sudo {
+        command.arg("-n").arg(cmd);
+    }
+    command
+}
+
+fn should_use_sudo() -> bool {
+    !(getuid().is_root())
+}


### PR DESCRIPTION
Adds a new driver for the VPN block to support Wireguard connections.

I couldn't find any way to control Wireguard without using root permissions, so I hope this route with sudo is OK. The docs include a sudoers configuration that should be safe if your Wireguard configuration files are locked down properly, but please correct me if I'm mistaken here.

The driver supports the same toggle action on click as the other drivers, but I've reduced the country code and flag to empty strings, as they don't make a lot of sense in this context.

We can update the Connected enum to support a state without country information included, but I tried to change as few things as possible on the existing drivers.