### PR TITLE
formatting(eng): add show parameter

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -56,6 +56,7 @@
 //! `force_prefix`  | force the prefix value instead of setting a "minimal prefix"                                     | `false`
 //! `pad_with`      | the character that is used to pad the number to be `width` long                                  | ` ` (a space)
 //! `range`         | a range of allowed values, in the format `<start>..<end>`, inclusive. Both start and end are optional. Can be used to, for example, hide the block when the value is not in a given range. | `..`
+//! `show`          | show this value. Can be used with `range` for conditional formatting                             | `true`
 //!
 //! ## `bar` - Display numbers as progress bars
 //!

--- a/src/formatting/formatter/eng.rs
+++ b/src/formatting/formatter/eng.rs
@@ -9,6 +9,7 @@ use super::*;
 const DEFAULT_NUMBER_WIDTH: usize = 2;
 
 pub const DEFAULT_NUMBER_FORMATTER: EngFormatter = EngFormatter {
+    show: true,
     width: DEFAULT_NUMBER_WIDTH,
     unit: None,
     unit_has_space: false,
@@ -23,6 +24,7 @@ pub const DEFAULT_NUMBER_FORMATTER: EngFormatter = EngFormatter {
 
 #[derive(Debug)]
 pub struct EngFormatter {
+    show: bool,
     width: usize,
     unit: Option<Unit>,
     unit_has_space: bool,
@@ -105,6 +107,9 @@ impl EngFormatter {
                             ..=end.parse::<f64>().error("invalid range end")?;
                     }
                 }
+                "show" => {
+                    result.show = arg.val.parse().ok().error("show must be true or false")?;
+                }
                 other => {
                     return Err(Error::new(format!("Unknown argument for 'eng': '{other}'")));
                 }
@@ -121,6 +126,10 @@ impl Formatter for EngFormatter {
             Value::Number { mut val, mut unit } => {
                 if !self.range.contains(&val) {
                     return Err(FormatError::NumberOutOfRange(val));
+                }
+
+                if !self.show {
+                    return Ok(String::new());
                 }
 
                 let is_negative = val.is_sign_negative();


### PR DESCRIPTION
Fixes #2113

Example usage (will show the icon but only if $status >= 1):

```toml
[[block]]
block = "maildir"
format = " $icon $status.eng(range:1..,show:false)|"
```