### PR TITLE
Omit line number for toml parse error for unknown spans

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -99,11 +99,15 @@ where
         let location_msg = err
             .span()
             .map(|span| {
-                let line = 1 + contents.as_bytes()[..(span.start)]
-                    .iter()
-                    .filter(|b| **b == b'\n')
-                    .count();
-                format!(" at line {line}")
+                if span == (0..0) {
+                    String::new()
+                } else {
+                    let line = 1 + contents.as_bytes()[..(span.start)]
+                        .iter()
+                        .filter(|b| **b == b'\n')
+                        .count();
+                    format!(" at line {line}")
+                }
             })
             .unwrap_or_default();
         Error::new(format!(


### PR DESCRIPTION
In the case that the span is (0..0), we don't usually know where the error really occurred. In that case just omit the line number. 

Of course the error really could be at the start of the file, but the error `unknown field XXX` should be easy enough to find and is less misleading than saying the error is on line 1, when it's not really.

Resolves: #2189

This error is tracked upstream:

* toml: https://github.com/toml-rs/toml/issues/589
* serde: https://github.com/serde-rs/serde/issues/1183