### PR TITLE
block[weather]: Remove redundant code

### DIFF
--- a/src/blocks/weather/met_no.rs
+++ b/src/blocks/weather/met_no.rs
@@ -26,41 +26,16 @@ impl<'a> Service<'a> {
         })
     }
 
-    fn get_weather_instant(&self, forecast_data: &ForecastData) -> WeatherMoment {
-        let instant = &forecast_data.instant.details;
-
-        let mut symbol_code_split = forecast_data
-            .next_1_hours
-            .as_ref()
-            .unwrap()
-            .summary
-            .symbol_code
-            .split('_');
-
-        let summary = symbol_code_split.next().unwrap();
-
-        // Times of day can be day, night, and polartwilight
-        let is_night = symbol_code_split
-            .next()
-            .map_or(false, |time_of_day| time_of_day == "night");
-
-        let translated = translate(self.legend, summary, &self.config.lang);
-
-        let temp = instant.air_temperature.unwrap_or_default();
-        let humidity = instant.relative_humidity.unwrap_or_default();
-        let wind_speed = instant.wind_speed.unwrap_or_default();
-
-        WeatherMoment {
-            temp,
-            apparent: australian_apparent_temp(temp, humidity, wind_speed),
-            humidity,
-            weather: translated.clone(),
-            weather_verbose: translated,
-            wind: wind_speed,
-            wind_kmh: wind_speed * 3.6,
-            wind_direction: instant.wind_from_direction,
-            icon: weather_to_icon(summary, is_night),
-        }
+    fn translate(&self, summary: &str) -> String {
+        self.legend
+            .get(summary)
+            .map(|res| match self.config.lang {
+                ApiLanguage::English => res.desc_en.as_str(),
+                ApiLanguage::NorwegianBokmaal => res.desc_nb.as_str(),
+                ApiLanguage::NorwegianNynorsk => res.desc_nn.as_str(),
+            })
+            .unwrap_or(summary)
+            .into()
     }
 }
 
