### PR TITLE
Escape " in code blocks, replace &vert; with \|

### DIFF
--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -18,8 +18,8 @@
 //! ----|--------|--------
 //! `mac` | MAC address of the Bluetooth device | **Required**
 //! `adapter_mac` | MAC Address of the Bluetooth adapter (in case your device was connected to multiple currently available adapters) | `None`
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>" $icon $name{ $percentage&vert;} "</code>
-//! `disconnected_format` | A string to customise the output of this block. See below for available placeholders. | <code>" $icon{ $name&vert;} "</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $icon $name{ $percentage\|} \"</code>
+//! `disconnected_format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $icon{ $name\|} \"</code>
 //! `battery_state` | A mapping from battery percentage to block's [state](State) (color). See example below. | 0..15 -> critical, 16..30 -> warning, 31..60 -> info, 61..100 -> good
 //!
 //! Placeholder    | Value                                                                 | Type   | Unit

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -12,7 +12,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>"{ $icon&vert;} $text.pango-str() "</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\"{ $icon\|} $text.pango-str() \"</code>
 //! `command` | Shell command to execute & display | `None`
 //! `persistent` | Run command in the background; update display for each output line of the command | `false`
 //! `cycle` | Commands to execute and change when the button is clicked | `None`

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -16,7 +16,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. | <code>"{ $icon&vert;}{ $text.pango-str()&vert;} "</code>
+//! `format` | A string to customise the output of this block. | <code>\"{ $icon\|}{ $text.pango-str()\|} \"</code>
 //!
 //! Placeholder  | Value                                  | Type   | Unit
 //! -------------|-------------------------------------------------------------------|--------|---------------

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -8,7 +8,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>" $title.str(max_w:21) &vert;"</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $title.str(max_w:21) \|\"</code>
 //! `driver` | Which driver to use. Available values: `sway_ipc` - for `i3` and `sway`, `wlr_toplevel_management` - for Wayland compositors that implement [wlr-foreign-toplevel-management-unstable-v1](https://gitlab.freedesktop.org/wlroots/wlr-protocols/-/blob/master/unstable/wlr-foreign-toplevel-management-unstable-v1.xml), `auto` - try to automatically guess which driver to use. | `"auto"`
 //!
 //! Placeholder     | Value                                                                 | Type | Unit

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -10,7 +10,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `device_id` | Device ID as per the output of `kdeconnect --list-devices`. | Chooses the first found device, if any.
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>" $icon $name{ $bat_icon $bat_charge&vert;}{ $notif_icon&vert;} "</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $icon $name{ $bat_icon $bat_charge\|}{ $notif_icon\|} \"</code>
 //! `format_disconnected` | Same as `format` but when device is disconnected | `" $icon "`
 //! `format_missing` | Same as `format` but when device does not exist | `" $icon x "`
 //! `bat_info` | Min battery level below which state is set to info. | `60`

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -18,9 +18,9 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>" $icon {$combo.str(max_w:25,rot_interval:0.5) $play &vert;}"</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $icon {$combo.str(max_w:25,rot_interval:0.5) $play \|}\"</code>
 //! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
-//! `player` | Name(s) of the music player(s) MPRIS interface. This can be either a music player name or an array of music player names. Run <code>busctl --user list &vert; grep "org.mpris.MediaPlayer2." &vert; cut -d' ' -f1</code> and the name is the part after "org.mpris.MediaPlayer2.". | `None`
+//! `player` | Name(s) of the music player(s) MPRIS interface. This can be either a music player name or an array of music player names. Run <code>busctl --user list \| grep "org.mpris.MediaPlayer2." \| cut -d' ' -f1</code> and the name is the part after "org.mpris.MediaPlayer2.". | `None`
 //! `interface_name_exclude` | A list of regex patterns for player MPRIS interface names to ignore. | `["playerctld"]`
 //! `separator` | String to insert between artist and title. | `" - "`
 //! `seek_step_secs` | Positive number of seconds to seek forward/backward when scrolling on the bar. Does not need to be an integer. | `1`

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -15,7 +15,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. | <code>" $icon{ $message&vert;} "</code>
+//! `format` | A string to customise the output of this block. | <code>\" $icon{ $message&vert;} \"</code>
 //! `message` | Message when timer expires | `"Pomodoro over! Take a break!"`
 //! `break_message` | Message when break is over | `"Break over! Time to work!"`
 //! `notify_cmd` | A shell command to run as a notifier. `{msg}` will be substituted with either `message` or `break_message`. | `None`

