### PR TITLE
dep[sunrise]: bump version to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,9 +2677,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sunrise"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0733c9f1eaa06ed6d103d88e21f784449d08a6733c2ca2b39381cbcbcfe89272"
+checksum = "15eecb5ec59a060dd9fe8f88c48b701abecd6be9d9c28d55081b80bdda73981c"
 dependencies = [
  "chrono",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ shellexpand = "3.0"
 signal-hook = "0.3"
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 smart-default = "0.7"
-sunrise = "2.1"
+sunrise = "3.0"
 swayipc-async = "3.0.0"
 thiserror = "2.0"
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/src/blocks/weather/open_weather_map.rs
+++ b/src/blocks/weather/open_weather_map.rs
@@ -275,11 +275,15 @@ impl WeatherProvider for Service<'_> {
 
         let current_weather = current_data.to_moment(self.units);
 
-        let sunrise = DateTime::<Utc>::from_timestamp(current_data.sys.sunrise, 0)
-            .error("Unable to convert timestamp to DateTime")?;
+        let sunrise = Some(
+            DateTime::<Utc>::from_timestamp(current_data.sys.sunrise, 0)
+                .error("Unable to convert timestamp to DateTime")?,
+        );
 
-        let sunset = DateTime::<Utc>::from_timestamp(current_data.sys.sunset, 0)
-            .error("Unable to convert timestamp to DateTime")?;
+        let sunset = Some(
+            DateTime::<Utc>::from_timestamp(current_data.sys.sunset, 0)
+                .error("Unable to convert timestamp to DateTime")?,
+        );
 
         if !need_forecast || self.forecast_hours == 0 {
             return Ok(WeatherResult {


### PR DESCRIPTION
https://github.com/nathan-osman/rust-sunrise/blob/2e7d1fd5d77ca753bd18ca914594ac391ccbe953/CHANGELOG.md#300

> ## 3.0.0
> 
>  - `SolarDay::event_time` now returns `None` on a polar day if the provided
  event never happens.

On polar days and polar nights, sunrise or sunset may not occur on a given day, and thus the corresponding value may be absent.
This behaviour depends on the weather service used.
For met.no and nws, both sunrise and sunset will be absent on polar days and polar nights, but OpenWeatherMap will show the same time for both sunrise and sunset.