### PR TITLE
Allow one or more format to be used

### DIFF
--- a/src/blocks/amd_gpu.rs
+++ b/src/blocks/amd_gpu.rs
@@ -5,8 +5,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `device` | The device in `/sys/class/drm/` to read from. | Any AMD card
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $utilization "`
-//! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
+//! `format` | A [MultiFormat][MaybeMultiFormatConfig] string to customise the output of this block. See below for available placeholders. | `[" $icon $utilization "]`
 //! `interval` | Update interval in seconds | `5`
 //!
 //! Placeholder          | Value                               | Type   | Unit
@@ -19,7 +18,9 @@
 //!
 //! Action          | Description                               | Default button
 //! ----------------|-------------------------------------------|---------------
-//! `toggle_format` | Toggles between `format` and `format_alt` | Left
+//! `toggle_format` **DEPRECATED** | Toggles between `format` and `format_alt` | -
+//! `next_format`  | Switches to the next format in the list     | Left
+//! `prev_format`  | Switches to the previous format in the list | Right
 //!
 //! # Example
 //!
@@ -43,24 +44,23 @@ use super::prelude::*;
 use crate::util::read_file;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
     pub device: Option<String>,
-    pub format: FormatConfig,
-    pub format_alt: Option<FormatConfig>,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     #[default(5.into())]
     pub interval: Seconds,
 }
 
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut actions = api.get_actions()?;
-    api.set_default_actions(&[(MouseButton::Left, None, "toggle_format")])?;
+    api.set_default_actions(&[
+        (MouseButton::Left, None, "next_format"),
+        (MouseButton::Right, None, "prev_format"),
+    ])?;
 
