### PR TITLE
Add duration formatter

### DIFF
--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -28,8 +28,11 @@
 //! -------------|-------------------------------------------------------------------------|-------------------|-----
 //! `icon`       | Icon based on battery's state                                           | Icon   | -
 //! `percentage` | Battery level, in percent                                               | Number | Percents
-//! `time`       | Time remaining until (dis)charge is complete. Presented only if battery's status is (dis)charging. | String | -
+//! `time_remaining`  | Time remaining until (dis)charge is complete. Presented only if battery's status is (dis)charging. | Duration | -
+//! `time`       | Time remaining until (dis)charge is complete. Presented only if battery's status is (dis)charging. | String *DEPRECATED* | -
 //! `power`      | Power consumption by the battery or from the power supply when charging | String or Float   | Watts
+//!
+//! `time` has been deprecated in favor of `time_remaining`.
 //!
 //! # Examples
 //!
@@ -44,7 +47,7 @@
 //! ```toml
 //! [[block]]
 //! block = "battery"
-//! format = " $percentage {$time |}"
+//! format = " $percentage {$time_remaining.dur(hms:true, min_unit:m) |}"
 //! device = "DisplayDevice"
 //! driver = "upower"
 //! ```
@@ -161,15 +164,19 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
                 info.power
                     .map(|p| values.insert("power".into(), Value::watts(p)));
