### PR TITLE
formatter[datetime]: fix timezone abbreviation (%Z)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
  "futures",
  "glob",
  "hyper",
+ "iana-time-zone",
  "icu_calendar",
  "icu_datetime",
  "icu_locid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ env_logger = "0.11"
 futures = { version = "0.3", default-features = false }
 glob = { version = "0.3.1", optional = true }
 hyper = "0.14"
+iana-time-zone = "0.1.60"
 icu_calendar = { version = "1.3.0", optional = true }
 icu_datetime = { version = "1.3.0", optional = true }
 icu_locid = { version = "1.3.0", optional = true }

--- a/src/formatting/formatter/datetime.rs
+++ b/src/formatting/formatter/datetime.rs
@@ -1,10 +1,13 @@
-use chrono::format::{Item, StrftimeItems};
-use chrono::{DateTime, Local, Locale, TimeZone};
+use chrono::format::{Fixed, Item, StrftimeItems};
+use chrono::{DateTime, Datelike, Local, LocalResult, Locale, TimeZone, Timelike};
+use chrono_tz::{OffsetName, Tz};
 use once_cell::sync::Lazy;
 
 use std::fmt::Display;
 
 use super::*;
+
+make_log_macro!(error, "datetime");
 
 const DEFAULT_DATETIME_FORMAT: &str = "%a %d/%m %R";
 
@@ -100,6 +103,68 @@ impl DatetimeFormatter {
     }
 }
 
