### PR TITLE
[feat] Display `connection-name` when connected to ethernet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,6 @@ dependencies = [
  "wayrs-protocols",
  "x11rb-async",
  "zbus",
- "zbus_macros",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,6 +1126,7 @@ dependencies = [
  "wayrs-protocols",
  "x11rb-async",
  "zbus",
+ "zbus_macros",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pulseaudio = ["libpulse-binding"]
 pipewire = ["dep:pipewire"]
 notmuch = ["dep:notmuch"]
 maildir = ["dep:maildir", "glob"]
-icu_calendar = ["dep:icu_datetime", "dep:icu_locale"]
+icu_calendar = ["dep:icu_datetime", "dep:icu_locid", "dep:icu_calendar"]
 debug_borders = []                # Make widgets' borders visible
 
 [package.metadata.docs.rs]
@@ -33,7 +33,9 @@ clap = { version = "4.0", default-features = false, features = ["std", "derive",
 
 [dependencies]
 async-trait = "0.1"
-backon = { version = "1.2", default-features = false, features = ["tokio-sleep"] }
+backon = { version = "1.2", default-features = false, features = [
+  "tokio-sleep",
+] }
 base64 = { version = "0.22.1" }
 bitflags = "2.9"
 bytes = "1.11"
@@ -83,7 +85,8 @@ unicode-segmentation = "1.10.1"
 wayrs-client = { version = "1.0", features = ["tokio"] }
 wayrs-protocols = { version = "0.14", features = ["wlr-foreign-toplevel-management-unstable-v1"] }
 x11rb-async = { version = "0.13.1", features = ["xkb"] }
-zbus = { version = "5", default-features = false, features = ["tokio"] }
+zbus = { version = "5.1.1", default-features = false, features = ["tokio"] }
+zbus_macros = "5.1.1"
 
 [dependencies.tokio]
 version = "1.43"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,11 @@ pulseaudio = ["libpulse-binding"]
 pipewire = ["dep:pipewire"]
 notmuch = ["dep:notmuch"]
 maildir = ["dep:maildir", "glob"]
+<<<<<<< HEAD
 icu_calendar = ["dep:icu_datetime", "dep:icu_locid", "dep:icu_calendar"]
+=======
+icu_calendar = ["dep:icu_datetime", "dep:icu_calendar", "dep:icu_locid"]
+>>>>>>> eb3fda7d2 (chore : dedup comments and revert cargo.toml)
 debug_borders = []                # Make widgets' borders visible
 
 [package.metadata.docs.rs]
@@ -33,9 +37,7 @@ clap = { version = "4.0", default-features = false, features = ["std", "derive",
 
 [dependencies]
 async-trait = "0.1"
-backon = { version = "1.2", default-features = false, features = [
-  "tokio-sleep",
-] }
+backon = { version = "1.2", default-features = false, features = ["tokio-sleep"] }
 base64 = { version = "0.22.1" }
 bitflags = "2.9"
 bytes = "1.11"

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -76,6 +76,7 @@ words:
   - iface
   - ifaces
   - ifaddrmsg
+  - ifindex
   - ifinfomsg
   - ifla
   - ifname
@@ -107,6 +108,7 @@ words:
   - Mupi
   - neli
   - NLMSG
+  - networkd
   - nlmsghdr
   - nmtui
   - noconfirm

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -34,7 +34,6 @@
 //! `ip`              | IPv4 address of the iface   | Text   | -
 //! `ipv6`            | IPv6 address of the iface   | Text   | -
 //! `nameserver`      | Nameserver                  | Text   | -
-//! `connection_name` | Connection name for Ethernet| Text   | -
 //!
 //! # Example
 //!
@@ -160,7 +159,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     [if let Some(v) = device.ip] "ip" => Value::text(v.to_string()),
                     [if let Some(v) = device.ipv6] "ipv6" => Value::text(v.to_string()),
                     [if let Some(v) = device.ssid()] "ssid" => Value::text(v), // Display SSID for WiFi
-                    [if let Some(ref v) = device.ethernet_id] "connection_name" => Value::text(v.clone()), // Convert &String to String
+                    [if let Some(ref v) = device.ethernet_id] "connection_name" => Value::text(v.clone()), // Display ethernet info for ethernet
                     [if let Some(v) = device.frequency()] "frequency" => Value::hertz(v),
                     [if let Some(v) = device.bitrate()] "bitrate" => Value::bits(v),
                     [if let Some(v) = device.signal()] "signal_strength" => Value::percents(v),

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -27,12 +27,14 @@
 //! `graph_up`        | Upload speed graph          | Text   | -
 //! `device`          | The name of device          | Text   | -
 //! `ssid`            | Network SSID (WiFi only)    | Text   | -
+//! `connection_name` | Connection name for Ethernet| Text   | -
 //! `frequency`       | WiFi frequency              | Number | Hz
 //! `signal_strength` | WiFi signal                 | Number | %
 //! `bitrate`         | WiFi connection bitrate     | Number | Bits per second
 //! `ip`              | IPv4 address of the iface   | Text   | -
 //! `ipv6`            | IPv6 address of the iface   | Text   | -
 //! `nameserver`      | Nameserver                  | Text   | -
+//! `connection_name` | Connection name for Ethernet| Text   | -
 //!
 //! # Example
 //!
@@ -157,7 +159,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     "graph_up" => Value::text(util::format_bar_graph(&tx_hist)),
                     [if let Some(v) = device.ip] "ip" => Value::text(v.to_string()),
                     [if let Some(v) = device.ipv6] "ipv6" => Value::text(v.to_string()),
-                    [if let Some(v) = device.ssid()] "ssid" => Value::text(v),
+                    [if let Some(v) = device.ssid()] "ssid" => Value::text(v), // Display SSID for WiFi
+                    [if let Some(ref v) = device.ethernet_id] "connection_name" => Value::text(v.clone()), // Convert &String to String
                     [if let Some(v) = device.frequency()] "frequency" => Value::hertz(v),
                     [if let Some(v) = device.bitrate()] "bitrate" => Value::bits(v),
                     [if let Some(v) = device.signal()] "signal_strength" => Value::percents(v),

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -16,6 +16,14 @@ use std::path::Path;
 use crate::errors::*;
 use crate::util;
 
+use zbus::Connection; // Add zbus for D-Bus communication
+use zbus_macros::proxy; // Use the proxy attribute macro instead of dbus_proxy
+
+#[proxy(interface = "org.freedesktop.NetworkManager.Connection.Active")]
+trait ActiveConnection {
+    fn id(&self) -> zbus::Result<String>;
+}
+
 // From `linux/rtnetlink.h`
 const RT_SCOPE_HOST: c_uchar = 254;
 
@@ -28,6 +36,7 @@ pub struct NetDevice {
     pub icon: &'static str,
     pub tun_wg_ppp: bool,
     pub nameservers: Vec<IpAddr>,
+    pub ethernet_id: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -72,6 +81,12 @@ impl NetDevice {
             .await
             .error("Failed to read nameservers")?;
 
+        let connection_name = if wifi_info.is_none() {
+            get_connection_name(&iface.name).await?
+        } else {
+            None
+        };
+
         // TODO: use netlink for the these too
         // I don't believe that this should ever change, so set it now:
         let path = Path::new("/sys/class/net").join(&iface.name);
@@ -104,6 +119,7 @@ impl NetDevice {
             icon,
             tun_wg_ppp: tun | wg | ppp,
             nameservers,
+            ethernet_id: connection_name, // Store connection name for Ethernet
         }))
     }
 
@@ -457,6 +473,67 @@ async fn read_nameservers() -> Result<Vec<IpAddr>> {
     }
 
     Ok(nameservers)
+}
+
+async fn get_connection_name(iface_name: &str) -> Result<Option<String>> {
+    let connection = Connection::system()
+        .await
+        .error("Failed to connect to D-Bus")?;
+    let proxy = zbus::Proxy::new(
+        &connection,
+        "org.freedesktop.NetworkManager",
+        "/org/freedesktop/NetworkManager",
+        "org.freedesktop.NetworkManager",
+    )
+    .await
+    .error("Failed to create D-Bus proxy")?;
+
+    let active_connections: Vec<zbus::zvariant::OwnedObjectPath> = proxy
+        .call("ActiveConnections", &())
+        .await
+        .error("Failed to get active connections")?;
+
+    for path in active_connections {
+        let active_proxy = zbus::Proxy::new(
+            &connection,
+            "org.freedesktop.NetworkManager",
+            path.as_str(),
+            "org.freedesktop.NetworkManager.Connection.Active",
+        )
+        .await
+        .error("Failed to create active connection proxy")?;
+
+        let devices: Vec<zbus::zvariant::OwnedObjectPath> = active_proxy
+            .get_property("Devices")
+            .await
+            .error("Failed to get devices for connection")?;
+
+        for device_path in devices {
+            let device_proxy = zbus::Proxy::new(
+                &connection,
+                "org.freedesktop.NetworkManager",
+                device_path.as_str(),
+                "org.freedesktop.NetworkManager.Device",
+            )
+            .await
+            .error("Failed to create device proxy")?;
+
+            let device_iface: String = device_proxy
+                .get_property("Interface")
+                .await
+                .error("Failed to get device interface")?;
+
+            if device_iface == iface_name {
+                let connection_id: String = active_proxy
+                    .get_property("Id")
+                    .await
+                    .error("Failed to get connection ID")?;
+                return Ok(Some(connection_id));
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 // Source: https://www.kernel.org/doc/Documentation/networking/operstates.txt

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -552,35 +552,35 @@ async fn get_connection_name_networkd(iface_name: &str) -> Option<String> {
     let Ok(connection) = Connection::system().await else {
         return None;
     };
-    let Ok(path) = zbus::zvariant::ObjectPath::try_from(
-          format!("/org/freedesktop/network1/link/{ifindex}"),
-      ) else {
-          return None;
-      };
-      let Ok(proxy) = zbus::Proxy::new(
-          &connection,
-          "org.freedesktop.network1",
-          &path,
-          "org.freedesktop.network1.Link",
-      )
+    let Ok(path) =
+        zbus::zvariant::ObjectPath::try_from(format!("/org/freedesktop/network1/link/{ifindex}"))
+    else {
+        return None;
+    };
+    let Ok(proxy) = zbus::Proxy::new(
+        &connection,
+        "org.freedesktop.network1",
+        &path,
+        "org.freedesktop.network1.Link",
+    )
     .await
     else {
         return None;
     };
     if let Ok(nf) = proxy.get_property::<String>("NetworkFile").await
-          && !nf.is_empty()
-      {
-          return Some(nf);
-      }
-      let Ok(json) = proxy.call::<_, _, String>("Describe", &()).await else {
-          return None;
-      };
-      let parsed: serde_json::Value = serde_json::from_str(&json).ok()?;
-      parsed
-          .get("NetworkFile")
-          .and_then(|v| v.as_str())
-          .filter(|s| !s.is_empty())
-          .map(|s| s.to_string())
+        && !nf.is_empty()
+    {
+        return Some(nf);
+    }
+    let Ok(json) = proxy.call::<_, _, String>("Describe", &()).await else {
+        return None;
+    };
+    let parsed: serde_json::Value = serde_json::from_str(&json).ok()?;
+    parsed
+        .get("NetworkFile")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
 }
 
 // Source: https://www.kernel.org/doc/Documentation/networking/operstates.txt

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -470,6 +470,14 @@ async fn read_nameservers() -> Result<Vec<IpAddr>> {
 }
 
 async fn get_connection_name(iface_name: &str) -> Option<String> {
+    if let Some(name) = get_connection_name_nm(iface_name).await {
+        return Some(name);
+    }
+    get_connection_name_networkd(iface_name).await
+}
+
+// for when networkmanager present
+async fn get_connection_name_nm(iface_name: &str) -> Option<String> {
     let Ok(connection) = Connection::system().await else {
         return None;
     };
@@ -533,6 +541,46 @@ async fn get_connection_name(iface_name: &str) -> Option<String> {
     }
 
     None
+}
+
+// for when systemd-networkd present
+async fn get_connection_name_networkd(iface_name: &str) -> Option<String> {
+    let ifindex = std::fs::read_to_string(format!("/sys/class/net/{iface_name}/ifindex"))
+        .ok()?
+        .trim()
+        .to_string();
+    let Ok(connection) = Connection::system().await else {
+        return None;
+    };
+    let Ok(path) = zbus::zvariant::ObjectPath::try_from(
+          format!("/org/freedesktop/network1/link/{ifindex}"),
+      ) else {
+          return None;
+      };
+      let Ok(proxy) = zbus::Proxy::new(
+          &connection,
+          "org.freedesktop.network1",
+          &path,
+          "org.freedesktop.network1.Link",
+      )
+    .await
+    else {
+        return None;
+    };
+    if let Ok(nf) = proxy.get_property::<String>("NetworkFile").await
+          && !nf.is_empty()
+      {
+          return Some(nf);
+      }
+      let Ok(json) = proxy.call::<_, _, String>("Describe", &()).await else {
+          return None;
+      };
+      let parsed: serde_json::Value = serde_json::from_str(&json).ok()?;
+      parsed
+          .get("NetworkFile")
+          .and_then(|v| v.as_str())
+          .filter(|s| !s.is_empty())
+          .map(|s| s.to_string())
 }
 
 // Source: https://www.kernel.org/doc/Documentation/networking/operstates.txt

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -16,13 +16,7 @@ use std::path::Path;
 use crate::errors::*;
 use crate::util;
 
-use zbus::Connection; // Add zbus for D-Bus communication
-use zbus_macros::proxy; // Use the proxy attribute macro instead of dbus_proxy
-
-#[proxy(interface = "org.freedesktop.NetworkManager.Connection.Active")]
-trait ActiveConnection {
-    fn id(&self) -> zbus::Result<String>;
-}
+use zbus::Connection;
 
 // From `linux/rtnetlink.h`
 const RT_SCOPE_HOST: c_uchar = 254;
@@ -82,7 +76,7 @@ impl NetDevice {
             .error("Failed to read nameservers")?;
 
         let connection_name = if wifi_info.is_none() {
-            get_connection_name(&iface.name).await?
+            get_connection_name(&iface.name).await
         } else {
             None
         };
@@ -475,65 +469,70 @@ async fn read_nameservers() -> Result<Vec<IpAddr>> {
     Ok(nameservers)
 }
 
-async fn get_connection_name(iface_name: &str) -> Result<Option<String>> {
-    let connection = Connection::system()
-        .await
-        .error("Failed to connect to D-Bus")?;
-    let proxy = zbus::Proxy::new(
+async fn get_connection_name(iface_name: &str) -> Option<String> {
+    let Ok(connection) = Connection::system().await else {
+        return None;
+    };
+    let Ok(proxy) = zbus::Proxy::new(
         &connection,
         "org.freedesktop.NetworkManager",
         "/org/freedesktop/NetworkManager",
         "org.freedesktop.NetworkManager",
     )
     .await
-    .error("Failed to create D-Bus proxy")?;
+    else {
+        return None;
+    };
 
-    let active_connections: Vec<zbus::zvariant::OwnedObjectPath> = proxy
-        .call("ActiveConnections", &())
+    let Ok(active_connections) = proxy
+        .get_property::<Vec<zbus::zvariant::OwnedObjectPath>>("ActiveConnections")
         .await
-        .error("Failed to get active connections")?;
+    else {
+        return None;
+    };
 
     for path in active_connections {
-        let active_proxy = zbus::Proxy::new(
+        let Ok(active_proxy) = zbus::Proxy::new(
             &connection,
             "org.freedesktop.NetworkManager",
             path.as_str(),
             "org.freedesktop.NetworkManager.Connection.Active",
         )
         .await
-        .error("Failed to create active connection proxy")?;
+        else {
+            continue;
+        };
 
-        let devices: Vec<zbus::zvariant::OwnedObjectPath> = active_proxy
-            .get_property("Devices")
+        let Ok(devices) = active_proxy
+            .get_property::<Vec<zbus::zvariant::OwnedObjectPath>>("Devices")
             .await
-            .error("Failed to get devices for connection")?;
+        else {
+            continue;
+        };
 
         for device_path in devices {
-            let device_proxy = zbus::Proxy::new(
+            let Ok(device_proxy) = zbus::Proxy::new(
                 &connection,
                 "org.freedesktop.NetworkManager",
                 device_path.as_str(),
                 "org.freedesktop.NetworkManager.Device",
             )
             .await
-            .error("Failed to create device proxy")?;
+            else {
+                continue;
+            };
 
-            let device_iface: String = device_proxy
-                .get_property("Interface")
-                .await
-                .error("Failed to get device interface")?;
+            let Ok(device_iface) = device_proxy.get_property::<String>("Interface").await else {
+                continue;
+            };
 
             if device_iface == iface_name {
-                let connection_id: String = active_proxy
-                    .get_property("Id")
-                    .await
-                    .error("Failed to get connection ID")?;
-                return Ok(Some(connection_id));
+                return active_proxy.get_property::<String>("Id").await.ok();
             }
         }
     }
 
-    Ok(None)
+    None
 }
 
 // Source: https://www.kernel.org/doc/Documentation/networking/operstates.txt


### PR DESCRIPTION
This pr adds functionality to get and display the `connection_name` for wired connection as set by `NetworkManager` as `ethernet_id` along with its icon.
Should solve [issue 1851](https://github.com/greshake/i3status-rust/issues/1851)
