### PR TITLE
Fix Bluetooth block not working when device has no icon

### DIFF
--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -300,25 +300,27 @@ impl DeviceMonitor {
     async fn get_device_info(&mut self) -> Option<DeviceInfo> {
         let device = self.device.as_ref()?;
 
-        let Ok((connected, icon, name)) = tokio::try_join!(
+        let Ok((connected, name)) = tokio::try_join!(
             device.device.connected(),
-            device.device.icon(),
             device.device.name(),
         ) else {
             debug!("failed to fetch device info, assuming device or bluez disappeared");
             self.device = None;
             return None;
         };
+        
+        //icon can be null, so ignore errors when fetching it
+        let icon: &str = match device.device.icon().await.ok().as_deref(){
+            Some("audio-card" | "audio-headset" | "audio-headphones") => "headphones",
+            Some("input-gaming") => "joystick",
+            Some("input-keyboard") => "keyboard",
+            Some("input-mouse") => "mouse",
+            _ => "bluetooth",
+        };
 
         Some(DeviceInfo {
             connected,
-            icon: match icon.as_str() {
-                "audio-card" | "audio-headset" | "audio-headphones" => "headphones",
-                "input-gaming" => "joystick",
-                "input-keyboard" => "keyboard",
-                "input-mouse" => "mouse",
-                _ => "bluetooth",
-            },
+            icon,
             name,
             battery_percentage: device.battery.percentage().await.ok(),
         })


### PR DESCRIPTION
The icon can be null for some bluetooth devices, so ignore errors while fetching the icon and default it to "bluetooth".

Fix #2077 