### PR TITLE
Fix device_id in kdeconnect block

### DIFF
--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -308,7 +308,7 @@ impl Device {
         debug!("all devices: {:?}", devices);
 
         if let Some(device_id) = device_id {
-            devices.retain(|id| id != device_id);
+            devices.retain(|id| id == device_id);
         }
 
         let mut selected_device = None;


### PR DESCRIPTION
With 2 devices connected to `kdeconnectd` and specifying `device_id` in i3rs config, it currently does the opposite of what is expected and ignores the `device_id` when looking for devices :laughing: 