### PR TITLE
Update calibright to 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,12 +402,12 @@ dependencies = [
 
 [[package]]
 name = "calibright"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2639326e43d1b2fa5d4c95fe3d668900afa214c3fb52da9d1ebe5c11600fada6"
+checksum = "d61a1bc948e4d4946e8ed02b5c36be74956524814f85ee4c4b80c385b6f4d09a"
 dependencies = [
  "dirs",
- "futures",
+ "futures-util",
  "log",
  "notify",
  "regex",
@@ -973,7 +973,6 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -995,17 +994,6 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1065,12 +1053,9 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",


### PR DESCRIPTION
Removes transient dependency `futures-executor`