### PR TITLE
warn clippy::unused_trait_names

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -29,7 +29,7 @@
 
 mod prelude;
 
-use futures::future::FutureExt;
+use futures::future::FutureExt as _;
 use futures::stream::FuturesUnordered;
 use serde::de::{self, Deserialize};
 use tokio::sync::{mpsc, Notify};
@@ -112,7 +112,7 @@ macro_rules! define_blocks {
             where
                 D: de::Deserializer<'de>,
             {
-                use de::Error;
+                use de::Error as _;
 
                 let mut table = toml::Table::deserialize(deserializer)?;
                 let block_name = table.remove("block").ok_or_else(|| D::Error::missing_field("block"))?;

--- a/src/blocks/calendar/auth.rs
+++ b/src/blocks/calendar/auth.rs
@@ -1,16 +1,16 @@
-use base64::Engine;
+use base64::Engine as _;
 use oauth2::basic::{BasicClient, BasicTokenType};
 use oauth2::reqwest::async_http_client;
 use oauth2::{
     AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, EmptyExtraTokenFields,
     PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, StandardTokenResponse,
-    TokenResponse, TokenUrl,
+    TokenResponse as _, TokenUrl,
 };
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::Url;
 use std::path::{Path, PathBuf};
 use tokio::fs::File;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
 use tokio::net::TcpListener;
 
 use super::CalendarError;

--- a/src/blocks/calendar/caldav.rs
+++ b/src/blocks/calendar/caldav.rs
@@ -1,7 +1,7 @@
-use std::{str::FromStr, time::Duration, vec};
+use std::{str::FromStr as _, time::Duration, vec};
 
 use chrono::{DateTime, Local, Utc};
-use icalendar::{Component, EventLike};
+use icalendar::{Component as _, EventLike as _};
 use reqwest::{
     self,
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -44,10 +44,10 @@
 //! - `cpu_boost_on`
 //! - `cpu_boost_off`
 
-use std::str::FromStr;
+use std::str::FromStr as _;
 
 use tokio::fs::File;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt as _, BufReader};
 
 use super::prelude::*;
 use crate::util::read_file;

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -100,7 +100,7 @@ use crate::formatting::Format;
 use super::prelude::*;
 use inotify::{Inotify, WatchMask};
 use std::process::Stdio;
-use tokio::io::{self, AsyncBufReadExt, BufReader};
+use tokio::io::{self, BufReader};
 use tokio::process::Command;
 
 #[derive(Deserialize, Debug, SmartDefault)]

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -71,9 +71,9 @@
 //! - `memory_swap`
 
 use std::cmp::min;
-use std::str::FromStr;
+use std::str::FromStr as _;
 use tokio::fs::{read_dir, File};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt as _, BufReader};
 
 use super::prelude::*;
 use crate::util::read_file;

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -62,7 +62,7 @@
 use super::prelude::*;
 use crate::netlink::NetDevice;
 use crate::util;
-use itertools::Itertools;
+use itertools::Itertools as _;
 use regex::Regex;
 use std::time::Instant;
 

--- a/src/blocks/privacy/pipewire.rs
+++ b/src/blocks/privacy/pipewire.rs
@@ -8,7 +8,7 @@ use ::pipewire::{
     context::Context, keys, main_loop::MainLoop, properties::properties, spa::utils::dict::DictRef,
     types::ObjectType,
 };
-use itertools::Itertools;
+use itertools::Itertools as _;
 use tokio::sync::Notify;
 
 use super::*;

--- a/src/blocks/sound/pulseaudio.rs
+++ b/src/blocks/sound/pulseaudio.rs
@@ -1,7 +1,7 @@
 use std::cmp::{max, min};
 use std::convert::{TryFrom, TryInto};
 use std::io;
-use std::os::fd::{IntoRawFd, RawFd};
+use std::os::fd::{IntoRawFd as _, RawFd};
 use std::sync::{Arc, Mutex, Weak};
 use std::thread;
 

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -49,7 +49,7 @@
 //! # Icons Used
 //! - `time`
 
-use chrono::{Timelike, Utc};
+use chrono::{Timelike as _, Utc};
 use chrono_tz::Tz;
 
 use super::prelude::*;

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -227,6 +227,6 @@ pub fn deserialize_local_timestamp<'de, D>(deserializer: D) -> Result<DateTime<L
 where
     D: Deserializer<'de>,
 {
-    use chrono::TimeZone;
+    use chrono::TimeZone as _;
     i64::deserialize(deserializer).map(|seconds| Local.timestamp_opt(seconds, 0).single().unwrap())
 }

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -145,7 +145,7 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use chrono::{DateTime, Datelike, Utc};
+use chrono::{DateTime, Datelike as _, Utc};
 use sunrise::{SolarDay, SolarEvent};
 
 use crate::formatting::Format;

--- a/src/click.rs
+++ b/src/click.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use serde::de::{self, Deserializer, Visitor};
 use serde::Deserialize;
 
-use crate::errors::{ErrorContext, Result};
+use crate::errors::{ErrorContext as _, Result};
 use crate::protocol::i3bar_event::I3BarEvent;
 use crate::subprocess::{spawn_shell, spawn_shell_sync};
 use crate::wrappers::SerdeRegex;

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Write;
 
-use unicode_segmentation::UnicodeSegmentation;
+use unicode_segmentation::UnicodeSegmentation as _;
 
 pub trait CollectEscaped {
     /// Write escaped version of `self` to `out`

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -1,4 +1,4 @@
-use unicode_segmentation::UnicodeSegmentation;
+use unicode_segmentation::UnicodeSegmentation as _;
 
 use std::time::Duration;
 use std::{borrow::Cow, fmt::Debug};

--- a/src/formatting/formatter/datetime.rs
+++ b/src/formatting/formatter/datetime.rs
@@ -1,6 +1,6 @@
 use chrono::format::{Fixed, Item, StrftimeItems};
 use chrono::{DateTime, Local, Locale, TimeZone};
-use chrono_tz::{OffsetName, Tz};
+use chrono_tz::{OffsetName as _, Tz};
 
 use std::fmt::Display;
 use std::sync::LazyLock;

--- a/src/formatting/formatter/str.rs
+++ b/src/formatting/formatter/str.rs
@@ -1,7 +1,7 @@
 use std::iter::repeat;
 use std::time::Instant;
 
-use crate::escape::CollectEscaped;
+use crate::escape::CollectEscaped as _;
 
 use super::*;
 

--- a/src/formatting/parse.rs
+++ b/src/formatting/parse.rs
@@ -7,7 +7,7 @@ use nom::{
     combinator::{cut, eof, map, not, opt},
     multi::{many0, separated_list0},
     sequence::{preceded, separated_pair, terminated, tuple},
-    IResult, Parser,
+    IResult, Parser as _,
 };
 
 use crate::errors::*;

--- a/src/formatting/scheduling.rs
+++ b/src/formatting/scheduling.rs
@@ -1,5 +1,5 @@
 use crate::BoxedStream;
-use futures::stream::StreamExt;
+use futures::stream::StreamExt as _;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::match_same_arms)]
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![warn(clippy::unnecessary_wraps)]
+#![warn(clippy::unused_trait_names)]
 #![allow(clippy::single_match)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
