### PR TITLE
Fix headphones indicator detection on PipeWire/WirePlumber

### DIFF
--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -160,11 +160,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 Some("headset") | Some("headphone") | Some("hands-free") | Some("portable") => true,
                 // Per discussion at
                 // https://github.com/greshake/i3status-rust/pull/1363#issuecomment-1046095869,
-                // some sinks may not have the form_factor property, so we should fall back to the
-                // active_port if that property is not present.
-                None => active_port.is_some_and(|p| p.to_lowercase().contains("headphones")),
-                // form_factor is present and is some non-headphone value
-                _ => false,
+                // fall back to checking active_port if form_factor is absent, unknown, or doesn't match
+                // known headphone values (common on PipeWire/WirePlumber systems).
+                _ => active_port
+                    .as_ref()
+                    .is_some_and(|p| p.to_lowercase().contains("headphone")),
             };
             if headphones {
                 return "headphones";


### PR DESCRIPTION
## Problem
The headphones indicator icon fails to appear on Linux systems using PipeWire/WirePlumber when `form_factor` is reported as `Unknown` or other unexpected values.

## Root Cause
The current logic only checks `active_port` as a fallback when `form_factor` is `None`. However, on many PipeWire setups, `form_factor` returns `Some("Unknown")` rather than `None`, causing the fallback to never trigger even when `active_port` correctly reports "analog-output-headphones".

## Solution
Extended the fallback logic to check `active_port` for all `form_factor` values that don't explicitly match known headphone types. This covers both `None` and unexpected values like `Unknown`.

## Changes
- Unified match arms to use wildcard pattern `_` for fallback
- Changed substring check from "headphones" to "headphone" to match both singular and plural port names
- Added `.as_ref()` to prevent moving `active_port` value

## Testing
Tested on PipeWire 1.4.9 with WirePlumber where `form_factor` reports as `Unknown` and `active_port` as "analog-output-headphones".