### PR TITLE
amd_gpu: better error message on device not found

### DIFF
--- a/src/blocks/amd_gpu.rs
+++ b/src/blocks/amd_gpu.rs
@@ -127,7 +127,7 @@ impl Device {
         if !path.exists() {
             Err(Error::new(format!("Device {name} not found")))
         } else {
-            Ok(Self {path})
+            Ok(Self { path })
         }
     }
 
@@ -189,7 +189,6 @@ mod tests {
     #[test]
     fn test_non_existing_gpu_device() {
         let device = Device::new("/nope");
-        //let expected = Err("Device /nope not found");
         assert!(device.is_err());
     }
 }

--- a/src/blocks/amd_gpu.rs
+++ b/src/blocks/amd_gpu.rs
@@ -181,7 +181,6 @@ impl Device {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/blocks/amd_gpu.rs
+++ b/src/blocks/amd_gpu.rs
@@ -63,7 +63,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     };
 
     let device = match &config.device {
-        Some(name) => Device::new(name),
+        Some(name) => Device::new(name)?,
         None => Device::default_card()
             .await
             .error("failed to get default GPU")?
@@ -121,9 +121,13 @@ struct GpuInfo {
 }
 
 impl Device {
-    fn new(name: &str) -> Self {
-        Self {
-            path: PathBuf::from(format!("/sys/class/drm/{name}/device")),
+    fn new(name: &str) -> Result<Self, Error> {
+        let path = PathBuf::from(format!("/sys/class/drm/{name}/device"));
+
+        if !path.exists() {
+            Err(Error::new(format!("Device {name} not found")))
+        } else {
+            Ok(Self {path})
         }
     }
 
@@ -174,5 +178,18 @@ impl Device {
                 .await
                 .error("Failed to read mem_info_vram_used")?,
         })
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_non_existing_gpu_device() {
+        let device = Device::new("/nope");
+        //let expected = Err("Device /nope not found");
+        assert!(device.is_err());
     }
 }


### PR DESCRIPTION
Improve error message when supplied device is non existent.

Fix #2034