### PR TITLE
formatting(eng): add `range` parameter

### DIFF
--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -27,7 +27,7 @@
 //! ----------------|-------------------------------------------|---------------
 //! `toggle_format` | Toggles between `format` and `format_alt` | Left
 //!
-//! # Example
+//! # Examples
 //!
 //! ```toml
 //! [[block]]
@@ -48,6 +48,14 @@
 //! [[block.click]]
 //! button = "right"
 //! update = true
+//! ```
+//!
+//! Show the block only if less than 10GB is available:
+//!
+//! ```toml
+//! [[block]]
+//! block = "disk_space"
+//! format = " $free.eng(range:..10e9) |"
 //! ```
 //!
 //! # Icons Used

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -46,7 +46,7 @@
 //! ----------------|-------------------------------------------|---------------
 //! `toggle_format` | Toggles between `format` and `format_alt` | Left
 //!
-//! # Example
+//! # Examples
 //!
 //! ```toml
 //! [[block]]
@@ -56,6 +56,14 @@
 //! interval = 30
 //! warning_mem = 70
 //! critical_mem = 90
+//! ```
+//!
+//! Show swap and hide if it is zero:
+//!
+//! ```toml
+//! [[block]]
+//! block = "memory"
+//! format = " $icon $swap_used.eng(range:1..) |"
 //! ```
 //!
 //! # Icons Used

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -53,6 +53,7 @@
 //! `prefix_space`  | have a whitespace before prefix symbol                                                           | `false`
 //! `force_prefix`  | force the prefix value instead of setting a "minimal prefix"                                     | `false`
 //! `pad_with`      | the character that is used to pad the number to be `width` long                                  | ` ` (a space)
+//! `range`         | a range of allowed values, in the format `<start>..<end>`, inclusive. Both start and end are optional. Can be used to, for example, hide the block when the value is not in a given range. | `..`
 //!
 //! ## `bar` - Display numbers as progress bars
 //!
@@ -120,6 +121,8 @@ pub enum FormatError {
     PlaceholderNotFound(String),
     #[error("{} cannot be formatted with '{}' formatter", .ty, .fmt)]
     IncompatibleFormatter { ty: &'static str, fmt: &'static str },
+    #[error("Number {0} is out of range")]
+    NumberOutOfRange(f64),
     #[error(transparent)]
     Other(#[from] Error),
 }

--- a/src/formatting/template.rs
+++ b/src/formatting/template.rs
@@ -51,7 +51,9 @@ impl FormatTemplate {
             match token_list.render(values, config) {
                 Ok(res) => return Ok(res),
                 Err(
-                    FormatError::PlaceholderNotFound(_) | FormatError::IncompatibleFormatter { .. },
+                    FormatError::PlaceholderNotFound(_)
+                    | FormatError::IncompatibleFormatter { .. }
+                    | FormatError::NumberOutOfRange(_),
                 ) if i != self.0.len() - 1 => (),
                 Err(e) => return Err(e),
             }


### PR DESCRIPTION
Closes #1957

## Example

Show the cpu block only if utilization is above 10%:

```toml
[[block]]
block = "cpu"
format = " $icon $utilization.eng(range:10..) |"
```

## Unresolved Questions

Support disjoint ranges? Would it be useful? How? Maybe by allowing multiple `range` arguments.

## Todo

- [ ] Add examles to the blocks that would benefit from it.
- [x] Support half-ranges. Like `10..`.