### PR TITLE
deps[nom]: bump to version 8.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
  "neli",
  "neli-wifi",
  "nix 0.29.0",
- "nom 7.1.3",
+ "nom 8.0.0",
  "notmuch",
  "num-traits",
  "oauth2",
@@ -1222,14 +1222,15 @@ dependencies = [
 
 [[package]]
 name = "icalendar"
-version = "0.16.9"
+version = "0.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2740e54a5de285fcc5eb7f97c75b4fb8842d807f62ecbbe716006676d6181"
+checksum = "48c81bcf05f183477037d33785dd7670d32170b7e96270a9e475c8adee0140a0"
 dependencies = [
  "chrono",
  "chrono-tz",
  "iso8601",
- "nom 7.1.3",
+ "nom 8.0.0",
+ "nom-language",
  "uuid",
 ]
 
@@ -1548,11 +1549,11 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "iso8601"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
- "nom 7.1.3",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -1886,6 +1887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
+dependencies = [
+ "nom 8.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ env_logger = "0.11"
 futures = { version = "0.3.31", default-features = false }
 glob = { version = "0.3.1", optional = true }
 iana-time-zone = "0.1.60"
-icalendar = { version = "0.16.2", features = ["chrono-tz"] }
+icalendar = { version = "0.16.12", features = ["chrono-tz"] }
 icu_calendar = { version = "1.3.0", optional = true }
 icu_datetime = { version = "1.3.0", optional = true }
 icu_locid = { version = "1.3.0", optional = true }
@@ -57,7 +57,7 @@ maildir = { version = "0.6", optional = true }
 neli = { version = "0.6", features = ["async"] }
 neli-wifi = { version = "0.6", features = ["async"] }
 nix = { version = "0.29", features = ["fs", "process"] }
-nom = "7.1.2"
+nom = "8.0.0"
 notmuch = { version = "0.8", optional = true }
 oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"] }
 num-traits = "0.2"

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -176,13 +176,13 @@ async fn get_monitors() -> Result<Vec<Monitor>> {
 
 mod parser {
     use super::*;
-    use nom::IResult;
     use nom::branch::alt;
     use nom::bytes::complete::{tag, take_until, take_while1};
     use nom::character::complete::{i32, space0, space1, u32};
     use nom::combinator::opt;
     use nom::number::complete::{double, float};
     use nom::sequence::preceded;
+    use nom::{IResult, Parser as _};
 
     /// Parses an output name, e.g. "HDMI-0", "eDP-1", etc.
     fn name(input: &str) -> IResult<&str, &str> {
@@ -207,8 +207,8 @@ mod parser {
     fn parse_output_header(input: &str) -> IResult<&str, (String, u32, u32, i32, i32)> {
         let (input, name) = name(input)?;
         let (input, _) = space1(input)?;
-        let (input, _) = alt((tag("connected"), tag("disconnected")))(input)?;
-        let (input, _) = opt(preceded(space1, tag("primary")))(input)?;
+        let (input, _) = alt((tag("connected"), tag("disconnected"))).parse(input)?;
+        let (input, _) = opt(preceded(space1, tag("primary"))).parse(input)?;
         let (input, _) = space1(input)?;
         let (input, (width, height, x, y)) = parse_mode_position(input)?;
         Ok((input, (name.to_owned(), width, height, x, y)))


### PR DESCRIPTION
Only `cexpr` depends on nom 7.x