### PR TITLE
change `COLOR_REGEX`

### DIFF
--- a/src/themes/xresources.rs
+++ b/src/themes/xresources.rs
@@ -20,7 +20,6 @@ fn read_xresources() -> std::io::Result<String> {
 #[cfg(test)]
 use tests::read_xresources;
 
-
 static COLOR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^\s*\*(?<name>[^: ]+)\s*:\s*(?<color>#[A-Fa-f0-9]{6,8}).*$").unwrap()
 });


### PR DESCRIPTION
Changed `COLOR_REGEX` to allow for it to read both upper-, and lowercase letters in HTML colorcodes in a `.Xresources` file.

I opened [an issue](https://github.com/greshake/i3status-rust/issues/2229) (#2229) about this, but I figured that it would be best to also propose a change for the matter.