-    let mut format = config.format.with_default(" $icon $utilization ")?;
-    let mut format_alt = match &config.format_alt {
-        Some(f) => Some(f.with_default("")?),
-        None => None,
-    };
+    let mut formats = config.formats.with_default(" $icon $utilization ")?;
 
     let device = match &config.device {
         Some(name) => Device::new(name).await?,
@@ -71,7 +71,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     };
 
     loop {
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = Widget::new().with_format(formats.get_format());
 
         let info = device.read_info().await?;
 
@@ -97,11 +97,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = sleep(config.interval.0) => break,
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
-                    "toggle_format" => {
-                        if let Some(ref mut format_alt) = format_alt {
-                            std::mem::swap(format_alt, &mut format);
-                            break;
-                        }
+                    "next_format" | "toggle_format" => {
+                        formats.next_format();
+                        break;
+                    }
+                    "prev_format" => {
+                        formats.prev_format();
+                        break;
                     }
                     _ => (),
                 }

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -4,8 +4,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $utilization "`
-//! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
+//! `format` | A [MultiFormat][MaybeMultiFormatConfig] string to customise the output of this block. See below for available placeholders. | `[" $icon $utilization "]`
 //! `interval` | Update interval in seconds | `5`
 //! `info_cpu` | Percentage of CPU usage, where state is set to info | `30.0`
 //! `warning_cpu` | Percentage of CPU usage, where state is set to warning | `60.0`
@@ -24,7 +23,9 @@
 //!
 //! Action          | Description                               | Default button
 //! ----------------|-------------------------------------------|---------------
-//! `toggle_format` | Toggles between `format` and `format_alt` | Left
+//! `toggle_format` **DEPRECATED** | Toggles between `format` and `format_alt` | -
+//! `next_format`  | Switches to the next format in the list     | Left
+//! `prev_format`  | Switches to the previous format in the list | Right
 //!
 //! # Example
 //!
@@ -56,10 +57,10 @@ const CPU_BOOST_PATH: &str = "/sys/devices/system/cpu/cpufreq/boost";
 const CPU_NO_TURBO_PATH: &str = "/sys/devices/system/cpu/intel_pstate/no_turbo";
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
-    pub format: FormatConfig,
-    pub format_alt: Option<FormatConfig>,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     #[default(5.into())]
     pub interval: Seconds,
     #[default(30.0)]
@@ -72,13 +73,12 @@ pub struct Config {
 
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut actions = api.get_actions()?;
-    api.set_default_actions(&[(MouseButton::Left, None, "toggle_format")])?;
+    api.set_default_actions(&[
+        (MouseButton::Left, None, "next_format"),
+        (MouseButton::Right, None, "prev_format"),
+    ])?;
 
-    let mut format = config.format.with_default(" $icon $utilization ")?;
-    let mut format_alt = match &config.format_alt {
-        Some(f) => Some(f.with_default("")?),
-        None => None,
-    };
+    let mut formats = config.formats.with_default(" $icon $utilization ")?;
 
     // Store previous /proc/stat state
     let mut cputime = read_proc_stat().await?;
@@ -136,7 +136,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             );
         }
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = Widget::new().with_format(formats.get_format());
         widget.set_values(values);
         widget.state = match utilization_avg * 100. {
             x if x > config.critical_cpu => State::Critical,
@@ -151,11 +151,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = timer.tick() => break,
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
-                    "toggle_format" => {
-                        if let Some(ref mut format_alt) = format_alt {
-                            std::mem::swap(format_alt, &mut format);
-                            break;
-                        }
+                    "next_format" | "toggle_format" => {
+                        formats.next_format();
+                        break;
+                    }
+                    "prev_format" => {
+                        formats.prev_format();
+                        break;
                     }
                     _ => (),
                 }

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -6,8 +6,7 @@
 //! ----|--------|--------
 //! `path` | Path to collect information from. Supports path expansions e.g. `~`. | `"/"`
 //! `interval` | Update time in seconds | `20`
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon $available "`
-//! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
+//! `format` | A [MultiFormat][MaybeMultiFormatConfig] string to customise the output of this block. See below for available placeholders. | `[" $icon $available "]`
 //! `warning` | A value which will trigger warning block state | `20.0`
 //! `alert` | A value which will trigger critical block state | `10.0`
 //! `info_type` | Determines which information will affect the block state. Possible values are `"available"`, `"free"` and `"used"` | `"available"`
@@ -26,7 +25,9 @@
 //!
 //! Action          | Description                               | Default button
 //! ----------------|-------------------------------------------|---------------
-//! `toggle_format` | Toggles between `format` and `format_alt` | Left
+//! `toggle_format` **DEPRECATED** | Toggles between `format` and `format_alt` | -
+//! `next_format`  | Switches to the next format in the list     | Left
+//! `prev_format`  | Switches to the previous format in the list | Right
 //!
 //! # Examples
 //!
@@ -89,14 +90,14 @@ pub enum Backend {
 }
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
     #[default("/".into())]
     pub path: ShellString,
     pub backend: Backend,
     pub info_type: InfoType,
-    pub format: FormatConfig,
-    pub format_alt: Option<FormatConfig>,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     pub alert_unit: Option<String>,
     #[default(20.into())]
     pub interval: Seconds,
@@ -108,13 +109,12 @@ pub struct Config {
 
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut actions = api.get_actions()?;
-    api.set_default_actions(&[(MouseButton::Left, None, "toggle_format")])?;
+    api.set_default_actions(&[
+        (MouseButton::Left, None, "next_format"),
+        (MouseButton::Right, None, "prev_format"),
+    ])?;
 
-    let mut format = config.format.with_default(" $icon $available ")?;
-    let mut format_alt = match &config.format_alt {
-        Some(f) => Some(f.with_default("")?),
-        None => None,
-    };
+    let mut formats = config.formats.with_default(" $icon $available ")?;
 
     let unit = match config.alert_unit.as_deref() {
         // Decimal
@@ -139,7 +139,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut timer = config.interval.timer();
 
     loop {
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = Widget::new().with_format(formats.get_format());
 
         let (total, used, available, free) = match config.backend {
             Backend::Vfs => get_vfs(&*path)?,
@@ -198,11 +198,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = timer.tick() => break,
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
-                    "toggle_format" => {
-                        if let Some(format_alt) = &mut format_alt {
-                            std::mem::swap(format_alt, &mut format);
-                            break;
-                        }
+                    "next_format" | "toggle_format" => {
+                        formats.next_format();
+                        break;
+                    }
+                    "prev_format" => {
+                        formats.prev_format();
+                        break;
                     }
                     _ => (),
                 }

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -4,8 +4,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block when in "Memory" view. See below for available placeholders. | `" $icon $mem_used.eng(prefix:Mi)/$mem_total.eng(prefix:Mi)($mem_used_percents.eng(w:2)) "`
-//! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
+//! `format` | A [MultiFormat][MaybeMultiFormatConfig] string to customise the output of this block when in "Memory" view. See below for available placeholders. | `[" $icon $mem_used.eng(prefix:Mi)/$mem_total.eng(prefix:Mi)($mem_used_percents.eng(w:2)) "]`
 //! `interval` | Update interval in seconds | `5`
 //! `warning_mem` | Percentage of memory usage, where state is set to warning | `80.0`
 //! `warning_swap` | Percentage of swap usage, where state is set to warning | `80.0`
@@ -44,7 +43,9 @@
 //!
 //! Action          | Description                               | Default button
 //! ----------------|-------------------------------------------|---------------
-//! `toggle_format` | Toggles between `format` and `format_alt` | Left
+//! `toggle_format` **DEPRECATED** | Toggles between `format` and `format_alt` | -
+//! `next_format`  | Switches to the next format in the list     | Left
+//! `prev_format`  | Switches to the previous format in the list | Right
 //!
 //! # Examples
 //!
@@ -79,10 +80,10 @@ use super::prelude::*;
 use crate::util::read_file;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
-    pub format: FormatConfig,
-    pub format_alt: Option<FormatConfig>,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     #[default(5.into())]
     pub interval: Seconds,
     #[default(80.0)]
@@ -97,15 +98,14 @@ pub struct Config {
 
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut actions = api.get_actions()?;
-    api.set_default_actions(&[(MouseButton::Left, None, "toggle_format")])?;
+    api.set_default_actions(&[
+        (MouseButton::Left, None, "next_format"),
+        (MouseButton::Right, None, "prev_format"),
+    ])?;
 
-    let mut format = config.format.with_default(
+    let mut formats = config.formats.with_default(
         " $icon $mem_used.eng(prefix:Mi)/$mem_total.eng(prefix:Mi)($mem_used_percents.eng(w:2)) ",
     )?;
-    let mut format_alt = match &config.format_alt {
-        Some(f) => Some(f.with_default("")?),
-        None => None,
-    };
 
     let mut timer = config.interval.timer();
 
@@ -179,7 +179,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             0.0
         };
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = Widget::new().with_format(formats.get_format());
         widget.set_values(map! {
             "icon" => Value::icon("memory_mem"),
             "icon_swap" => Value::icon("memory_swap"),
@@ -237,11 +237,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = timer.tick() => break,
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
-                    "toggle_format" => {
-                        if let Some(ref mut format_alt) = format_alt {
-                            std::mem::swap(format_alt, &mut format);
-                            break;
-                        }
+                    "next_format" | "toggle_format" => {
+                        formats.next_format();
+                        break;
+                    }
+                    "prev_format" => {
+                        formats.prev_format();
+                        break;
                     }
                     _ => (),
                 }

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -18,8 +18,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $icon {$combo.str(max_w:25,rot_interval:0.5) $play \|}\"</code>
-//! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
+//! `format` | A [MultiFormat][MaybeMultiFormatConfig] string to customise the output of this block. See below for available placeholders. | <code>[\" $icon {$combo.str(max_w:25,rot_interval:0.5) $play \|}\"]</code>
 //! `player` | Name(s) of the music player(s) MPRIS interface. This can be either a music player name or an array of music player names. Run <code>busctl \--user list \| grep \"org.mpris.MediaPlayer2.\" \| cut -d\' \' -f1</code> and the name is the part after "org.mpris.MediaPlayer2.". | `None`
 //! `interface_name_exclude` | A list of regex patterns for player MPRIS interface names to ignore. | `["playerctld"]`
 //! `separator` | String to insert between artist and title. | `" - "`
@@ -62,7 +61,9 @@
 //! `seek_backward` | Wheel Down
 //! `volume_up`     | -
 //! `volume_down`   | -
-//! `toggle_format` | Left
+//! `toggle_format` **DEPRECATED** | -
+//! `next_format`  | Left
+//! `prev_format`  | -
 //!
 //! # Examples
 //!
@@ -107,7 +108,7 @@
 //! [[block.click]]
 //! button = "middle"
 //! widget = "."
-//! action = "toggle_format"
+//! action = "next_format"
 //! ```
 //!
 //! Scroll to change the player volume, use the forward and back buttons to seek:
@@ -160,10 +161,10 @@ const NEXT_BTN: &str = "next_btn";
 const PREV_BTN: &str = "prev_btn";
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
-    pub format: FormatConfig,
-    pub format_alt: Option<FormatConfig>,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     pub player: PlayerName,
     #[default(vec!["playerctld".into()])]
     pub interface_name_exclude: Vec<String>,
@@ -194,18 +195,14 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         (MouseButton::Right, None, "next_player"),
         (MouseButton::WheelUp, None, "seek_forward"),
         (MouseButton::WheelDown, None, "seek_backward"),
-        (MouseButton::Left, None, "toggle_format"),
+        (MouseButton::Left, None, "next_format"),
     ])?;
 
     let dbus_conn = new_dbus_connection().await?;
 
-    let mut format = config
-        .format
+    let mut formats = config
+        .formats
         .with_default(" $icon {$combo.str(max_w:25,rot_interval:0.5) $play |}")?;
-    let mut format_alt = match &config.format_alt {
-        Some(f) => Some(f.with_default("")?),
-        None => None,
-    };
 
     let volume_step = config.volume_step.clamp(0.0, 50.0) / 100.0;
 
@@ -363,13 +360,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     );
                     values.insert("volume".into(), Value::percents(volume * 100.0));
                 }
-                let mut widget = Widget::new().with_format(format.clone());
+                let mut widget = Widget::new().with_format(formats.get_format());
                 widget.set_values(values);
                 widget.state = state;
                 api.set_widget(widget)?;
             }
             None => {
-                let mut widget = Widget::new().with_format(format.clone());
+                let mut widget = Widget::new().with_format(formats.get_format());
                 widget.set_values(map!("icon" => Value::icon("music")));
                 api.set_widget(widget)?;
             }
@@ -488,11 +485,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                             "volume_down" => {
                                 player.set_volume(-volume_step).await?;
                             }
-                            "toggle_format" => {
-                                if let Some(format_alt) = &mut format_alt {
-                                    std::mem::swap(format_alt, &mut format);
-                                    break;
-                                }
+                            "next_format" | "toggle_format" => {
+                                formats.next_format();
+                                break;
+                            }
+                            "prev_format" => {
+                                formats.prev_format();
+                                break;
                             }
                             _ => (),
                         }

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -8,14 +8,15 @@
 //! ----|--------|--------
 //! `device` | Network interface to monitor (as specified in `/sys/class/net/`). Supports regex. | If not set, device will be automatically selected every `interval`
 //! `interval` | Update interval in seconds | `2`
-//! `format` | A string to customise the output of this block. See below for available placeholders. | `" $icon ^icon_net_down $speed_down.eng(prefix:K) ^icon_net_up $speed_up.eng(prefix:K) "`
-//! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
+//! `format` | A [MultiFormat][MaybeMultiFormatConfig] string to customise the output of this block. See below for available placeholders. | `[" $icon ^icon_net_down $speed_down.eng(prefix:K) ^icon_net_up $speed_up.eng(prefix:K) "]`
 //! `inactive_format` | Same as `format` but for when the interface is inactive | `" $icon Down "`
 //! `missing_format` | Same as `format` but for when the device is missing | `" × "`
 //!
 //! Action          | Description                               | Default button
 //! ----------------|-------------------------------------------|---------------
-//! `toggle_format` | Toggles between `format` and `format_alt` | Left
+//! `toggle_format` **DEPRECATED** | Toggles between `format` and `format_alt` | -
+//! `next_format`  | Switches to the next format in the list     | Left
+//! `prev_format`  | Switches to the previous format in the list | Right
 //!
 //! Placeholder       | Value                       | Type   | Unit
 //! ------------------|-----------------------------|--------|---------------
@@ -25,7 +26,7 @@
 //! `graph_down`      | Download speed graph        | Text   | -
 //! `graph_up`        | Upload speed graph          | Text   | -
 //! `device`          | The name of device          | Text   | -
-//! `ssid`            | Netfork SSID (WiFi only)    | Text   | -
+//! `ssid`            | Network SSID (WiFi only)    | Text   | -
 //! `frequency`       | WiFi frequency              | Number | Hz
 //! `signal_strength` | WiFi signal                 | Number | %
 //! `bitrate`         | WiFi connection bitrate     | Number | Bits per second
@@ -67,30 +68,29 @@ use regex::Regex;
 use std::time::Instant;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
     pub device: Option<String>,
     #[default(2.into())]
     pub interval: Seconds,
-    pub format: FormatConfig,
-    pub format_alt: Option<FormatConfig>,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     pub inactive_format: FormatConfig,
     pub missing_format: FormatConfig,
 }
 
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut actions = api.get_actions()?;
-    api.set_default_actions(&[(MouseButton::Left, None, "toggle_format")])?;
+    api.set_default_actions(&[
+        (MouseButton::Left, None, "next_format"),
+        (MouseButton::Right, None, "prev_format"),
+    ])?;
 
-    let mut format = config.format.with_default(
+    let mut formats = config.formats.with_default(
         " $icon ^icon_net_down $speed_down.eng(prefix:K) ^icon_net_up $speed_up.eng(prefix:K) ",
     )?;
     let missing_format = config.missing_format.with_default(" × ")?;
     let inactive_format = config.inactive_format.with_default(" $icon Down ")?;
-    let mut format_alt = match &config.format_alt {
-        Some(f) => Some(f.with_default("")?),
-        None => None,
-    };
 
     let mut timer = config.interval.timer();
 
@@ -116,7 +116,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 let mut widget = Widget::new();
 
                 if device.is_up() {
-                    widget.set_format(format.clone());
+                    widget.set_format(formats.get_format());
                 } else {
                     widget.set_format(inactive_format.clone());
                 }
@@ -180,11 +180,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = timer.tick() => break,
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
-                    "toggle_format" => {
-                        if let Some(format_alt) = &mut format_alt {
-                            std::mem::swap(format_alt, &mut format);
-                            break;
-                        }
+                    "next_format" | "toggle_format" => {
+                        formats.next_format();
+                        break;
+                    }
+                    "prev_format" => {
+                        formats.prev_format();
+                        break;
                     }
                     _ => ()
                 }

--- a/src/blocks/prelude.rs
+++ b/src/blocks/prelude.rs
@@ -4,7 +4,10 @@ pub(crate) use crate::REQWEST_CLIENT;
 pub(crate) use crate::REQWEST_CLIENT_IPV4;
 pub use crate::click::MouseButton;
 pub use crate::errors::*;
-pub use crate::formatting::{Values, config::Config as FormatConfig, value::Value};
+pub use crate::formatting::{
+    Values, config::Config as FormatConfig, config::MaybeMultiConfig as MaybeMultiFormatConfig,
+    value::Value,
+};
 pub use crate::util::{default, new_dbus_connection, new_system_dbus_connection};
 pub use crate::widget::{State, Widget};
 pub use crate::wrappers::{Seconds, ShellString};

--- a/src/blocks/privacy.rs
+++ b/src/blocks/privacy.rs
@@ -5,8 +5,7 @@
 //! Key        | Values | Default|
 //! -----------|--------|--------|
 //! `driver` | The configuration of a driver (see below). | **Required**
-//! `format`   | Format string. | <code>\"{ $icon_audio \|}{ $icon_audio_sink \|}{ $icon_video \|}{ $icon_webcam \|}{ $icon_unknown \|}\"</code> |
-//! `format_alt`   | Format string. | <code>\"{ $icon_audio $info_audio \|}{ $icon_audio_sink $info_audio_sink \|}{ $icon_video $info_video \|}{ $icon_webcam $info_webcam \|}{ $icon_unknown $info_unknown \|}\"</code> |
+//! `format`   | [MultiFormat][MaybeMultiFormatConfig] string. | <code>[\"{ $icon_audio \|}{ $icon_audio_sink \|}{ $icon_video \|}{ $icon_webcam \|}{ $icon_unknown \|}\", \"{ $icon_audio $info_audio \|}{ $icon_audio_sink $info_audio_sink \|}{ $icon_video $info_video \|}{ $icon_webcam $info_webcam \|}{ $icon_unknown $info_unknown \|}\"]</code> |
 //!
 //! # pipewire Options (requires the pipewire feature to be enabled)
 //!
@@ -46,7 +45,9 @@
 //!
 //! Action          | Description                               | Default button
 //! ----------------|-------------------------------------------|---------------
-//! `toggle_format` | Toggles between `format` and `format_alt` | Left
+//! `toggle_format` **DEPRECATED** | Toggles between `format` and `format_alt` | -
+//! `next_format`  | Switches to the next format in the list     | Left
+//! `prev_format`  | Switches to the previous format in the list | Right
 //!
 //! # Example
 //!
@@ -79,12 +80,9 @@ mod pipewire;
 mod v4l;
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
 pub struct Config {
-    #[serde(default)]
-    pub format: FormatConfig,
-    #[serde(default)]
-    pub format_alt: FormatConfig,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     pub driver: Vec<PrivacyDriver>,
 }
 
@@ -161,12 +159,19 @@ trait PrivacyMonitor {
 
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut actions = api.get_actions()?;
-    api.set_default_actions(&[(MouseButton::Left, None, "toggle_format")])?;
+    api.set_default_actions(&[
+        (MouseButton::Left, None, "next_format"),
+        (MouseButton::Right, None, "prev_format"),
+    ])?;
 
-    let mut format = config.format.with_default(
-        "{ $icon_audio |}{ $icon_audio_sink |}{ $icon_video |}{ $icon_webcam |}{ $icon_unknown |}",
-    )?;
-    let mut format_alt = config.format_alt.with_default("{ $icon_audio $info_audio |}{ $icon_audio_sink $info_audio_sink |}{ $icon_video $info_video |}{ $icon_webcam $info_webcam |}{ $icon_unknown $info_unknown |}")?;
+    let mut formats = config
+        .formats
+        .with_default_formats(&[
+            "{ $icon_audio |}{ $icon_audio_sink |}{ $icon_video |}{ $icon_webcam |}{ $icon_unknown |}"
+                .parse()?,
+            "{ $icon_audio $info_audio |}{ $icon_audio_sink $info_audio_sink |}{ $icon_video $info_video |}{ $icon_webcam $info_webcam |}{ $icon_unknown $info_unknown |}"
+                .parse()?
+        ]);
 
     let mut drivers: Vec<Box<dyn PrivacyMonitor + Send + Sync>> = Vec::new();
 
@@ -183,7 +188,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     }
 
     loop {
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = Widget::new().with_format(formats.get_format());
 
         let mut info = PrivacyInfo::default();
         //Merge driver info
@@ -240,8 +245,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             _ = api.wait_for_update_request() => (),
             _ = select_all(drivers.iter_mut().map(|driver| driver.wait_for_change())) =>(),
             Some(action) = actions.recv() => match action.as_ref() {
-                "toggle_format" => {
-                    std::mem::swap(&mut format_alt, &mut format);
+                "next_format" | "toggle_format" => {
+                    formats.next_format();
+                }
+                "prev_format" => {
+                    formats.prev_format();
                 }
                 _ => (),
             }

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -11,8 +11,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `driver` | `"auto"`, `pipewire`, `"pulseaudio"`, `"alsa"`. | `"auto"` (Pipewire with Pulseaudio fallback with ALSA fallback)
-//! `format` | A string to customise the output of this block. See below for available placeholders. | <code>\" $icon {$volume.eng(w:2) \|}\"</code>
-//! `format_alt` | If set, block will switch between `format` and `format_alt` on every click. | `None`
+//! `format` | A [MultiFormat][MaybeMultiFormatConfig] string to customise the output of this block. See below for available placeholders. | <code>[\" $icon {$volume.eng(w:2) \|}\"]</code>
 //! `name` | PulseAudio device name, or the ALSA control name as found in the output of `amixer -D yourdevice scontrols`. | PulseAudio: `@DEFAULT_SINK@` / ALSA: `Master`
 //! `device` | ALSA device name, usually in the form "hw:X" or "hw:X,Y" where `X` is the card number and `Y` is the device number as found in the output of `aplay -l`. | `default`
 //! `device_kind` | PulseAudio device kind: `source` or `sink`. | `"sink"`
@@ -35,10 +34,12 @@
 //!
 //! Action          | Default button
 //! ----------------|---------------
-//! `toggle_format` | Left
 //! `toggle_mute`   | Right
 //! `volume_down`   | Wheel Down
 //! `volume_up`     | Wheel Up
+//! `toggle_format` **DEPRECATED** | Toggles between `format` and `format_alt` | -
+//! `next_format`  | Switches to the next format in the list     | Left
+//! `prev_format`  | Switches to the previous format in the list | -
 //!
 //! # Examples
 //!
@@ -106,7 +107,7 @@ use indexmap::IndexMap;
 use regex::Regex;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
     pub driver: SoundDriver,
     pub name: Option<String>,
@@ -115,8 +116,8 @@ pub struct Config {
     pub natural_mapping: bool,
     #[default(5)]
     pub step_width: u32,
-    pub format: FormatConfig,
-    pub format_alt: Option<FormatConfig>,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     pub headphones_indicator: bool,
     pub show_volume_when_muted: bool,
     pub mappings: Option<IndexMap<String, String>>,
@@ -134,17 +135,13 @@ enum Mappings<'a> {
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
-        (MouseButton::Left, None, "toggle_format"),
+        (MouseButton::Left, None, "next_format"),
         (MouseButton::Right, None, "toggle_mute"),
         (MouseButton::WheelUp, None, "volume_up"),
         (MouseButton::WheelDown, None, "volume_down"),
     ])?;
 
-    let mut format = config.format.with_default(" $icon {$volume.eng(w:2)|} ")?;
-    let mut format_alt = match &config.format_alt {
-        Some(f) => Some(f.with_default("")?),
-        None => None,
-    };
+    let mut formats = config.formats.with_default(" $icon {$volume.eng(w:2)|} ")?;
 
     let device_kind = config.device_kind;
     let step_width = config.step_width.clamp(0, 50) as i32;
@@ -286,7 +283,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             [if let Some(ap) = active_port] "active_port" => Value::text(ap),
         };
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = Widget::new().with_format(formats.get_format());
 
         if muted {
             widget.state = State::Warning;
@@ -306,11 +303,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 }
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
-                    "toggle_format" => {
-                        if let Some(format_alt) = &mut format_alt {
-                            std::mem::swap(format_alt, &mut format);
-                            break;
-                        }
+                    "next_format" | "toggle_format" => {
+                        formats.next_format();
+                        break;
+                    }
+                    "prev_format" => {
+                        formats.prev_format();
+                        break;
                     }
                     "toggle_mute" => {
                         device.toggle().await?;

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -18,8 +18,7 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `format` | A string to customise the output of this block. See below for available placeholders | `" $icon $average avg, $max max "`
-//! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
+//! `format` | A [MultiFormat][MaybeMultiFormatConfig] string to customise the output of this block. See below for available placeholders | `[" $icon $average avg, $max max "]`
 //! `interval` | Update interval in seconds | `5`
 //! `scale` | Either `"celsius"` or `"fahrenheit"` | `"celsius"`
 //! `good` | Maximum temperature to set state to good | `20` °C (`68` °F)
@@ -31,7 +30,9 @@
 //!
 //! Action          | Description                               | Default button
 //! ----------------|-------------------------------------------|---------------
-//! `toggle_format` | Toggles between `format` and `format_alt` | Left
+//! `toggle_format` **DEPRECATED** | Toggles between `format` and `format_alt` | -
+//! `next_format`  | Switches to the next format in the list     | Left
+//! `prev_format`  | Switches to the previous format in the list | Right
 //!
 //! Placeholder | Value                                | Type   | Unit
 //! ------------|--------------------------------------|--------|--------
@@ -67,10 +68,10 @@ const DEFAULT_INFO: f64 = 60.0;
 const DEFAULT_WARN: f64 = 80.0;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
-    pub format: FormatConfig,
-    pub format_alt: Option<FormatConfig>,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     #[default(5.into())]
     pub interval: Seconds,
     pub scale: TemperatureScale,
@@ -109,15 +110,14 @@ impl TemperatureScale {
 
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut actions = api.get_actions()?;
-    api.set_default_actions(&[(MouseButton::Left, None, "toggle_format")])?;
+    api.set_default_actions(&[
+        (MouseButton::Left, None, "next_format"),
+        (MouseButton::Right, None, "prev_format"),
+    ])?;
 
-    let mut format = config
-        .format
+    let mut formats = config
+        .formats
         .with_default(" $icon $average avg, $max max ")?;
-    let mut format_alt = match &config.format_alt {
-        Some(f) => Some(f.with_default("")?),
-        None => None,
-    };
 
     let good = config
         .good
@@ -186,7 +186,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             .unwrap_or(0.0);
         let avg_temp = temp.iter().sum::<f64>() / temp.len() as f64;
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = Widget::new().with_format(formats.get_format());
 
         widget.state = match max_temp {
             x if x <= good => State::Good,
@@ -209,10 +209,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             _ = sleep(config.interval.0) => (),
             _ = api.wait_for_update_request() => (),
             Some(action) = actions.recv() => match action.as_ref() {
-                "toggle_format" => {
-                    if let Some(format_alt) = &mut format_alt {
-                        std::mem::swap(format_alt, &mut format);
-                    }
+                "next_format" | "toggle_format" => {
+                    formats.next_format();
+                }
+                "prev_format" => {
+                    formats.prev_format();
                 }
                 _ => (),
             }

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -4,7 +4,7 @@
 //!
 //! Key        | Values | Default
 //! -----------|--------|--------
-//! `format`   | Format string. See [chrono docs](https://docs.rs/chrono/0.3.0/chrono/format/strftime/index.html#specifiers) for all options. | `" $icon $timestamp.datetime() "`
+//! `format`   | [MultiFormat][MaybeMultiFormatConfig] string. See [chrono docs](https://docs.rs/chrono/0.3.0/chrono/format/strftime/index.html#specifiers) for all options. | `[" $icon $timestamp.datetime() "]`
 //! `interval` | Update interval in seconds | `10`
 //! `timezone` | A timezone specifier (e.g. "Europe/Lisbon") | Local timezone
 //!
@@ -17,6 +17,8 @@
 //! ----------------|---------------
 //! `next_timezone` | Left
 //! `prev_timezone` | Right
+//! `next_format`   | -
+//! `prev_format`   | -
 //!
 //! # Example
 //!
@@ -44,7 +46,7 @@
 //! [[block]]
 //! block = "time"
 //! interval = 60
-//! format = "$timestamp.datetime(locale:'fa_IR-u-ca-persian', f:'full', precision: minutes)"
+//! format = "$timestamp.datetime(locale:'fa-IR-u-ca-persian', f:'full', precision: minutes)"
 //! ```
 //!
 //! # Icons Used
@@ -56,9 +58,10 @@ use chrono_tz::Tz;
 use super::prelude::*;
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
-    pub format: FormatConfig,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     #[default(10.into())]
     pub interval: Seconds,
     pub timezone: Option<Timezone>,
@@ -78,8 +81,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         (MouseButton::Right, None, "prev_timezone"),
     ])?;
 
-    let format = config
-        .format
+    let mut formats = config
+        .formats
         .with_default(" $icon $timestamp.datetime() ")?;
 
     let timezones = match config.timezone.clone() {
@@ -105,7 +108,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = Widget::new().with_format(formats.get_format());
         let now = Utc::now();
 
         widget.set_values(map! {
@@ -129,6 +132,12 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 },
                 "prev_timezone" => {
                     timezone = timezone_iter.nth(prev_step_length);
+                },
+                "next_format" => {
+                    formats.next_format();
+                },
+                "prev_format" => {
+                   formats.prev_format();
                 },
                 _ => (),
             }

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -14,8 +14,7 @@
 //! Key | Values | Default
 //! ----|--------|--------
 //! `service` | The configuration of a weather service (see below). | **Required**
-//! `format` | A string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | `" $icon $weather $temp "`
-//! `format_alt` | If set, block will switch between `format` and `format_alt` on every click | `None`
+//! `format` | A [MultiFormat][MaybeMultiFormatConfig] string to customise the output of this block. See below for available placeholders. Text may need to be escaped, refer to [Escaping Text](#escaping-text). | `[" $icon $weather $temp "]`
 //! `interval` | Update interval, in seconds. | `600`
 //! `autolocate` | Gets your location using the ipapi.co IP location service (no API key required). If the API call fails then the block will fallback to service specific location config. | `false`
 //! `autolocate_interval` | Update interval for `autolocate` in seconds or "once" | `interval`
@@ -102,7 +101,9 @@
 //!
 //! Action          | Description                               | Default button
 //! ----------------|-------------------------------------------|---------------
-//! `toggle_format` | Toggles between `format` and `format_alt` | Left
+//! `toggle_format` **DEPRECATED** | Toggles between `format` and `format_alt` | -
+//! `next_format`  | Switches to the next format in the list     | Left
+//! `prev_format`  | Switches to the previous format in the list | Right
 //!
 //! # Examples
 //!
@@ -150,7 +151,7 @@ use chrono::{DateTime, Utc};
 use sunrise::{SolarDay, SolarEvent};
 
 use super::prelude::*;
-use crate::formatting::Format;
+use crate::formatting::{Format, MultiFormat};
 pub(super) use crate::geolocator::IPAddressInfo;
 use crate::util::{celsius_to_fahrenheit, kmh_to_mph, kmh_to_mps};
 
@@ -159,13 +160,11 @@ pub mod nws;
 pub mod open_weather_map;
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default = "default_interval")]
     pub interval: Seconds,
-    #[serde(default)]
-    pub format: FormatConfig,
-    pub format_alt: Option<FormatConfig>,
+    #[serde(flatten)]
+    pub formats: MaybeMultiFormatConfig,
     pub service: WeatherService,
     #[serde(default)]
     pub autolocate: bool,
@@ -426,13 +425,12 @@ impl Forecast {
 
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut actions = api.get_actions()?;
-    api.set_default_actions(&[(MouseButton::Left, None, "toggle_format")])?;
+    api.set_default_actions(&[
+        (MouseButton::Left, None, "next_format"),
+        (MouseButton::Right, None, "prev_format"),
+    ])?;
 
-    let mut format = config.format.with_default(" $icon $weather $temp ")?;
-    let mut format_alt = match &config.format_alt {
-        Some(f) => Some(f.with_default("")?),
-        None => None,
-    };
+    let mut formats = config.formats.with_default(" $icon $weather $temp ")?;
 
     let (provider, service_units): (Box<dyn WeatherProvider + Send + Sync>, UnitSystem) =
         match &config.service {
@@ -451,14 +449,14 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         };
     let units = config.units.unwrap_or(service_units);
 
-    let autolocate_interval = config.autolocate_interval.unwrap_or(config.interval);
-    let need_forecast = need_forecast(&format, format_alt.as_ref());
+    let autolocate_interval = config.autolocate_interval.unwrap_or(config.interval).0;
+    let need_forecast = need_forecast(&formats);
 
     let mut timer = config.interval.timer();
 
     loop {
         let location = if config.autolocate {
-            let fetch = || api.find_ip_location(&REQWEST_CLIENT, autolocate_interval.0);
+            let fetch = || api.find_ip_location(&REQWEST_CLIENT, autolocate_interval);
             Some(fetch.retry(ExponentialBuilder::default()).await?)
         } else {
             None
@@ -469,7 +467,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         let data_values = data.into_values(&units);
 
         loop {
-            let mut widget = Widget::new().with_format(format.clone());
+            let mut widget = Widget::new().with_format(formats.get_format());
             widget.set_values(data_values.clone());
             api.set_widget(widget)?;
 
@@ -477,10 +475,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = timer.tick() => break,
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
-                        "toggle_format" => {
-                            if let Some(ref mut format_alt) = format_alt {
-                                std::mem::swap(format_alt, &mut format);
-                            }
+                        "next_format" | "toggle_format" => {
+                            formats.next_format();
+                        }
+                        "prev_format" => {
+                            formats.prev_format();
                         }
                         _ => (),
                     }
@@ -489,7 +488,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     }
 }
 
-fn need_forecast(format: &Format, format_alt: Option<&Format>) -> bool {
+fn need_forecast(formats: &MultiFormat) -> bool {
     fn has_forecast_key(format: &Format) -> bool {
         macro_rules! format_suffix {
             ($($suffix: literal),* $(,)?) => {
@@ -510,7 +509,7 @@ fn need_forecast(format: &Format, format_alt: Option<&Format>) -> bool {
             || format.contains_key("weather_ffin")
             || format.contains_key("weather_verbose_ffin")
     }
-    has_forecast_key(format) || format_alt.is_some_and(has_forecast_key)
+    formats.iter().any(has_forecast_key)
 }
 
 fn calculate_sunrise_sunset(

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -142,6 +142,7 @@ pub mod value;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use crate::config::SharedConfig;
 use crate::errors::*;
@@ -162,6 +163,37 @@ pub enum FormatError {
     Other(#[from] Error),
 }
 
+#[derive(Debug)]
+pub struct MultiFormat {
+    // The length is always at least one, so we don't need to worry about
+    // dividing by zero when doing the modulo math to calculate the
+    // previous and next formats.
+    formats: Vec<Format>,
+    index: usize,
+}
+
+impl MultiFormat {
+    pub fn new(formats: Vec<Format>) -> Self {
+        Self { formats, index: 0 }
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, Format> {
+        self.formats.iter()
+    }
+
+    pub fn get_format(&self) -> Format {
+        self.formats[self.index].clone()
+    }
+
+    pub fn next_format(&mut self) {
+        self.index = (self.index + 1) % self.formats.len();
+    }
+
+    pub fn prev_format(&mut self) {
+        self.index = (self.index + (self.formats.len() - 1)) % self.formats.len();
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Format {
     full: FormatTemplate,
@@ -170,6 +202,18 @@ pub struct Format {
 }
 
 impl Format {
+    pub fn new(full: FormatTemplate, short: FormatTemplate) -> Self {
+        let mut intervals = Vec::new();
+        full.init_intervals(&mut intervals);
+        short.init_intervals(&mut intervals);
+
+        Self {
+            full,
+            short,
+            intervals,
+        }
+    }
+
     pub fn contains_key(&self, key: &str) -> bool {
         self.full.contains_key(key) || self.short.contains_key(key)
     }
@@ -192,6 +236,14 @@ impl Format {
             .render(values, config)
             .error("Failed to render short text")?;
         Ok((full, short))
+    }
+}
+
+impl FromStr for Format {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Ok(Self::new(s.parse()?, FormatTemplate::default()))
     }
 }
 

--- a/src/formatting/config.rs
+++ b/src/formatting/config.rs
@@ -1,7 +1,9 @@
-use super::{Format, template::FormatTemplate};
+use super::{Format, MultiFormat, template::FormatTemplate};
 use crate::errors::*;
+use itertools::Itertools as _;
 use serde::de::{MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, de};
+use smart_default::SmartDefault;
 use std::fmt;
 use std::str::FromStr;
 
@@ -27,15 +29,7 @@ impl Config {
             None => default_short.parse()?,
         };
 
-        let mut intervals = Vec::new();
-        full.init_intervals(&mut intervals);
-        short.init_intervals(&mut intervals);
-
-        Ok(Format {
-            full,
-            short,
-            intervals,
-        })
+        Ok(Format::new(full, short))
     }
 
     pub fn with_default_config(&self, default_config: &Self) -> Format {
@@ -50,15 +44,7 @@ impl Config {
             .or_else(|| default_config.short.clone())
             .unwrap_or_default();
 
-        let mut intervals = Vec::new();
-        full.init_intervals(&mut intervals);
-        short.init_intervals(&mut intervals);
-
-        Format {
-            full,
-            short,
-            intervals,
-        }
+        Format::new(full, short)
     }
 
     pub fn with_default_format(&self, default_format: &Format) -> Format {
@@ -71,15 +57,142 @@ impl Config {
             .clone()
             .unwrap_or_else(|| default_format.short.clone());
 
-        let mut intervals = Vec::new();
-        full.init_intervals(&mut intervals);
-        short.init_intervals(&mut intervals);
+        Format::new(full, short)
+    }
+}
 
-        Format {
-            full,
-            short,
-            intervals,
-        }
+impl From<Config> for Format {
+    fn from(config: Config) -> Self {
+        let full = config.full.unwrap_or_default();
+        let short = config.short.unwrap_or_default();
+
+        Format::new(full, short)
+    }
+}
+
+/// The [`MaybeMultiConfig`] type is used to represent a configuration that can either be a single [`Config`] or multiple [`Config`]s.
+///
+/// <div class="warning">
+/// Note: An empty list of configs is not allowed
+/// </div>
+///
+/// It is used to support different ways of specifying formats in the configuration file:
+///
+/// * A single format:
+/// ```toml
+/// [[block]]
+/// block = "xxx"
+/// format = "{layout}"
+/// ```
+///
+/// * A format and an alternative format:
+/// ```toml
+/// [[block]]
+/// block = "xxx"
+/// format = "{layout}"
+/// format_alt = "{layout^2}"
+/// ```
+///
+/// * A list of formats:
+/// ```toml
+/// [[block]]
+/// block = "xxx"
+/// format = ["{layout}"]
+/// ```
+///
+/// * A single format with full and short variants:
+/// ```toml
+/// [[block]]
+/// block = "xxx"
+/// [block.format]
+/// full = "{layout}"
+/// short = "{layout^2}"
+/// ```
+///
+/// * A format and an alternative format with full and short variants:
+/// ```toml
+/// [[block]]
+/// block = "xxx"
+/// [block.format]
+/// full = "{layout}"
+/// short = "{layout^2}"
+/// [block.format_alt]
+/// full = "{layout^3}"
+/// short = "{layout^4}"
+/// ```
+///
+/// * A list of formats with full and short variants:
+/// ```toml
+/// [[block]]
+/// block = "xxx"
+/// [[block.format]]
+/// full = "{layout}"
+/// short = "{layout^2}"
+/// ```
+#[derive(Debug, Clone, SmartDefault)]
+pub enum MaybeMultiConfig {
+    #[default]
+    Split {
+        config: Option<Config>,
+        config_alt: Option<Config>,
+    },
+    Multiple {
+        configs: Vec<Config>,
+    },
+}
+
+impl MaybeMultiConfig {
+    pub fn with_default(&self, default_full: &str) -> Result<MultiFormat> {
+        self.with_defaults(default_full, "")
+    }
+
+    pub fn with_defaults(&self, default_full: &str, default_short: &str) -> Result<MultiFormat> {
+        Ok(MultiFormat::new(match self.clone() {
+            MaybeMultiConfig::Multiple { configs } => configs
+                .into_iter()
+                .enumerate()
+                .map(|(i, config)| {
+                    if i == 0 {
+                        config.with_defaults(default_full, default_short)
+                    } else {
+                        Ok(config.into())
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?,
+            MaybeMultiConfig::Split { config, config_alt } => {
+                let mut formats = vec![
+                    config
+                        .unwrap_or_default()
+                        .with_defaults(default_full, default_short)?,
+                ];
+
+                if let Some(config_alt) = config_alt {
+                    formats.push(config_alt.into());
+                }
+                formats
+            }
+        }))
+    }
+
+    pub fn with_default_formats(&self, default_formats: &[Format]) -> MultiFormat {
+        MultiFormat::new(
+            match self.clone() {
+                MaybeMultiConfig::Multiple { configs } => configs,
+                MaybeMultiConfig::Split { config, config_alt } => {
+                    vec![config.unwrap_or_default(), config_alt.unwrap_or_default()]
+                }
+            }
+            .into_iter()
+            .zip_longest(default_formats)
+            .filter_map(|pair| match pair {
+                itertools::EitherOrBoth::Both(config, default_format) => {
+                    Some(config.with_default_format(default_format))
+                }
+                itertools::EitherOrBoth::Left(config) => Some(config.into()),
+                itertools::EitherOrBoth::Right(_) => None,
+            })
+            .collect(),
+        )
     }
 }
 
@@ -161,5 +274,97 @@ impl<'de> Deserialize<'de> for Config {
         }
 
         deserializer.deserialize_any(FormatTemplateVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for MaybeMultiConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum MaybeVecConfig {
+            Multiple(Vec<Config>),
+            Single(Config),
+        }
+
+        struct MaybeMultiConfigVisitor;
+
+        impl<'de> Visitor<'de> for MaybeMultiConfigVisitor {
+            type Value = MaybeMultiConfig;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("multiformat structure")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut format: Option<MaybeVecConfig> = None;
+                let mut format_alt: Option<Config> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "format" => {
+                            if format.is_some() {
+                                return Err(de::Error::duplicate_field("format"));
+                            }
+
+                            // This ensures Config deserialization errors are surfaced
+                            let maybe_vec_config = match map.next_value()? {
+                                serde_json::Value::Array(arr) => MaybeVecConfig::Multiple(
+                                    serde_json::from_value(serde_json::Value::Array(arr))
+                                        .serde_error()?,
+                                ),
+                                value => MaybeVecConfig::Single(
+                                    serde_json::from_value(value).serde_error()?,
+                                ),
+                            };
+                            format = Some(maybe_vec_config);
+                        }
+                        "format_alt" => {
+                            if format_alt.is_some() {
+                                return Err(de::Error::duplicate_field("format_alt"));
+                            }
+                            format_alt = Some(map.next_value()?);
+                        }
+                        unknown => {
+                            return Err(de::Error::unknown_field(
+                                unknown,
+                                &["format", "format_alt"],
+                            ));
+                        }
+                    }
+                }
+
+                match format {
+                    Some(MaybeVecConfig::Multiple(configs)) => {
+                        if format_alt.is_some() {
+                            return Err(de::Error::custom(
+                                "data did not match any variant of untagged enum MaybeMultiConfig",
+                            ));
+                        }
+                        if configs.is_empty() {
+                            return Err(de::Error::custom(
+                                "An empty list of configs is not allowed",
+                            ));
+                        }
+                        Ok(MaybeMultiConfig::Multiple { configs })
+                    }
+                    Some(MaybeVecConfig::Single(config)) => Ok(MaybeMultiConfig::Split {
+                        config: Some(config),
+                        config_alt: format_alt,
+                    }),
+                    None => Ok(MaybeMultiConfig::Split {
+                        config: None,
+                        config_alt: format_alt,
+                    }),
+                }
+            }
+        }
+
+        deserializer.deserialize_map(MaybeMultiConfigVisitor)
     }
 }


### PR DESCRIPTION
Currently this has only been applied to the time block, but any block that doesn't have formats for specific states/conditions could use this do allow one or more format, while still being able to continue using `format` and `format_alt`. (This could work as a fix to #2163)

One drawback about this is that I was unable to figure out how to be able to keep the `deny_unknown_fields` on the `Config`

This will allow configs to be specified in any of these ways:

```toml
[[block]]
block = "time"
[[block.click]]
button = "left"
action = "next_format"
[[block.click]]
button = "right"
action = "prev_format"

[[block]]
block = "time"
format = " $icon $timestamp.datetime(f:'%a %Y-%m-%d %R %z') "
[[block.click]]
button = "left"
action = "next_format"
[[block.click]]
button = "right"
action = "prev_format"

[[block]]
block = "time"
format = " $icon $timestamp.datetime(f:'%a %Y-%m-%d %R %z') "
format_alt = " $icon $timestamp.datetime(f:long, l:en-u-ca-hebrew-hc-h23)"
[[block.click]]
button = "left"
action = "next_format"
[[block.click]]
button = "right"
action = "prev_format"

[[block]]
block = "time"
format = [" $icon $timestamp.datetime(f:'%a %Y-%m-%d %R %z') ", " $icon $timestamp.datetime(f:long, l:en-u-ca-hebrew-hc-h23)"]
[[block.click]]
button = "left"
action = "next_format"
[[block.click]]
button = "right"
action = "prev_format"

[[block]]
block = "time"
[[block.format]]
full = " $icon $timestamp.datetime(f:'%a %Y-%m-%d %R %z') "
[[block.format]]
full = " $icon $timestamp.datetime(f:long, l:en-u-ca-hebrew-hc-h23)"
[[block.click]]
button = "left"
action = "next_format"
[[block.click]]
button = "right"
action = "prev_format"

[[block]]
block = "time"
testing = true
[block.format]
full = " $icon $timestamp.datetime(f:'%a %Y-%m-%d %R %z') "
[[block.click]]
button = "left"
action = "next_format"
[[block.click]]
button = "right"
action = "prev_format"
```