--- a/src/blocks/privacy.rs
+++ b/src/blocks/privacy.rs
@@ -5,8 +5,8 @@
 //! Key        | Values | Default|
 //! -----------|--------|--------|
 //! `driver` | The configuration of a driver (see below). | **Required**
-//! `format`   | Format string. | <code>"{ $icon_audio \|}{ $icon_audio_sink \|}{ $icon_video \|}{ $icon_webcam \|}{ $icon_unknown \|}"</code> |
-//! `format_alt`   | Format string. | <code>"{ $icon_audio $info_audio \|}{ $icon_audio_sink $info_audio_sink \|}{ $icon_video $info_video \|}{ $icon_webcam $info_webcam \|}{ $icon_unknown $info_unknown \|}"</code> |
+//! `format`   | Format string. | <code>\"{ $icon_audio \|}{ $icon_audio_sink \|}{ $icon_video \|}{ $icon_webcam \|}{ $icon_unknown \|}\"</code> |
+//! `format_alt`   | Format string. | <code>\"{ $icon_audio $info_audio \|}{ $icon_audio_sink $info_audio_sink \|}{ $icon_video $info_video \|}{ $icon_webcam $info_webcam \|}{ $icon_unknown $info_unknown \|}\"</code> |
 //!
 //! # pipewire Options (requires the pipewire feature to be enabled)
 //!

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -11,7 +11,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `driver` | `"auto"`, `"pulseaudio"`, `"alsa"`. | `"auto"` (Pulseaudio with ALSA fallback)
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code> $icon {$volume.eng(w:2) &vert;}</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $icon {$volume.eng(w:2) \|}\"</code>
 //! `name` | PulseAudio device name, or the ALSA control name as found in the output of `amixer -D yourdevice scontrols`. | PulseAudio: `@DEFAULT_SINK@` / ALSA: `Master`
 //! `device` | ALSA device name, usually in the form "hw:X" or "hw:X,Y" where `X` is the card number and `Y` is the device number as found in the output of `aplay -l`. | `default`
 //! `device_kind` | PulseAudio device kind: `source` or `sink`. | `"sink"`

--- a/src/blocks/tea_timer.rs
+++ b/src/blocks/tea_timer.rs
@@ -4,7 +4,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>" $icon {$minutes:$seconds &vert;}"</code>
+//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $icon {$minutes:$seconds \|}\"</code>
 //! `increment` | The numbers of seconds to add each time the block is clicked. | 30
 //! `done_cmd` | A command to run in `sh` when timer finishes. | None
 //!

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -34,7 +34,7 @@
 //! `max_width` or `max_w` | if text is longer it will be truncated            | Infinity
 //! `width` or `w`         | Text will be exactly this length by padding or truncating as needed | N/A
 //! `rot_interval`         | if text is longer than `max_width` it will be rotated every `rot_interval` seconds, if set | None
-//! `rot_separator`        | if text is longer than `max_width` it will be rotated with this seporator | <code>"\|"</code>
+//! `rot_separator`        | if text is longer than `max_width` it will be rotated with this seporator | <code>\"\|\"</code>
 //!
 //! Note: width just changes the values of both min_width and max_width to be the same. Use width
 //! if you want the values to be the same, or the other two otherwise. Don't mix width with


### PR DESCRIPTION
Escaping the `"`s in `<code>` blocks prevents the `"` from being rendered as `“` or `”` (left and right double quotation marks).

Standardized using `\|` instead of `&vert`