@@ -96,6 +71,73 @@ struct ForecastProperties {
 struct ForecastTimeStep {
     data: ForecastData,
     // time: String,
+}
+
+impl ForecastTimeStep {
+    fn to_moment(&self, service: &Service) -> WeatherMoment {
+        let instant = &self.data.instant.details;
+
+        let mut symbol_code_split = self
+            .data
+            .next_1_hours
+            .as_ref()
+            .unwrap()
+            .summary
+            .symbol_code
+            .split('_');
+
+        let summary = symbol_code_split.next().unwrap();
+
+        // Times of day can be day, night, and polartwilight
+        let is_night = symbol_code_split
+            .next()
+            .map_or(false, |time_of_day| time_of_day == "night");
+
+        let translated = service.translate(summary);
+
+        let temp = instant.air_temperature.unwrap_or_default();
+        let humidity = instant.relative_humidity.unwrap_or_default();
+        let wind_speed = instant.wind_speed.unwrap_or_default();
+
+        WeatherMoment {
+            temp,
+            apparent: australian_apparent_temp(temp, humidity, wind_speed),
+            humidity,
+            weather: translated.clone(),
+            weather_verbose: translated,
+            wind: wind_speed,
+            wind_kmh: wind_speed * 3.6,
+            wind_direction: instant.wind_from_direction,
+            icon: weather_to_icon(summary, is_night),
+        }
+    }
+
+    fn to_aggregate(&self) -> ForecastAggregateSegment {
+        let instant = &self.data.instant.details;
+
+        let apparent = if let (Some(air_temperature), Some(relative_humidity), Some(wind_speed)) = (
+            instant.air_temperature,
+            instant.relative_humidity,
+            instant.wind_speed,
+        ) {
+            Some(australian_apparent_temp(
+                air_temperature,
+                relative_humidity,
+                wind_speed,
+            ))
+        } else {
+            None
+        };
+
+        ForecastAggregateSegment {
+            temp: instant.air_temperature,
+            apparent,
+            humidity: instant.relative_humidity,
+            wind: instant.wind_speed,
+            wind_kmh: instant.wind_speed.map(|t| t * 3.6),
+            wind_direction: instant.wind_from_direction,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -134,18 +176,6 @@ static LEGENDS: Lazy<Option<LegendsStore>> =
 
 const FORECAST_URL: &str = "https://api.met.no/weatherapi/locationforecast/2.0/compact";
 
-fn translate(legend: &LegendsStore, summary: &str, lang: &ApiLanguage) -> String {
-    legend
-        .get(summary)
-        .map(|res| match lang {
-            ApiLanguage::English => res.desc_en.as_str(),
-            ApiLanguage::NorwegianBokmaal => res.desc_nb.as_str(),
-            ApiLanguage::NorwegianNynorsk => res.desc_nn.as_str(),
-        })
-        .unwrap_or(summary)
-        .into()
-}
-
 #[async_trait]
 impl WeatherProvider for Service<'_> {
     async fn get_weather(
@@ -177,116 +207,39 @@ impl WeatherProvider for Service<'_> {
             .error("Forecast request failed")?;
 
         let forecast_hours = self.config.forecast_hours;
+        let location_name = location.map_or("Unknown".to_string(), |c| c.city.clone());
 
-        let forecast = if !need_forecast || forecast_hours == 0 {
-            None
-        } else {
-            let mut temp_avg = 0.0;
-            let mut temp_min = f64::MAX;
-            let mut temp_max = f64::MIN;
-            let mut temp_count = 0.0;
-            let mut humidity_avg = 0.0;
-            let mut humidity_min = f64::MAX;
-            let mut humidity_max = f64::MIN;
-            let mut humidity_count = 0.0;
-            let mut wind_forecasts = Vec::new();
-            let mut apparent_avg = 0.0;
-            let mut apparent_min = f64::MAX;
-            let mut apparent_max = f64::MIN;
-            let mut apparent_count = 0.0;
-            if data.properties.timeseries.len() < forecast_hours {
-                Err(Error::new(
+        let current_weather = data.properties.timeseries.first().unwrap().to_moment(self);
+
+        if !need_forecast || forecast_hours == 0 {
+            return Ok(WeatherResult {
+                location: location_name,
+                current_weather,
+                forecast: None,
+            });
+        }
+
+        if data.properties.timeseries.len() < forecast_hours {
+            return Err(Error::new(
                 format!("Unable to fetch the specified number of forecast_hours specified {}, only {} hours available", forecast_hours, data.properties.timeseries.len()),
             ))?;
-            }
-            for forecast_time_step in data.properties.timeseries.iter().take(forecast_hours) {
-                let forecast_instant = &forecast_time_step.data.instant.details;
-                if let Some(air_temperature) = forecast_instant.air_temperature {
-                    temp_avg += air_temperature;
-                    temp_min = temp_min.min(air_temperature);
-                    temp_max = temp_max.max(air_temperature);
-                    temp_count += 1.0;
-                }
-                if let Some(relative_humidity) = forecast_instant.relative_humidity {
-                    humidity_avg += relative_humidity;
-                    humidity_min = humidity_min.min(relative_humidity);
-                    humidity_max = humidity_max.max(relative_humidity);
-                    humidity_count += 1.0;
-                }
-                if let Some(wind_speed) = forecast_instant.wind_speed {
-                    wind_forecasts.push(Wind {
-                        speed: wind_speed,
-                        degrees: forecast_instant.wind_from_direction,
-                    });
-                }
-                if let (Some(air_temperature), Some(relative_humidity), Some(wind_speed)) = (
-                    forecast_instant.air_temperature,
-                    forecast_instant.relative_humidity,
-                    forecast_instant.wind_speed,
-                ) {
-                    let apparent =
-                        australian_apparent_temp(air_temperature, relative_humidity, wind_speed);
-                    apparent_avg += apparent;
-                    apparent_min = apparent_min.min(apparent);
-                    apparent_max = apparent_max.max(apparent);
-                    apparent_count += 1.0;
-                }
-            }
-            temp_avg /= temp_count;
-            humidity_avg /= humidity_count;
-            apparent_avg /= apparent_count;
-            let Wind {
-                speed: wind_avg,
-                degrees: direction_avg,
-            } = average_wind(&wind_forecasts);
-            let Wind {
-                speed: wind_min,
-                degrees: direction_min,
-            } = wind_forecasts
-                .iter()
-                .min_by(|x, y| x.speed.total_cmp(&y.speed))
-                .error("No min wind")?;
-            let Wind {
-                speed: wind_max,
-                degrees: direction_max,
-            } = wind_forecasts
-                .iter()
-                .min_by(|x, y| x.speed.total_cmp(&y.speed))
-                .error("No max wind")?;
+        }
 
-            Some(Forecast {
-                avg: ForecastAggregate {
-                    temp: temp_avg,
-                    apparent: apparent_avg,
-                    humidity: humidity_avg,
-                    wind: wind_avg,
-                    wind_kmh: wind_avg * 3.6,
-                    wind_direction: direction_avg,
-                },
-                min: ForecastAggregate {
-                    temp: temp_min,
-                    apparent: apparent_min,
-                    humidity: humidity_min,
-                    wind: *wind_min,
-                    wind_kmh: wind_min * 3.6,
-                    wind_direction: *direction_min,
-                },
-                max: ForecastAggregate {
-                    temp: temp_max,
-                    apparent: apparent_max,
-                    humidity: humidity_max,
-                    wind: *wind_max,
-                    wind_kmh: wind_max * 3.6,
-                    wind_direction: *direction_max,
-                },
-                fin: self.get_weather_instant(&data.properties.timeseries[forecast_hours - 1].data),
-            })
-        };
+        let data_agg: Vec<ForecastAggregateSegment> = data
+            .properties
+            .timeseries
+            .iter()
+            .take(forecast_hours)
+            .map(|f| f.to_aggregate())
+            .collect();
+
+        let fin = data.properties.timeseries[forecast_hours - 1].to_moment(self);
+
+        let forecast = Some(Forecast::new(&data_agg, fin));
 
         Ok(WeatherResult {
-            location: location.map_or("Unknown".to_string(), |c| c.city.clone()),
-            current_weather: self
-                .get_weather_instant(&data.properties.timeseries.first().unwrap().data),
+            location: location_name,
+            current_weather,
             forecast,
         })
     }


### PR DESCRIPTION
Moved `combine_forecasts` that @Cognoscan just added from nws to be used by all of the backends (now `Forecast::new`).

Added `ForecastAggregateSegment` which has the same members as `ForecastAggregate`, but makes all of the fields Optional since met.no does not promise that they're included in the response.
