### PR TITLE
Nameserver information to network block

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -160,6 +160,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     [if let Some(v) = device.frequency()] "frequency" => Value::hertz(v),
                     [if let Some(v) = device.bitrate()] "bitrate" => Value::bits(v),
                     [if let Some(v) = device.signal()] "signal_strength" => Value::percents(v),
+                    [if let Some(v) = device.nameserver] "nameserver" => Value::text(v.to_string()),
                     "device" => Value::text(device.iface.name),
                 });
 

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -31,6 +31,7 @@
 //! `bitrate`         | WiFi connection bitrate     | Number | Bits per second
 //! `ip`              | IPv4 address of the iface   | Text   | -
 //! `ipv6`            | IPv6 address of the iface   | Text   | -
+//! `nameserver`      | Nameserver                  | Text   | -
 //!
 //! # Example
 //!

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -429,6 +429,21 @@ async fn ipv6(sock: &mut NlSocket, ifa_index: i32) -> Result<Option<Ipv6Addr>> {
         .map(Ipv6Addr::from))
 }
 
+async fn read_nameservers() -> Result<Vec<IpAddr>> {
+    let file = util::read_file("/etc/resolv.conf").await?;
+    let mut nameservers = Vec::new();
+
+    for line in file.lines() {
+        if let Some(ip) = line.strip_prefix("nameserver ") {
+            if let Ok(ip) = ip.parse() {
+                nameservers.push(ip);
+            }
+        }
+    }
+
+    Ok(nameservers)
+}
+
 // Source: https://www.kernel.org/doc/Documentation/networking/operstates.txt
 #[derive(Debug, PartialEq, Eq)]
 pub enum Operstate {

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 
 use libc::c_uchar;
 
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::ops;
 use std::path::Path;
 
@@ -27,6 +27,7 @@ pub struct NetDevice {
     pub ipv6: Option<Ipv6Addr>,
     pub icon: &'static str,
     pub tun_wg_ppp: bool,
+    pub nameservers: Vec<IpAddr>,
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
This PR is the first implementation to add more information to the network block. 

The previous discussion was held in the following issue #2053. Specifically the first step of reading the `nameservers` saved in `etc/resolv.conf`.

It files that are modified are `netlinks.rs` and `net.rs`. With the former being the one that changes the most by creating a function to read the file, modify the Device struct and the last file by updating the documentation and adding the information to be displayed.