### PR TITLE
feat(theme): add sway bar color integration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,15 @@ use crate::geolocator::Geolocator;
 use crate::icons::{Icon, Icons};
 use crate::themes::{Theme, ThemeOverrides, ThemeUserConfig};
 
+use dirs;               //used in implementing parsing logic for the sway override function
+
+
+// === Optional sway integration ===
+#[derive(Deserialize, Debug)]
+pub struct SwayIntegration {
+    pub use_sway_bar_colors: Option<bool>,
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
@@ -36,6 +45,9 @@ pub struct Config {
     #[serde(default)]
     #[serde(rename = "block")]
     pub blocks: Vec<BlockConfigEntry>,
+
+    #[serde(default)]
+    pub sway_integration: Option<SwayIntegration>, 
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -124,4 +136,46 @@ where
     let theme_config = ThemeUserConfig::deserialize(deserializer)?;
     let theme = Theme::try_from(theme_config).serde_error()?;
     Ok(Arc::new(theme))
+}
+
+use crate::themes::color::Color;
+
+pub fn try_parse_sway_bar_colors() -> Option<(Color, Color)> {
+    let config_path = dirs::home_dir()?.join(".config/sway/config");
+    let contents = std::fs::read_to_string(config_path).ok()?;
+
+    let mut in_bar_block = false;
+    let mut in_colors_block = false;
+    let mut background = None;
+    let mut statusline = None;
+
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("bar") && trimmed.ends_with("{") {
+            in_bar_block = true;
+            continue;
+        }
+        if in_bar_block && trimmed.starts_with("colors") && trimmed.ends_with("{") {
+            in_colors_block = true;
+            continue;
+        }
+        if in_colors_block {
+            if trimmed.starts_with("}") {
+                break;
+            }
+            if trimmed.starts_with("background") {
+                background = trimmed.split_whitespace().nth(1).map(str::to_string);
+            } else if trimmed.starts_with("statusline") {
+                statusline = trimmed.split_whitespace().nth(1).map(str::to_string);
+            }
+        }
+    }
+
+    if let (Some(bg_str), Some(fg_str)) = (background, statusline) {
+        let bg: Color = bg_str.parse().ok()?;
+        let fg: Color = fg_str.parse().ok()?;
+        Some((bg, fg))
+    } else {
+        None
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Deserializer};
 use smart_default::SmartDefault;
 use std::collections::HashMap;
+use std::os::unix::process::parent_id;
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::blocks::BlockConfig;
@@ -9,15 +11,14 @@ use crate::errors::*;
 use crate::formatting::config::Config as FormatConfig;
 use crate::geolocator::Geolocator;
 use crate::icons::{Icon, Icons};
+use crate::themes::color::Color;
 use crate::themes::{Theme, ThemeOverrides, ThemeUserConfig};
+use crate::util::read_file;
 
-use dirs;               //used in implementing parsing logic for the sway override function
-
-
-// === Optional sway integration ===
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
+#[serde(default, deny_unknown_fields)]
 pub struct SwayIntegration {
-    pub use_sway_bar_colors: Option<bool>,
+    pub use_sway_bar_colors: bool,
 }
 
 #[derive(Deserialize, Debug)]
@@ -47,7 +48,7 @@ pub struct Config {
     pub blocks: Vec<BlockConfigEntry>,
 
     #[serde(default)]
-    pub sway_integration: Option<SwayIntegration>, 
+    pub sway_integration: SwayIntegration,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -138,44 +139,62 @@ where
     Ok(Arc::new(theme))
 }
 
-use crate::themes::color::Color;
+pub struct SwayBarColors {
+    pub background: Color,
+    pub statusline: Color,
+    pub separator: Color,
+}
 
-pub fn try_parse_sway_bar_colors() -> Option<(Color, Color)> {
-    let config_path = dirs::home_dir()?.join(".config/sway/config");
-    let contents = std::fs::read_to_string(config_path).ok()?;
+pub async fn try_parse_sway_bar_colors() -> Result<SwayBarColors> {
+    let mut swayipc_connection = swayipc_async::Connection::new()
+        .await
+        .error("Failed to open swayipc connection")?;
 
-    let mut in_bar_block = false;
-    let mut in_colors_block = false;
-    let mut background = None;
-    let mut statusline = None;
+    let mut current_pid = parent_id().to_string();
+    while current_pid != "1" {
+        let cmdline = read_file(Path::new("/proc").join(&current_pid).join("cmdline"))
+            .await
+            .or_error(|| format!("Failed to read /proc/{current_pid}/cmdline"))?;
+        let cmdline_parts: Vec<_> = cmdline.split('\0').collect();
+        if let Some(bar_id) = cmdline_parts
+            .iter()
+            .position(|&s| s == "-b" || s == "--bar_id")
+            .and_then(|pos| cmdline_parts.get(pos + 1))
+        {
+            let bar_config = swayipc_connection
+                .get_bar_config(&bar_id)
+                .await
+                .error("Failed to get swaybar config")?;
+            return Ok(SwayBarColors {
+                background: bar_config
+                    .colors
+                    .background
+                    .parse()
+                    .error("Failed to parse background color")?,
+                statusline: bar_config
+                    .colors
+                    .statusline
+                    .parse()
+                    .error("Failed to parse statusline color")?,
+                separator: bar_config
+                    .colors
+                    .separator
+                    .parse()
+                    .error("Failed to parse separator color")?,
+            });
+        }
+        let stat = read_file(Path::new("/proc").join(&current_pid).join("stat"))
+            .await
+            .or_error(|| format!("Failed to read /proc/{current_pid}/stat"))?;
 
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("bar") && trimmed.ends_with("{") {
-            in_bar_block = true;
-            continue;
-        }
-        if in_bar_block && trimmed.starts_with("colors") && trimmed.ends_with("{") {
-            in_colors_block = true;
-            continue;
-        }
-        if in_colors_block {
-            if trimmed.starts_with("}") {
-                break;
-            }
-            if trimmed.starts_with("background") {
-                background = trimmed.split_whitespace().nth(1).map(str::to_string);
-            } else if trimmed.starts_with("statusline") {
-                statusline = trimmed.split_whitespace().nth(1).map(str::to_string);
-            }
-        }
+        current_pid = stat
+            .split(' ')
+            .nth(3)
+            .unwrap()
+            .parse()
+            .or_error(|| format!("Failed to parse parent PID from /proc/{current_pid}/stat"))?;
     }
-
-    if let (Some(bg_str), Some(fg_str)) = (background, statusline) {
-        let bg: Color = bg_str.parse().ok()?;
-        let fg: Color = fg_str.parse().ok()?;
-        Some((bg, fg))
-    } else {
-        None
-    }
+    Err(Error::new(
+        "Unable to find swaybar process in parent process tree",
+    ))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Deserializer};
 use smart_default::SmartDefault;
 use std::collections::HashMap;
+use std::os::unix::process::parent_id;
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::blocks::BlockConfig;
@@ -10,14 +12,13 @@ use crate::formatting::config::Config as FormatConfig;
 use crate::geolocator::Geolocator;
 use crate::icons::{Icon, Icons};
 use crate::themes::{Theme, ThemeOverrides, ThemeUserConfig};
-
-use dirs;               //used in implementing parsing logic for the sway override function
-
+use crate::util::read_file;
 
 // === Optional sway integration ===
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
+#[serde(default, deny_unknown_fields)]
 pub struct SwayIntegration {
-    pub use_sway_bar_colors: Option<bool>,
+    pub use_sway_bar_colors: bool,
 }
 
 #[derive(Deserialize, Debug)]
@@ -47,7 +48,7 @@ pub struct Config {
     pub blocks: Vec<BlockConfigEntry>,
 
     #[serde(default)]
-    pub sway_integration: Option<SwayIntegration>, 
+    pub sway_integration: SwayIntegration,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -140,42 +141,51 @@ where
 
 use crate::themes::color::Color;
 
-pub fn try_parse_sway_bar_colors() -> Option<(Color, Color)> {
-    let config_path = dirs::home_dir()?.join(".config/sway/config");
-    let contents = std::fs::read_to_string(config_path).ok()?;
+pub async fn try_parse_sway_bar_colors() -> Result<(Color, Color)> {
+    let mut swayipc_connection = swayipc_async::Connection::new()
+        .await
+        .error("Failed to open swayipc connection")?;
 
-    let mut in_bar_block = false;
-    let mut in_colors_block = false;
-    let mut background = None;
-    let mut statusline = None;
+    let mut current_pid = parent_id().to_string();
+    while current_pid != "1" {
+        let cmdline = read_file(Path::new("/proc").join(&current_pid).join("cmdline"))
+            .await
+            .or_error(|| format!("Failed to read /proc/{current_pid}/cmdline"))?;
+        let cmdline_parts: Vec<_> = cmdline.split('\0').collect();
+        if let Some(bar_id) = cmdline_parts
+            .iter()
+            .position(|&s| s == "-b" || s == "--bar_id")
+            .and_then(|pos| cmdline_parts.get(pos + 1))
+        {
+            let bar_config = swayipc_connection
+                .get_bar_config(&bar_id)
+                .await
+                .error("Failed to get swaybar config")?;
+            return Ok((
+                bar_config
+                    .colors
+                    .background
+                    .parse()
+                    .error("Failed to parse background color")?,
+                bar_config
+                    .colors
+                    .statusline
+                    .parse()
+                    .error("Failed to parse statusline color")?,
+            ));
+        }
+        let stat = read_file(Path::new("/proc").join(&current_pid).join("stat"))
+            .await
+            .or_error(|| format!("Failed to read /proc/{current_pid}/stat"))?;
 
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("bar") && trimmed.ends_with("{") {
-            in_bar_block = true;
-            continue;
-        }
-        if in_bar_block && trimmed.starts_with("colors") && trimmed.ends_with("{") {
-            in_colors_block = true;
-            continue;
-        }
-        if in_colors_block {
-            if trimmed.starts_with("}") {
-                break;
-            }
-            if trimmed.starts_with("background") {
-                background = trimmed.split_whitespace().nth(1).map(str::to_string);
-            } else if trimmed.starts_with("statusline") {
-                statusline = trimmed.split_whitespace().nth(1).map(str::to_string);
-            }
-        }
+        current_pid = stat
+            .split(' ')
+            .nth(3)
+            .unwrap()
+            .parse()
+            .or_error(|| format!("Failed to parse parent PID from /proc/{current_pid}/stat"))?;
     }
-
-    if let (Some(bg_str), Some(fg_str)) = (background, statusline) {
-        let bg: Color = bg_str.parse().ok()?;
-        let fg: Color = fg_str.parse().ok()?;
-        Some((bg, fg))
-    } else {
-        None
-    }
+    Err(Error::new(
+        "Unable to find swaybar process in parent process tree",
+    ))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,12 +38,12 @@ fn main() {
             let mut config: Config = util::deserialize_toml_file(&config_path)?;
 
             // === Inject Sway bar color override if enabled ===
-            if let Some((bg, fg)) = try_parse_sway_bar_colors() {
+            if config.sway_integration.use_sway_bar_colors {
+                let (bg, fg) = try_parse_sway_bar_colors().await?;
                 let theme = Arc::make_mut(&mut config.shared.theme);
                 theme.idle_bg = bg;
                 theme.idle_fg = fg;
             }
-            
 
             let blocks = std::mem::take(&mut config.blocks);
             let mut bar = BarState::new(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,13 +37,14 @@ fn main() {
                 .or_error(|| format!("Configuration file '{}' not found", args.config))?;
             let mut config: Config = util::deserialize_toml_file(&config_path)?;
 
-            // === Inject Sway bar color override if enabled ===
-            if let Some((bg, fg)) = try_parse_sway_bar_colors() {
+            // Inject Sway bar color override if enabled
+            if config.sway_integration.use_sway_bar_colors {
+                let sway_bar_colors = try_parse_sway_bar_colors().await?;
                 let theme = Arc::make_mut(&mut config.shared.theme);
-                theme.idle_bg = bg;
-                theme.idle_fg = fg;
+                theme.idle_bg = sway_bar_colors.background;
+                theme.idle_fg = sway_bar_colors.statusline;
+                theme.separator_fg = sway_bar_colors.separator;
             }
-            
 
             let blocks = std::mem::take(&mut config.blocks);
             let mut bar = BarState::new(config);


### PR DESCRIPTION
## Summary

This PR introduces optional integration with the user's Sway configuration to automatically apply bar colors (background and foreground) from the `~/.config/sway/config` file. Fix for the open issue #2145

## Motivation

As a Wayland-native window manager, Sway allows defining custom bar colors. This enhancement bridges the theme configuration in i3status-rust with Sway’s color settings, improving visual consistency and user experience for Sway users.

## Implementation

- Introduced a `sway_integration` section in `config.toml`
- Parsed Sway bar colors (`background`, `statusline`) from the local Sway config
- Applied parsed colors to the theme's `idle_bg` and `idle_fg` fields
- Added necessary Rust glue code with minimal footprint

## Config Usage

To enable this, add to your `config.toml`:

```toml
[sway_integration]
use_sway_bar_colors = true
