### PR TITLE
Disable landlock for pacman 7.1

### DIFF
--- a/src/blocks/packages/pacman.rs
+++ b/src/blocks/packages/pacman.rs
@@ -85,6 +85,7 @@ impl Backend for Pacman {
                 "--".as_ref(),
                 "pacman".as_ref(),
                 "-Sy".as_ref(),
+                "--disable-sandbox-filesystem".as_ref(),
                 "--dbpath".as_ref(),
                 PACMAN_UPDATES_DB.as_os_str(),
                 "--logfile".as_ref(),


### PR DESCRIPTION
Not disabling sandboxing leads to:
```
error: restricting filesystem access failed because the Landlock ruleset could not be applied: Operation not permitted
error: switching to sandbox user 'alpm' failed!
error: failed to synchronize all databases (failed to retrieve some files)
```