-                info.time_remaining.map(|t| {
-                    values.insert(
-                        "time".into(),
-                        Value::text(format!(
-                            "{}:{:02}",
-                            (t / 3600.) as i32,
-                            (t % 3600. / 60.) as i32
-                        )),
-                    )
+                info.time_remaining.inspect(|&t| {
+                    map! { @extend values
+                        "time" => Value::text(
+                            format!(
+                                "{}:{:02}",
+                                (t / 3600.) as i32,
+                                (t % 3600. / 60.) as i32
+                            ),
+                        ),
+                        "time_remaining" =>  Value::duration(
+                            Duration::from_secs(t as u64),
+                        ),
+                    }
                 });
 
                 let (icon_name, icon_value, state) = match (info.status, info.capacity) {

--- a/src/blocks/tea_timer.rs
+++ b/src/blocks/tea_timer.rs
@@ -4,18 +4,21 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $icon {$minutes:$seconds \|}\"</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $icon {$time.duration(hms:true) \|}\"</code>
 //! `increment` | The numbers of seconds to add each time the block is clicked. | 30
 //! `done_cmd` | A command to run in `sh` when timer finishes. | None
 //!
-//! Placeholder      | Value                                                          | Type   | Unit
-//! -----------------|----------------------------------------------------------------|--------|---------------
-//! `icon`           | A static icon                                                  | Icon   | -
-//! `hours`          | The hours remaining on the timer                               | Text   | h
-//! `minutes`        | The minutes remaining on the timer                             | Text   | mn
-//! `seconds`        | The seconds remaining on the timer                             | Text   | s
+//! Placeholder            | Value                                                          | Type     | Unit
+//! -----------------------|----------------------------------------------------------------|----------|---------------
+//! `icon`                 | A static icon                                                  | Icon     | -
+//! `time`                 | The time remaining on the timer                                | Duration | -
+//! `hours` *DEPRECATED*   | The hours remaining on the timer                               | Text     | h
+//! `minutes` *DEPRECATED* | The minutes remaining on the timer                             | Text     | mn
+//! `seconds` *DEPRECATED* | The seconds remaining on the timer                             | Text     | s
 //!
-//! `hours`, `minutes`, and `seconds` are unset when the timer is inactive.
+//! `time`, `hours`, `minutes`, and `seconds` are unset when the timer is inactive.
+//!
+//! `hours`, `minutes`, and `seconds` have been deprecated in favor of `time`.
 //!
 //! Action      | Default button
 //! ------------|---------------
@@ -37,13 +40,14 @@
 
 use super::prelude::*;
 use crate::subprocess::spawn_shell;
-use chrono::{Duration, Utc};
+
+use std::time::{Duration, Instant};
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     pub format: FormatConfig,
-    pub increment: Option<i64>,
+    pub increment: Option<u64>,
     pub done_cmd: Option<String>,
 }
 
@@ -59,17 +63,20 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let interval: Seconds = 1.into();
     let mut timer = interval.timer();
 
-    let format = config.format.with_default(" $icon {$minutes:$seconds |}")?;
+    let format = config
+        .format
+        .with_default(" $icon {$time.duration(hms:true) |}")?;
 
-    let increment =
-        Duration::try_seconds(config.increment.unwrap_or(30)).error("invalid increment value")?;
-    let mut timer_end = Utc::now();
+    let increment = Duration::from_secs(config.increment.unwrap_or(30));
+    let mut timer_end = Instant::now();
 
     let mut timer_was_active = false;
 
     loop {
-        let remaining_time = timer_end - Utc::now();
-        let is_timer_active = remaining_time > Duration::zero();
+        let mut widget = Widget::new().with_format(format.clone());
+
+        let remaining_time = timer_end - Instant::now();
+        let is_timer_active = !remaining_time.is_zero();
 
         if !is_timer_active && timer_was_active {
             if let Some(cmd) = &config.done_cmd {
@@ -78,24 +85,30 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         }
         timer_was_active = is_timer_active;
 
-        let (hours, minutes, seconds) = if is_timer_active {
-            (
-                remaining_time.num_hours(),
-                remaining_time.num_minutes() % 60,
-                remaining_time.num_seconds() % 60,
-            )
-        } else {
-            (0, 0, 0)
-        };
-
-        let mut widget = Widget::new().with_format(format.clone());
-
-        widget.set_values(map!(
+        let mut values = map!(
             "icon" => Value::icon("tea"),
-            [if is_timer_active] "hours" => Value::text(format!("{hours:02}")),
-            [if is_timer_active] "minutes" => Value::text(format!("{minutes:02}")),
-            [if is_timer_active] "seconds" => Value::text(format!("{seconds:02}")),
-        ));
+        );
+
+        if is_timer_active {
+            values.insert("time".into(), Value::duration(remaining_time));
+            let mut seconds = remaining_time.as_secs();
+
+            if format.contains_key("hours") {
+                let hours = seconds / 3_600;
+                values.insert("hours".into(), Value::text(format!("{hours:02}")));
+                seconds %= 3_600;
+            }
+
+            if format.contains_key("minutes") {
+                let minutes = seconds / 60;
+                values.insert("minutes".into(), Value::text(format!("{minutes:02}")));
+                seconds %= 60;
+            }
+
+            values.insert("seconds".into(), Value::text(format!("{seconds:02}")));
+        }
+
+        widget.set_values(values);
 
         api.set_widget(widget)?;
 
@@ -103,7 +116,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             _ = timer.tick(), if is_timer_active => (),
             _ = api.wait_for_update_request() => (),
             Some(action) = actions.recv() => {
-                let now = Utc::now();
+                let now = Instant::now();
                 match action.as_ref() {
                     "increment" if is_timer_active => timer_end += increment,
                     "increment" => timer_end = now + increment,

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -80,15 +80,15 @@
 //! ## `duration`/`dur` - Format durations
 //!
 //! Argument                     | Description                                                                                      |Default value
-//! -----------------------------|--------------------------------------------------------------------------------------------------|------------------------------------------------------
-//! `hms`                        | Should the format be hours:minutes:seconds.milliseconds                                          | `false`
-//! `max_unit`                   | The largest unit to display the duration with (see below for the list of all possible units)     | hms ? `h` : `y`
-//! `min_unit`                   | The smallest unit to display the duration with (see below for the list of all possible units)    | `s`
-//! `units`                      | The number of units to display                                                                   | min(# of units between `max_unit` and `min_unit``, 2)
-//! `round_up`                   | Round up to the nearest minimum displayed unit                                                   | `true`
-//! `unit_space`                 | Should there be a space between the value and unit symbol (not allowed when `hms:true`)                | `false`
-//! `pad_with`                   | The character that is used to pad the numbers                                                    | hms ? `0` : ` ` (a space)
-//! `show_leading_units_if_zero` | If fewer than `units` are non-zero should leading numbers that have a value of zero be shown     | `true`
+//! -----------------|--------------------------------------------------------------------------------------------------|------------------------------------------------------
+//! `hms`            | Should the format be hours:minutes:seconds.milliseconds                                          | `false`
+//! `max_unit`       | The largest unit to display the duration with (see below for the list of all possible units)     | hms ? `h` : `y`
+//! `min_unit`       | The smallest unit to display the duration with (see below for the list of all possible units)    | `s`
+//! `units`          | The number of units to display                                                                   | min(# of units between `max_unit` and `min_unit``, 2)
+//! `round_up`       | Round up to the nearest minimum displayed unit                                                   | `true`
+//! `unit_space`     | Should there be a space between the value and unit symbol (not allowed when `hms:true`)          | `false`
+//! `pad_with`       | The character that is used to pad the numbers                                                    | hms ? `0` : ` ` (a space)
+//! `leading_zeroes` | If fewer than `units` are non-zero should leading numbers that have a value of zero be shown     | `true`
 //!
 //! Unit | Description
 //! -----|------------

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -17,6 +17,8 @@
 //! --------------------------|------------------
 //! Text                      | `str`
 //! Number                    | `eng`
+//! Datetime                  | `datetime`
+//! Duration                  | `duration`
 //! [Flag](#how-to-use-flags) | N/A
 //!
 //! # Formatters
@@ -73,6 +75,30 @@
 //! -----------------------|-----------------------------------------------------------------------------------------------------------|-------------
 //! `format` or `f`        | [chrono docs](https://docs.rs/chrono/0.3.0/chrono/format/strftime/index.html#specifiers) for all options. | `'%a %d/%m %R'`
 //! `locale` or `l`        | Locale to apply when formatting the time                                                                  | System locale
+//!
+//!
+//! ## `duration`/`dur` - Format durations
+//!
+//! Argument                     | Description                                                                                      |Default value
+//! -----------------------------|--------------------------------------------------------------------------------------------------|------------------------------------------------------
+//! `hms`                        | Should the format be hours:minutes:seconds.milliseconds                                          | `false`
+//! `max_unit`                   | The largest unit to display the duration with (see below for the list of all possible units)     | hms ? `h` : `y`
+//! `min_unit`                   | The smallest unit to display the duration with (see below for the list of all possible units)    | `s`
+//! `units`                      | The number of units to display                                                                   | min(# of units between `max_unit` and `min_unit``, 2)
+//! `round_up`                   | Round up to the nearest minimum displayed unit                                                   | `true`
+//! `unit_space`                 | Should there be a space between the value and unit symbol (not allowed when `hms:true`)                | `false`
+//! `pad_with`                   | The character that is used to pad the numbers                                                    | hms ? `0` : ` ` (a space)
+//! `show_leading_units_if_zero` | If fewer than `units` are non-zero should leading numbers that have a value of zero be shown     | `true`
+//!
+//! Unit | Description
+//! -----|------------
+//! y    | years
+//! w    | weeks
+//! d    | days
+//! h    | hours
+//! m    | minutes
+//! s    | seconds
+//! ms   | milliseconds
 //!
 //! # Handling missing placeholders and incorrect types
 //!

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -1,7 +1,7 @@
 use unicode_segmentation::UnicodeSegmentation;
 
-use std::fmt::Debug;
 use std::time::Duration;
+use std::{borrow::Cow, fmt::Debug};
 
 use super::parse::Arg;
 use super::value::ValueInner as Value;
@@ -14,7 +14,7 @@ use crate::errors::*;
 #[macro_export]
 macro_rules! new_fmt {
     ($name:ident) => {{
-        fmt!($name,)
+        new_fmt!($name,)
     }};
     ($name:ident, $($key:ident : $value:tt),* $(,)?) => {
         new_formatter(stringify!($name), &[
@@ -27,6 +27,8 @@ mod bar;
 pub use bar::BarFormatter;
 mod datetime;
 pub use datetime::{DatetimeFormatter, DEFAULT_DATETIME_FORMATTER};
+mod duration;
+pub use duration::{DurationFormatter, DEFAULT_DURATION_FORMATTER};
 mod eng;
 pub use eng::{EngFormatter, DEFAULT_NUMBER_FORMATTER};
 mod flag;
@@ -35,6 +37,10 @@ mod pango;
 pub use pango::PangoStrFormatter;
 mod str;
 pub use str::{StrFormatter, DEFAULT_STRING_FORMATTER};
+
+type PadWith = Cow<'static, str>;
+
+const DEFAULT_NUMBER_PAD_WITH: PadWith = Cow::Borrowed(" ");
 
 pub trait Formatter: Debug + Send + Sync {
     fn format(&self, val: &Value, config: &SharedConfig) -> Result<String, FormatError>;
@@ -48,6 +54,7 @@ pub fn new_formatter(name: &str, args: &[Arg]) -> Result<Box<dyn Formatter>> {
     match name {
         "bar" => Ok(Box::new(BarFormatter::from_args(args)?)),
         "datetime" => Ok(Box::new(DatetimeFormatter::from_args(args)?)),
+        "dur" | "duration" => Ok(Box::new(DurationFormatter::from_args(args)?)),
         "eng" => Ok(Box::new(EngFormatter::from_args(args)?)),
         "pango-str" => Ok(Box::new(PangoStrFormatter::from_args(args)?)),
         "str" => Ok(Box::new(StrFormatter::from_args(args)?)),

--- a/src/formatting/formatter/duration.rs
+++ b/src/formatting/formatter/duration.rs
@@ -1,0 +1,529 @@
+use std::cmp::min;
+
+use super::*;
+
+const UNIT_COUNT: usize = 7;
+const UNITS: [&str; UNIT_COUNT] = ["y", "w", "d", "h", "m", "s", "ms"];
+const UNIT_CONVERSION_RATES: [u128; UNIT_COUNT] = [
+    31_556_952_000, // Based on there being 365.2425 days/year
+    604_800_000,
+    86_400_000,
+    3_600_000,
+    60_000,
+    1_000,
+    1,
+];
+const UNIT_PAD_WIDTHS: [usize; UNIT_COUNT] = [1, 2, 1, 2, 2, 2, 3];
+
+pub const DEFAULT_DURATION_FORMATTER: DurationFormatter = DurationFormatter {
+    hms: false,
+    max_unit_index: 0,
+    min_unit_index: 5,
+    units: 2,
+    round_up: true,
+    unit_has_space: false,
+    pad_with: DEFAULT_NUMBER_PAD_WITH,
+    show_leading_units_if_zero: true,
+};
+
+#[derive(Debug, Default)]
+pub struct DurationFormatter {
+    hms: bool,
+    max_unit_index: usize,
+    min_unit_index: usize,
+    units: usize,
+    round_up: bool,
+    unit_has_space: bool,
+    pad_with: PadWith,
+    show_leading_units_if_zero: bool,
+}
+
+impl DurationFormatter {
+    pub(super) fn from_args(args: &[Arg]) -> Result<Self> {
+        let mut hms = false;
+        let mut max_unit = None;
+        let mut min_unit = "s";
+        let mut units: Option<usize> = None;
+        let mut round_up = true;
+        let mut unit_has_space = false;
+        let mut pad_with = None;
+        let mut show_leading_units_if_zero = true;
+        for arg in args {
+            match arg.key {
+                "hms" => {
+                    hms = arg.val.parse().ok().error("hms must be true or false")?;
+                }
+                "max_unit" => {
+                    max_unit = Some(arg.val);
+                }
+                "min_unit" => {
+                    min_unit = arg.val;
+                }
+                "units" => {
+                    units = Some(
+                        arg.val
+                            .parse()
+                            .ok()
+                            .error("units must be a positive integer")?,
+                    );
+                }
+                "round_up" => {
+                    round_up = arg
+                        .val
+                        .parse()
+                        .ok()
+                        .error("round_up must be true or false")?;
+                }
+                "unit_space" => {
+                    unit_has_space = arg
+                        .val
+                        .parse()
+                        .ok()
+                        .error("unit_space must be true or false")?;
+                }
+                "pad_with" => {
+                    if arg.val.graphemes(true).count() < 2 {
+                        pad_with = Some(Cow::Owned(arg.val.into()));
+                    } else {
+                        return Err(Error::new(
+                            "pad_with must be an empty string or a single character",
+                        ));
+                    };
+                }
+                "show_leading_units_if_zero" => {
+                    show_leading_units_if_zero =
+                        arg.val.parse().ok().error("units must be true or false")?;
+                }
+
+                _ => return Err(Error::new(format!("Unexpected argument {:?}", arg.key))),
+            }
+        }
+
+        if hms && unit_has_space {
+            return Err(Error::new(
+                "When hms is enabled unit_space should not be true",
+            ));
+        }
+
+        let max_unit = max_unit.unwrap_or(if hms { "h" } else { "y" });
+        let pad_with = pad_with.unwrap_or(if hms {
+            Cow::Borrowed("0")
+        } else {
+            DEFAULT_NUMBER_PAD_WITH
+        });
+
+        let max_unit_index = UNITS
+            .iter()
+            .position(|&x| x == max_unit)
+            .error("max_unit must be one of \"y\", \"w\", \"d\", \"h\", \"m\", \"s\", or \"ms\"")?;
+
+        let min_unit_index = UNITS
+            .iter()
+            .position(|&x| x == min_unit)
+            .error("min_unit must be one of \"y\", \"w\", \"d\", \"h\", \"m\", \"s\", or \"ms\"")?;
+
+        if hms && max_unit_index < 3 {
+            return Err(Error::new(
+                "When hms is enabled the max unit must be h,m,s,ms",
+            ));
+        }
+
+        // UNITS are sorted largest to smallest
+        if min_unit_index < max_unit_index {
+            return Err(Error::new(format!(
+                "min_unit({}) must be smaller than or equal to max_unit({})",
+                min_unit, max_unit,
+            )));
+        }
+
+        let units_upper_bound = min_unit_index - max_unit_index + 1;
+        let units = units.unwrap_or_else(|| min(units_upper_bound, 2));
+
+        if units > units_upper_bound {
+            return Err(Error::new(format!(
+                "there aren't {} units between min_unit({}) and max_unit({})",
+                units, min_unit, max_unit,
+            )));
+        }
+
+        Ok(Self {
+            hms,
+            max_unit_index,
+            min_unit_index,
+            units,
+            round_up,
+            unit_has_space,
+            pad_with,
+            show_leading_units_if_zero,
+        })
+    }
+
+    fn get_time_parts(&self, mut ms: u128) -> Vec<(usize, u128)> {
+        let mut should_push = false;
+        // A Vec of the unit index and value pairs
+        let mut v = Vec::with_capacity(self.units);
+        for (i, div) in UNIT_CONVERSION_RATES[self.max_unit_index..=self.min_unit_index]
+            .iter()
+            .enumerate()
+        {
+            // Offset i by the offset used to slice UNIT_CONVERSION_RATES
+            let index = i + self.max_unit_index;
+            let value = ms / div;
+
+            // Only add the non-zero, unless we want to display the leading units of time with value of zero.
+            // For example we want to have a minimum unit of seconds but to always show two values we could have:
+            // " 0m 15s"
+            if !should_push {
+                should_push = value != 0
+                    || (self.show_leading_units_if_zero
+                        && index >= self.min_unit_index + 1 - self.units);
+            }
+
+            if should_push {
+                v.push((index, value));
+                // We have the right number of values/units
+                if v.len() == self.units {
+                    break;
+                }
+            }
+            ms %= div;
+        }
+
+        v
+    }
+}
+
+impl Formatter for DurationFormatter {
+    fn format(&self, val: &Value, _config: &SharedConfig) -> Result<String, FormatError> {
+        match val {
+            Value::Duration(duration) => {
+                let mut v = self.get_time_parts(duration.as_millis());
+
+                if self.round_up {
+                    // Get the index for which unit we should round up to
+                    let i = v.last().map_or(self.min_unit_index, |&(i, _)| i);
+                    v = self.get_time_parts(duration.as_millis() + UNIT_CONVERSION_RATES[i] - 1);
+                }
+
+                let mut first_entry = true;
+                let mut result = String::new();
+                for (i, value) in v {
+                    // No separator before the first entry
+                    if !first_entry {
+                        if self.hms {
+                            // Separator between s and ms should be a '.'
+                            if i == 6 {
+                                result.push('.');
+                            } else {
+                                result.push(':');
+                            }
+                        } else {
+                            result.push(' ');
+                        }
+                    } else {
+                        first_entry = false;
+                    }
+
+                    // Pad the value
+                    let value_str = value.to_string();
+                    for _ in value_str.len()..UNIT_PAD_WIDTHS[i] {
+                        result.push_str(&self.pad_with);
+                    }
+                    result.push_str(&value_str);
+
+                    // No units in hms mode
+                    if !self.hms {
+                        if self.unit_has_space {
+                            result.push(' ');
+                        }
+                        result.push_str(UNITS[i]);
+                    }
+                }
+
+                Ok(result)
+            }
+            other => Err(FormatError::IncompatibleFormatter {
+                ty: other.type_name(),
+                fmt: "duration",
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! dur {
+        ($($key:ident : $value:expr),*) => {{
+            let mut ms = 0;
+            $(
+            let unit = stringify!($key);
+            ms += $value
+                * (UNIT_CONVERSION_RATES[UNITS
+                    .iter()
+                    .position(|&x| x == unit)
+                    .expect("unit must be one of \"y\", \"w\", \"d\", \"h\", \"m\", \"s\", or \"ms\"")]
+                    as u64);
+            )*
+           Value::Duration(std::time::Duration::from_millis(ms))
+        }};
+    }
+
+    #[test]
+    fn dur_default_single_unit() {
+        let config = SharedConfig::default();
+        let fmt = new_fmt!(dur).unwrap();
+
+        let result = fmt.format(&dur!(y:1), &config).unwrap();
+        assert_eq!(result, "1y  0w");
+
+        let result = fmt.format(&dur!(w:1), &config).unwrap();
+        assert_eq!(result, " 1w 0d");
+
+        let result = fmt.format(&dur!(d:1), &config).unwrap();
+        assert_eq!(result, "1d  0h");
+
+        let result = fmt.format(&dur!(h:1), &config).unwrap();
+        assert_eq!(result, " 1h  0m");
+
+        let result = fmt.format(&dur!(m:1), &config).unwrap();
+        assert_eq!(result, " 1m  0s");
+
+        let result = fmt.format(&dur!(s:1), &config).unwrap();
+        assert_eq!(result, " 0m  1s");
+
+        //This is rounded to 1s since min_unit is 's' and round_up is true
+        let result = fmt.format(&dur!(ms:1), &config).unwrap();
+        assert_eq!(result, " 0m  1s");
+    }
+
+    #[test]
+    fn dur_default_consecutive_units() {
+        let config = SharedConfig::default();
+        let fmt = new_fmt!(dur).unwrap();
+
+        let result = fmt.format(&dur!(y:1, w:2), &config).unwrap();
+        assert_eq!(result, "1y  2w");
+
+        let result = fmt.format(&dur!(w:1, d:2), &config).unwrap();
+        assert_eq!(result, " 1w 2d");
+
+        let result = fmt.format(&dur!(d:1, h:2), &config).unwrap();
+        assert_eq!(result, "1d  2h");
+
+        let result = fmt.format(&dur!(h:1, m:2), &config).unwrap();
+        assert_eq!(result, " 1h  2m");
+
+        let result = fmt.format(&dur!(m:1, s:2), &config).unwrap();
+        assert_eq!(result, " 1m  2s");
+
+        //This is rounded to 2s since min_unit is 's' and round_up is true
+        let result = fmt.format(&dur!(s:1, ms:2), &config).unwrap();
+        assert_eq!(result, " 0m  2s");
+    }
+
+    #[test]
+    fn dur_hms_no_ms() {
+        let config = SharedConfig::default();
+        let fmt = new_fmt!(dur, hms:true, min_unit:s).unwrap();
+
+        let result = fmt.format(&dur!(d:1, h:2), &config).unwrap();
+        assert_eq!(result, "26:00");
+
+        let result = fmt.format(&dur!(h:1, m:2), &config).unwrap();
+        assert_eq!(result, "01:02");
+
+        let result = fmt.format(&dur!(m:1, s:2), &config).unwrap();
+        assert_eq!(result, "01:02");
+
+        //This is rounded to 2s since min_unit is 's' and round_up is true
+        let result = fmt.format(&dur!(s:1, ms:2), &config).unwrap();
+        assert_eq!(result, "00:02");
+    }
+
+    #[test]
+    fn dur_hms_with_ms() {
+        let config = SharedConfig::default();
+        let fmt = new_fmt!(dur, hms:true, min_unit:ms).unwrap();
+
+        let result = fmt.format(&dur!(d:1, h:2), &config).unwrap();
+        assert_eq!(result, "26:00");
+
+        let result = fmt.format(&dur!(h:1, m:2), &config).unwrap();
+        assert_eq!(result, "01:02");
+
+        let result = fmt.format(&dur!(m:1, s:2), &config).unwrap();
+        assert_eq!(result, "01:02");
+
+        let result = fmt.format(&dur!(s:1, ms:2), &config).unwrap();
+        assert_eq!(result, "01.002");
+    }
+
+    #[test]
+    fn dur_round_up_true() {
+        let config = SharedConfig::default();
+        let fmt = new_fmt!(dur, round_up:true).unwrap();
+
+        let result = fmt.format(&dur!(y:1, ms:1), &config).unwrap();
+        assert_eq!(result, "1y  1w");
+
+        let result = fmt.format(&dur!(w:1, ms:1), &config).unwrap();
+        assert_eq!(result, " 1w 1d");
+
+        let result = fmt.format(&dur!(d:1, ms:1), &config).unwrap();
+        assert_eq!(result, "1d  1h");
+
+        let result = fmt.format(&dur!(h:1, ms:1), &config).unwrap();
+        assert_eq!(result, " 1h  1m");
+
+        let result = fmt.format(&dur!(m:1, ms:1), &config).unwrap();
+        assert_eq!(result, " 1m  1s");
+
+        //This is rounded to 2s since min_unit is 's' and round_up is true
+        let result = fmt.format(&dur!(s:1, ms:1), &config).unwrap();
+        assert_eq!(result, " 0m  2s");
+    }
+
+    #[test]
+    fn dur_units() {
+        let config = SharedConfig::default();
+        let val = dur!(y:1, w:2, d:3, h:4, m:5, s:6, ms:7);
+
+        let fmt = new_fmt!(dur, round_up:false, min_unit:ms, units: 1).unwrap();
+        let result = fmt.format(&val, &config).unwrap();
+        assert_eq!(result, "1y");
+
+        let fmt = new_fmt!(dur, round_up:false, min_unit:ms, units: 2).unwrap();
+        let result = fmt.format(&val, &config).unwrap();
+        assert_eq!(result, "1y  2w");
+
+        let fmt = new_fmt!(dur, round_up:false, min_unit:ms, units: 3).unwrap();
+        let result = fmt.format(&val, &config).unwrap();
+        assert_eq!(result, "1y  2w 3d");
+
+        let fmt = new_fmt!(dur, round_up:false, min_unit:ms, units: 4).unwrap();
+        let result = fmt.format(&val, &config).unwrap();
+        assert_eq!(result, "1y  2w 3d  4h");
+
+        let fmt = new_fmt!(dur, round_up:false, min_unit:ms, units: 5).unwrap();
+        let result = fmt.format(&val, &config).unwrap();
+        assert_eq!(result, "1y  2w 3d  4h  5m");
+
+        let fmt = new_fmt!(dur, round_up:false, min_unit:ms, units: 6).unwrap();
+        let result = fmt.format(&val, &config).unwrap();
+        assert_eq!(result, "1y  2w 3d  4h  5m  6s");
+
+        let fmt = new_fmt!(dur, round_up:false, min_unit:ms, units: 7).unwrap();
+        let result = fmt.format(&val, &config).unwrap();
+        assert_eq!(result, "1y  2w 3d  4h  5m  6s   7ms");
+    }
+
+    #[test]
+    fn dur_round_up_false() {
+        let config = SharedConfig::default();
+        let fmt = new_fmt!(dur, round_up:false).unwrap();
+
+        let result = fmt.format(&dur!(y:1, ms:1), &config).unwrap();
+        assert_eq!(result, "1y  0w");
+
+        let result = fmt.format(&dur!(w:1, ms:1), &config).unwrap();
+        assert_eq!(result, " 1w 0d");
+
+        let result = fmt.format(&dur!(d:1, ms:1), &config).unwrap();
+        assert_eq!(result, "1d  0h");
+
+        let result = fmt.format(&dur!(h:1, ms:1), &config).unwrap();
+        assert_eq!(result, " 1h  0m");
+
+        let result = fmt.format(&dur!(m:1, ms:1), &config).unwrap();
+        assert_eq!(result, " 1m  0s");
+
+        let result = fmt.format(&dur!(s:1, ms:1), &config).unwrap();
+        assert_eq!(result, " 0m  1s");
+
+        let result = fmt.format(&dur!(ms:1), &config).unwrap();
+        assert_eq!(result, " 0m  0s");
+    }
+
+    #[test]
+    fn dur_invalid_config_hms_and_unit_space() {
+        let fmt_err = new_fmt!(dur, hms:true, unit_space:true).unwrap_err();
+        assert_eq!(
+            fmt_err.message,
+            Some("When hms is enabled unit_space should not be true".into())
+        );
+    }
+
+    #[test]
+    fn dur_invalid_config_invalid_unit() {
+        let fmt_err = new_fmt!(dur, max_unit:does_not_exist).unwrap_err();
+        assert_eq!(
+            fmt_err.message,
+            Some(
+                "max_unit must be one of \"y\", \"w\", \"d\", \"h\", \"m\", \"s\", or \"ms\""
+                    .into()
+            )
+        );
+
+        let fmt_err = new_fmt!(dur, min_unit:does_not_exist).unwrap_err();
+        assert_eq!(
+            fmt_err.message,
+            Some(
+                "min_unit must be one of \"y\", \"w\", \"d\", \"h\", \"m\", \"s\", or \"ms\""
+                    .into()
+            )
+        );
+    }
+
+    #[test]
+    fn dur_invalid_config_hms_max_unit_too_large() {
+        let fmt_err = new_fmt!(dur, max_unit:d, hms:true).unwrap_err();
+        assert_eq!(
+            fmt_err.message,
+            Some("When hms is enabled the max unit must be h,m,s,ms".into())
+        );
+    }
+
+    #[test]
+    fn dur_invalid_config_min_larger_than_max() {
+        let fmt = new_fmt!(dur, max_unit:h, min_unit:h);
+        assert!(fmt.is_ok());
+
+        let fmt_err = new_fmt!(dur, max_unit:h, min_unit:d).unwrap_err();
+        assert_eq!(
+            fmt_err.message,
+            Some("min_unit(d) must be smaller than or equal to max_unit(h)".into())
+        );
+    }
+
+    #[test]
+    fn dur_invalid_config_too_many_units() {
+        let fmt = new_fmt!(dur, max_unit:y, min_unit:s, units:6);
+        assert!(fmt.is_ok());
+
+        let fmt_err = new_fmt!(dur, max_unit:y, min_unit:s, units:7).unwrap_err();
+        assert_eq!(
+            fmt_err.message,
+            Some("there aren't 7 units between min_unit(s) and max_unit(y)".into())
+        );
+
+        let fmt = new_fmt!(dur, max_unit:w, min_unit:s, units:5);
+        assert!(fmt.is_ok());
+
+        let fmt_err = new_fmt!(dur, max_unit:w, min_unit:s, units:6).unwrap_err();
+        assert_eq!(
+            fmt_err.message,
+            Some("there aren't 6 units between min_unit(s) and max_unit(w)".into())
+        );
+
+        let fmt = new_fmt!(dur, max_unit:y, min_unit:ms, units:7);
+        assert!(fmt.is_ok());
+
+        let fmt_err = new_fmt!(dur, max_unit:y, min_unit:ms, units:8).unwrap_err();
+        assert_eq!(
+            fmt_err.message,
+            Some("there aren't 8 units between min_unit(ms) and max_unit(y)".into())
+        );
+    }
+}

--- a/src/formatting/formatter/duration.rs
+++ b/src/formatting/formatter/duration.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_DURATION_FORMATTER: DurationFormatter = DurationFormatter {
     round_up: true,
     unit_has_space: false,
     pad_with: DEFAULT_NUMBER_PAD_WITH,
-    show_leading_units_if_zero: true,
+    leading_zeroes: true,
 };
 
 #[derive(Debug, Default)]
@@ -35,7 +35,7 @@ pub struct DurationFormatter {
     round_up: bool,
     unit_has_space: bool,
     pad_with: PadWith,
-    show_leading_units_if_zero: bool,
+    leading_zeroes: bool,
 }
 
 impl DurationFormatter {
@@ -47,7 +47,7 @@ impl DurationFormatter {
         let mut round_up = true;
         let mut unit_has_space = false;
         let mut pad_with = None;
-        let mut show_leading_units_if_zero = true;
+        let mut leading_zeroes = true;
         for arg in args {
             match arg.key {
                 "hms" => {
@@ -90,9 +90,8 @@ impl DurationFormatter {
                         ));
                     };
                 }
-                "show_leading_units_if_zero" => {
-                    show_leading_units_if_zero =
-                        arg.val.parse().ok().error("units must be true or false")?;
+                "leading_zeroes" => {
+                    leading_zeroes = arg.val.parse().ok().error("units must be true or false")?;
                 }
 
                 _ => return Err(Error::new(format!("Unexpected argument {:?}", arg.key))),
@@ -154,7 +153,7 @@ impl DurationFormatter {
             round_up,
             unit_has_space,
             pad_with,
-            show_leading_units_if_zero,
+            leading_zeroes,
         })
     }
 
@@ -175,8 +174,7 @@ impl DurationFormatter {
             // " 0m 15s"
             if !should_push {
                 should_push = value != 0
-                    || (self.show_leading_units_if_zero
-                        && index >= self.min_unit_index + 1 - self.units);
+                    || (self.leading_zeroes && index >= self.min_unit_index + 1 - self.units);
             }
 
             if should_push {

--- a/src/formatting/formatter/eng.rs
+++ b/src/formatting/formatter/eng.rs
@@ -6,10 +6,7 @@ use std::ops::RangeInclusive;
 
 use super::*;
 
-type PadWith = Cow<'static, str>;
-
 const DEFAULT_NUMBER_WIDTH: usize = 2;
-const DEFAULT_NUMBER_PAD_WITH: PadWith = Cow::Borrowed(" ");
 
 pub const DEFAULT_NUMBER_FORMATTER: EngFormatter = EngFormatter {
     width: DEFAULT_NUMBER_WIDTH,

--- a/src/formatting/value.rs
+++ b/src/formatting/value.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::time::Duration;
 
 use super::formatter;
 use super::unit::Unit;
@@ -18,6 +19,7 @@ pub enum ValueInner {
     Icon(Cow<'static, str>, Option<f64>),
     Number { val: f64, unit: Unit },
     Datetime(DateTime<Utc>, Option<Tz>),
+    Duration(Duration),
     Flag,
 }
 
@@ -28,6 +30,7 @@ impl ValueInner {
             ValueInner::Icon(..) => "Icon",
             ValueInner::Number { .. } => "Number",
             ValueInner::Datetime(..) => "Datetime",
+            ValueInner::Duration(..) => "Duration",
             ValueInner::Flag => "Flag",
         }
     }
@@ -65,6 +68,10 @@ impl Value {
 
     pub fn datetime(datetime: DateTime<Utc>, tz: Option<Tz>) -> Self {
         Self::new(ValueInner::Datetime(datetime, tz))
+    }
+
+    pub fn duration(duration: Duration) -> Self {
+        Self::new(ValueInner::Duration(duration))
     }
 
     pub fn icon<S>(name: S) -> Self
@@ -146,6 +153,7 @@ impl Value {
             ValueInner::Text(_) | ValueInner::Icon(..) => &formatter::DEFAULT_STRING_FORMATTER,
             ValueInner::Number { .. } => &formatter::DEFAULT_NUMBER_FORMATTER,
             ValueInner::Datetime { .. } => &*formatter::DEFAULT_DATETIME_FORMATTER,
+            ValueInner::Duration { .. } => &formatter::DEFAULT_DURATION_FORMATTER,
             ValueInner::Flag => &formatter::DEFAULT_FLAG_FORMATTER,
         }
     }


### PR DESCRIPTION
TODO: document duration formatter.

Any thoughts on the names of the arguments, the format, or the defaults?

The formatted can be used by the battery, uptime, tea_timer and pomodoro blocks.