+pub(crate) trait TimezoneName {
+    fn timezone_name(datetime: &DateTime<Self>) -> Item
+    where
+        Self: TimeZone;
+}
+
+impl TimezoneName for Tz {
+    fn timezone_name(datetime: &DateTime<Tz>) -> Item {
+        Item::Literal(datetime.offset().abbreviation())
+    }
+}
+
+impl TimezoneName for Local {
+    fn timezone_name(datetime: &DateTime<Local>) -> Item {
+        let fallback = Item::Fixed(Fixed::TimezoneName);
+        let Ok(tz_name) = iana_time_zone::get_timezone() else {
+            error!("Could not get local timezone");
+            return fallback;
+        };
+        let tz = match tz_name.parse::<Tz>() {
+            Ok(tz) => tz,
+            Err(e) => {
+                error!("{}", e);
+                return fallback;
+            }
+        };
+
+        match tz.with_ymd_and_hms(
+            datetime.year(),
+            datetime.month(),
+            datetime.day(),
+            datetime.hour(),
+            datetime.minute(),
+            datetime.second(),
+        ) {
+            LocalResult::Single(tz_datetime) => {
+                Item::OwnedLiteral(tz_datetime.offset().abbreviation().into())
+            }
+            LocalResult::Ambiguous(..) => {
+                error!("Timezone is ambiguous");
+                fallback
+            }
+            LocalResult::None => {
+                error!("Timezone is none");
+                fallback
+            }
+        }
+    }
+}
+
+fn borrow_item<'a>(item: &'a Item) -> Item<'a> {
+    match item {
+        Item::Literal(s) => Item::Literal(s),
+        Item::OwnedLiteral(s) => Item::Literal(s),
+        Item::Space(s) => Item::Space(s),
+        Item::OwnedSpace(s) => Item::Space(s),
+        Item::Numeric(n, p) => Item::Numeric(n.clone(), *p),
+        Item::Fixed(f) => Item::Fixed(f.clone()),
+        Item::Error => Item::Error,
+    }
+}
+
 impl Formatter for DatetimeFormatter {
     fn format(&self, val: &Value, _config: &SharedConfig) -> Result<String, FormatError> {
         #[allow(clippy::unnecessary_wraps)]
@@ -108,20 +173,27 @@ impl Formatter for DatetimeFormatter {
             datetime: DateTime<T>,
         ) -> Result<String, FormatError>
         where
-            T: TimeZone,
+            T: TimeZone + TimezoneName,
             T::Offset: Display,
         {
             Ok(match this {
-                DatetimeFormatter::Chrono { items, locale } => match *locale {
-                    Some(locale) => datetime.format_localized_with_items(items.iter(), locale),
-                    None => datetime.format_with_items(items.iter()),
+                DatetimeFormatter::Chrono { items, locale } => {
+                    let new_items = items.iter().map(|item| match item {
+                        Item::Fixed(Fixed::TimezoneName) => T::timezone_name(&datetime),
+                        item => borrow_item(item),
+                    });
+                    match *locale {
+                        Some(locale) => datetime
+                            .format_localized_with_items(new_items, locale)
+                            .to_string(),
+                        None => datetime.format_with_items(new_items).to_string(),
+                    }
                 }
-                .to_string(),
                 #[cfg(feature = "icu_calendar")]
                 DatetimeFormatter::Icu { locale, length } => {
                     use chrono::Datelike as _;
                     let date = icu_calendar::Date::try_new_iso_date(
-                        datetime.year_ce().1 as i32,
+                        datetime.year(),
                         datetime.month() as u8,
                         datetime.day() as u8,
                     )


### PR DESCRIPTION
Fixes #1965

What is the right behavior if the timezone abbreviation fails? Right now it will display an error, but a few other options would be to still display the old "`TimezoneName`" (ex -05:00)  or fall back to printing just the long name like America/Chicago

Perhaps something like:

```diff
diff --git a/src/formatting/formatter/datetime.rs b/src/formatting/formatter/datetime.rs
index 7b288b906..bf506a184 100644
--- a/src/formatting/formatter/datetime.rs
+++ b/src/formatting/formatter/datetime.rs
@@ -121,25 +121,19 @@ impl TimezoneName<Tz> for Tz {
 
 impl TimezoneName<Local> for Local {
     fn timezone_name(datetime: &DateTime<Local>) -> Result<Box<str>> {
-        match iana_time_zone::get_timezone()
-            .error("Could not get local timezone")?
-            .parse::<Tz>()
-            .map_err(Error::new)?
-            .with_ymd_and_hms(
-                datetime.year(),
-                datetime.month(),
-                datetime.day(),
-                datetime.hour(),
-                datetime.minute(),
-                datetime.second(),
-            ) {
-            LocalResult::Single(datetime) => Ok(datetime
-                .offset()
-                .abbreviation()
-                .to_string()
-                .into_boxed_str()),
-            LocalResult::Ambiguous(..) => Err(Error::new("Timezone is ambiguous")),
-            LocalResult::None => Err(Error::new("Timezone is none")),
+        let tz_name = iana_time_zone::get_timezone().error("Could not get local timezone")?;
+        let tz = tz_name.parse::<Tz>().map_err(Error::new)?;
+
+        match tz.with_ymd_and_hms(
+            datetime.year(),
+            datetime.month(),
+            datetime.day(),
+            datetime.hour(),
+            datetime.minute(),
+            datetime.second(),
+        ) {
+            LocalResult::Single(datetime) => Tz::timezone_name(&datetime),
+            _ => Ok(tz_name.into_boxed_str()),
         }
     }
 }
@@ -161,7 +155,10 @@ impl Formatter for DatetimeFormatter {
                     for item in items {
                         new_items.push(match item {
                             Item::Fixed(format::Fixed::TimezoneName) => {
-                                Item::OwnedLiteral(T::timezone_name(&datetime)?)
+                                match T::timezone_name(&datetime) {
+                                    Ok(timezone) => Item::OwnedLiteral(timezone),
+                                    _ => Item::Fixed(format::Fixed::TimezoneName),
+                                }
                             }
                             item => item.to_owned(),
                         });
```

or

```diff
diff --git a/src/formatting/formatter/datetime.rs b/src/formatting/formatter/datetime.rs
index 7b288b906..5f066f767 100644
--- a/src/formatting/formatter/datetime.rs
+++ b/src/formatting/formatter/datetime.rs
@@ -106,40 +106,42 @@ where
     T: TimeZone,
     T::Offset: Display,
 {
-    fn timezone_name(datetime: &DateTime<T>) -> Result<Box<str>>;
+    fn timezone_name(datetime: &DateTime<T>) -> Item;
 }
 
 impl TimezoneName<Tz> for Tz {
-    fn timezone_name(datetime: &DateTime<Tz>) -> Result<Box<str>> {
-        Ok(datetime
-            .offset()
-            .abbreviation()
-            .to_string()
-            .into_boxed_str())
+    fn timezone_name(datetime: &DateTime<Tz>) -> Item {
+        Item::OwnedLiteral(
+            datetime
+                .offset()
+                .abbreviation()
+                .to_string()
+                .into_boxed_str(),
+        )
     }
 }
 
 impl TimezoneName<Local> for Local {
-    fn timezone_name(datetime: &DateTime<Local>) -> Result<Box<str>> {
-        match iana_time_zone::get_timezone()
-            .error("Could not get local timezone")?
-            .parse::<Tz>()
-            .map_err(Error::new)?
-            .with_ymd_and_hms(
-                datetime.year(),
-                datetime.month(),
-                datetime.day(),
-                datetime.hour(),
-                datetime.minute(),
-                datetime.second(),
-            ) {
-            LocalResult::Single(datetime) => Ok(datetime
-                .offset()
-                .abbreviation()
-                .to_string()
-                .into_boxed_str()),
-            LocalResult::Ambiguous(..) => Err(Error::new("Timezone is ambiguous")),
-            LocalResult::None => Err(Error::new("Timezone is none")),
+    fn timezone_name(datetime: &DateTime<Local>) -> Item {
+        let tz_name = match iana_time_zone::get_timezone() {
+            Ok(tz_name) => tz_name,
+            _ => return Item::Fixed(format::Fixed::TimezoneName),
+        };
+        let tz = match tz_name.parse::<Tz>() {
+            Ok(tz) => tz,
+            _ => return Item::OwnedLiteral(tz_name.into_boxed_str()),
+        };
+
+        match tz.with_ymd_and_hms(
+            datetime.year(),
+            datetime.month(),
+            datetime.day(),
+            datetime.hour(),
+            datetime.minute(),
+            datetime.second(),
+        ) {
+            LocalResult::Single(tz_datetime) => Tz::timezone_name(&tz_datetime).to_owned(),
+            _ => Item::OwnedLiteral(tz_name.into_boxed_str()),
         }
     }
 }
@@ -160,9 +162,7 @@ impl Formatter for DatetimeFormatter {
                     let mut new_items = Vec::with_capacity(items.len());
                     for item in items {
                         new_items.push(match item {
-                            Item::Fixed(format::Fixed::TimezoneName) => {
-                                Item::OwnedLiteral(T::timezone_name(&datetime)?)
-                            }
+                            Item::Fixed(format::Fixed::TimezoneName) => T::timezone_name(&datetime),
                             item => item.to_owned(),
                         });
                     }
```