### PR TITLE
Make end_separator respect separator_fg and separator_bg

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -112,12 +112,28 @@ where
     }
 
     if let Separator::Custom(end_separator) = &config.theme.end_separator {
-        rendered_blocks.push(I3BarBlock {
+        // The separator's FG is the last block's last widget's BG
+        let sep_fg = if config.theme.separator_fg == Color::Auto {
+            prev_last_bg
+        } else {
+            config.theme.separator_fg
+        };
+
+        // The separator has no background color
+        let sep_bg = if config.theme.separator_bg == Color::Auto {
+            Color::None
+        } else {
+            config.theme.separator_bg
+        };
+
+        let separator = I3BarBlock {
             full_text: end_separator.clone(),
-            background: Color::None,
-            color: prev_last_bg,
+            background: sep_bg,
+            color: sep_fg,
             ..Default::default()
-        });
+        };
+
+        rendered_blocks.push(separator);
     }
 
     println!("{},", serde_json::to_string(&rendered_blocks).unwrap());


### PR DESCRIPTION
This change preserves the end separator colors when separator_fg and separator_bg are set to "auto", and makes it use the configured colors when they are set.

resolves https://github.com/greshake/i3status-rust/issues/2110

before: 
![image](https://github.com/user-attachments/assets/343414e3-3a45-49c8-93ab-6d0e82107f48)

after: 
![image](https://github.com/user-attachments/assets/577f75d0-8fc7-49a6-bc13-48cad592ef36)