@@ -31,7 +32,7 @@ use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::stream::{FuturesUnordered, StreamExt as _};
 use futures::Stream;
 use tokio::process::Command;
 use tokio::sync::{mpsc, Notify};

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -1,4 +1,4 @@
-use neli::attr::Attribute;
+use neli::attr::Attribute as _;
 use neli::consts::{nl::*, rtnl::*, socket::*};
 use neli::nl::{NlPayload, Nlmsghdr};
 use neli::rtnl::{Ifaddrmsg, Ifinfomsg, Rtmsg};

--- a/src/protocol/i3bar_event.rs
+++ b/src/protocol/i3bar_event.rs
@@ -1,11 +1,11 @@
-use std::os::unix::io::FromRawFd;
+use std::os::unix::io::FromRawFd as _;
 use std::time::Duration;
 
 use serde::Deserialize;
 
-use futures::StreamExt;
+use futures::StreamExt as _;
 use tokio::fs::File;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt as _, BufReader};
 
 use crate::click::MouseButton;
 use crate::BoxedStream;

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,4 +1,4 @@
-use futures::stream::StreamExt;
+use futures::stream::StreamExt as _;
 use libc::{SIGRTMAX, SIGRTMIN};
 use signal_hook::consts::{SIGUSR1, SIGUSR2};
 use signal_hook_tokio::Signals;

--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::os::unix::process::CommandExt;
+use std::os::unix::process::CommandExt as _;
 use std::process::{Command, Stdio};
 
 /// Spawn a new detached process

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use dirs::{config_dir, data_dir};
 use serde::de::DeserializeOwned;
-use tokio::io::AsyncReadExt;
+use tokio::io::AsyncReadExt as _;
 use tokio::process::Command;
 
 use crate::errors::*;


### PR DESCRIPTION
Checks for use Trait where the Trait is only used for its methods and not referenced by a path directly.

Traits imported that aren’t used directly can be imported anonymously with use Trait as _. It is more explicit, avoids polluting the current scope with unused names and can be useful to show which imports are required for traits.