### PR TITLE
blocks[calendar]: parse multiple comp within support-calendar-componet-set

### DIFF
--- a/src/blocks/calendar/caldav.rs
+++ b/src/blocks/calendar/caldav.rs
@@ -228,11 +228,12 @@ enum ResourceType {
 
 #[derive(Debug, Deserialize)]
 struct SupportedCalendarComponentSet {
-    comp: Option<Comp>,
+    #[serde(rename = "$value", default)]
+    pub values: Vec<Comp>,
 }
 impl SupportedCalendarComponentSet {
     fn supports_events(&self) -> bool {
-        self.comp.as_ref().is_some_and(|v| v.name == "VEVENT")
+        self.values.iter().any(|v| v.name == "VEVENT")
     }
 }
 


### PR DESCRIPTION
fixes calendar retrieval if caldav server replies with multiple `<comp ..>` entities eg.

```xml
<?xml version="1.0" encoding="utf-8"?>
<D:multistatus xmlns:D="DAV:" xmlns:a="urn:ietf:params:xml:ns:caldav">
  <D:response>
    <D:href>/SOGo/dav/___redacted___/Calendar/</D:href>
    <D:propstat>
      <D:status>HTTP/1.1 200 OK</D:status>
      <D:prop>
        <D:displayname>Calendar</D:displayname>
        <D:resourcetype>
          <D:collection/>
        </D:resourcetype>
        <n1:supported-calendar-component-set xmlns:n1="urn:ietf:params:xml:ns:caldav" xmlns:D="DAV:">
          <n1:comp name="VEVENT"/>
          <n1:comp name="VTODO"/>
        </n1:supported-calendar-component-set>
      </D:prop>
    </D:propstat>
  </D:response>
  <D:response>
....
```

this is the case for sogo caldav service and apparently for nexcloud accoring to: #2175