### PR TITLE
Add support for apk package manager to `packages` block

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -22,6 +22,7 @@ words:
   - amixer
   - apcupsd
   - aplay
+  - apk
   - armv
   - arphrd
   - backon

--- a/src/blocks/packages/apk.rs
+++ b/src/blocks/packages/apk.rs
@@ -1,0 +1,38 @@
+use tokio::process::Command;
+
+use super::*;
+
+#[derive(Default)]
+pub struct Apk;
+
+impl Apk {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+#[async_trait]
+impl Backend for Apk {
+    fn name(&self) -> Cow<'static, str> {
+        "apk".into()
+    }
+
+    async fn get_updates_list(&self) -> Result<Vec<String>> {
+        let stdout = Command::new("apk")
+            .env("LC_LANG", "C")
+            .args(["--no-cache", "-q", "list", "--upgradable"])
+            .output()
+            .await
+            .error("Problem running apk command")?
+            .stdout;
+
+        let updates = String::from_utf8(stdout).expect("apk produced non-UTF8 output");
+        let updates_list: Vec<String> = updates
+            .lines()
+            .filter(|line| line.len() > 1)
+            .map(|line| line.to_string())
+            .collect();
+
+        Ok(updates_list)
+    }
+}


### PR DESCRIPTION
Resolves: #2212

Manually tested it on an Alpine system that has no updates available, and one that has updates available.