### PR TITLE
Adjust phase of time block

### DIFF
--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -49,7 +49,7 @@
 //! # Icons Used
 //! - `time`
 
-use chrono::Utc;
+use chrono::{Timelike, Utc};
 use chrono_tz::Tz;
 
 use super::prelude::*;
@@ -96,6 +96,14 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut timezone = timezone_iter.next();
 
     let mut timer = config.interval.timer();
+
+    let interval_seconds = config.interval.seconds();
+    if interval_seconds <= 60 {
+        let phase = Utc::now().second() as u64 % interval_seconds;
+        if phase != 0 {
+            timer.reset_after(Duration::from_secs(interval_seconds - phase));
+        }
+    }
 
     loop {
         let mut widget = Widget::new().with_format(format.clone());

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -101,19 +101,22 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     );
     timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+    let interval_seconds = config.interval.seconds();
+
     loop {
         let mut widget = Widget::new().with_format(format.clone());
+        let now = Utc::now();
 
         widget.set_values(map! {
             "icon" => Value::icon("time"),
-            "timestamp" => Value::datetime(Utc::now(), timezone.copied())
+            "timestamp" => Value::datetime(now, timezone.copied())
         });
 
         api.set_widget(widget)?;
 
-        let phase = Utc::now().second() as u64 % config.interval.seconds();
+        let phase = now.second() as u64 % interval_seconds;
         if phase != 0 {
-            timer.reset_after(Duration::from_secs(config.interval.seconds() - phase));
+            timer.reset_after(Duration::from_secs(interval_seconds - phase));
         }
 
         tokio::select! {

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -111,16 +111,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
         api.set_widget(widget)?;
 
-        let tick = async {
-            let phase = Utc::now().second() as u64 % config.interval.seconds();
-            if phase != 0 {
-                timer.reset_after(Duration::from_secs(config.interval.seconds() - phase));
-            }
-            timer.tick().await;
-        };
+        let phase = Utc::now().second() as u64 % config.interval.seconds();
+        if phase != 0 {
+            timer.reset_after(Duration::from_secs(config.interval.seconds() - phase));
+        }
 
         tokio::select! {
-            _ = tick => (),
+            _ = timer.tick() => (),
             _ = api.wait_for_update_request() => (),
             Some(action) = actions.recv() => match action.as_ref() {
                 "next_timezone" => {

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -95,7 +95,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
     let mut timezone = timezone_iter.next();
 
-    let mut timer = config.interval.timer();
+    let mut timer = tokio::time::interval_at(
+        tokio::time::Instant::now() + config.interval.0,
+        config.interval.0,
+    );
+    timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     let interval_seconds = config.interval.seconds();
     if interval_seconds <= 60 {


### PR DESCRIPTION
Closes #1991 

Instead of snapping to the start (`:00`) of the next minute, it snaps to the nearest multiple of the interval value. 

For example, if the interval value is `5` and the config is initialized at `:17`, the sequence shown will be `:17`, `:20`, `:25` and so on. 