### PR TITLE
Expand xresources color support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,8 @@ dependencies = [
  "notmuch",
  "num-traits",
  "oauth2",
+ "phf",
+ "phf_codegen",
  "pipewire",
  "quick-xml",
  "regex",
@@ -2044,6 +2046,26 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
+dependencies = [
+ "fastrand",
  "phf_shared",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,8 @@ dependencies = [
  "notmuch",
  "num-traits",
  "oauth2",
+ "phf",
+ "phf_codegen",
  "pipewire",
  "quick-xml",
  "regex",
@@ -1977,6 +1979,26 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
+dependencies = [
+ "fastrand",
  "phf_shared",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,9 @@ neli-wifi = { version = "0.6", features = ["async"] }
 nix = { version = "0.29", features = ["fs", "process"] }
 nom = "8.0.0"
 notmuch = { version = "0.8", optional = true }
-oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"] }
 num-traits = "0.2"
+oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"] }
+phf = { version = "0.12", default-features = false }
 pipewire = { version = "0.10", default-features = false, optional = true }
 quick-xml = { version = "0.37", features = ["serialize"] }
 regex = "1.5"
@@ -102,6 +103,10 @@ features = [
   "sync",
   "time",
 ]
+
+[build-dependencies]
+phf = { version = "0.12", default-features = false }
+phf_codegen = "0.12"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ nom = "8.0.0"
 notmuch = { version = "0.8", optional = true }
 num-traits = "0.2"
 oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"] }
+phf = { version = "0.12", default-features = false }
 pipewire = { version = "0.10", default-features = false, optional = true }
 quick-xml = { version = "0.37", features = ["serialize"] }
 regex = "1.5"
@@ -101,6 +102,10 @@ features = [
   "sync",
   "time",
 ]
+
+[build-dependencies]
+phf = { version = "0.12", default-features = false }
+phf_codegen = "0.12"
 
 [profile.release]
 lto = "thin"

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -3,8 +3,9 @@ language: en-US, en-GB
 allowCompoundWords: true
 ignorePaths:
   - _typos.toml
-  - target/
   - src/blocks/weather/met_no_legends.json
+  - src/themes/xorg-rgb.txt
+  - target/
   - testdata/
 ignoreRegExpList:
   # Ignore usernames that are @'d
@@ -37,6 +38,7 @@ words:
   - cbrt
   - ccache
   - chrono
+  - CIEXYZ
   - clippy
   - CLOEXEC
   - cmap
@@ -141,6 +143,7 @@ words:
   - reqwest
   - resolv
   - retval
+  - rgbi
   - rofi
   - rofication
   - rsplit
@@ -202,6 +205,7 @@ words:
   - xkbevent
   - xkbswitch
   - XKCD
+  - xorg
   - xrandr
   - xresources
   - xtask

--- a/src/themes/color.rs
+++ b/src/themes/color.rs
@@ -219,9 +219,6 @@ impl FromStr for Color {
         } else if color.starts_with("x:") {
             let name = color.split_at(2).1;
             super::xresources::get_color(name)?
-                .or_error(|| format!("color '{name}' not defined in ~/.Xresources"))?
-                .parse()
-                .or_error(|| format!("invalid color definition '{name}'"))?
         } else {
             let err_msg = || format!("'{color}' is not a valid RGBA color");
             let rgb = color.get(1..7).or_error(err_msg)?;

--- a/src/themes/xorg-rgb.txt
+++ b/src/themes/xorg-rgb.txt
@@ -1,0 +1,783 @@
+! from https://gitlab.freedesktop.org/xorg/app/rgb/raw/master/rgb.txt
+255 250 250		snow
+248 248 255		ghost white
+248 248 255		GhostWhite
+245 245 245		white smoke
+245 245 245		WhiteSmoke
+220 220 220		gainsboro
+255 250 240		floral white
+255 250 240		FloralWhite
+253 245 230		old lace
+253 245 230		OldLace
+250 240 230		linen
+250 235 215		antique white
+250 235 215		AntiqueWhite
+255 239 213		papaya whip
+255 239 213		PapayaWhip
+255 235 205		blanched almond
+255 235 205		BlanchedAlmond
+255 228 196		bisque
+255 218 185		peach puff
+255 218 185		PeachPuff
+255 222 173		navajo white
+255 222 173		NavajoWhite
+255 228 181		moccasin
+255 248 220		cornsilk
+255 255 240		ivory
+255 250 205		lemon chiffon
+255 250 205		LemonChiffon
+255 245 238		seashell
+240 255 240		honeydew
+245 255 250		mint cream
+245 255 250		MintCream
+240 255 255		azure
+240 248 255		alice blue
+240 248 255		AliceBlue
+230 230 250		lavender
+255 240 245		lavender blush
+255 240 245		LavenderBlush
+255 228 225		misty rose
+255 228 225		MistyRose
+255 255 255		white
+  0   0   0		black
+ 47  79  79		dark slate gray
+ 47  79  79		DarkSlateGray
+ 47  79  79		dark slate grey
+ 47  79  79		DarkSlateGrey
+105 105 105		dim gray
+105 105 105		DimGray
+105 105 105		dim grey
+105 105 105		DimGrey
+112 128 144		slate gray
+112 128 144		SlateGray
+112 128 144		slate grey
+112 128 144		SlateGrey
+119 136 153		light slate gray
+119 136 153		LightSlateGray
+119 136 153		light slate grey
+119 136 153		LightSlateGrey
+190 190 190		gray
+190 190 190		grey
+190 190 190		x11 gray
+190 190 190		X11Gray
+190 190 190		x11 grey
+190 190 190		X11Grey
+128 128 128		web gray
+128 128 128		WebGray
+128 128 128		web grey
+128 128 128		WebGrey
+211 211 211		light grey
+211 211 211		LightGrey
+211 211 211		light gray
+211 211 211		LightGray
+ 25  25 112		midnight blue
+ 25  25 112		MidnightBlue
+  0   0 128		navy
+  0   0 128		navy blue
+  0   0 128		NavyBlue
+100 149 237		cornflower blue
+100 149 237		CornflowerBlue
+ 72  61 139		dark slate blue
+ 72  61 139		DarkSlateBlue
+106  90 205		slate blue
+106  90 205		SlateBlue
+123 104 238		medium slate blue
+123 104 238		MediumSlateBlue
+132 112 255		light slate blue
+132 112 255		LightSlateBlue
+  0   0 205		medium blue
+  0   0 205		MediumBlue
+ 65 105 225		royal blue
+ 65 105 225		RoyalBlue
+  0   0 255		blue
+ 30 144 255		dodger blue
+ 30 144 255		DodgerBlue
+  0 191 255		deep sky blue
+  0 191 255		DeepSkyBlue
+135 206 235		sky blue
+135 206 235		SkyBlue
+135 206 250		light sky blue
+135 206 250		LightSkyBlue
+ 70 130 180		steel blue
+ 70 130 180		SteelBlue
+176 196 222		light steel blue
+176 196 222		LightSteelBlue
+173 216 230		light blue
+173 216 230		LightBlue
+176 224 230		powder blue
+176 224 230		PowderBlue
+175 238 238		pale turquoise
+175 238 238		PaleTurquoise
+  0 206 209		dark turquoise
+  0 206 209		DarkTurquoise
+ 72 209 204		medium turquoise
+ 72 209 204		MediumTurquoise
+ 64 224 208		turquoise
+  0 255 255		cyan
+  0 255 255		aqua
+224 255 255		light cyan
+224 255 255		LightCyan
+ 95 158 160		cadet blue
+ 95 158 160		CadetBlue
+102 205 170		medium aquamarine
+102 205 170		MediumAquamarine
+127 255 212		aquamarine
+  0 100   0		dark green
+  0 100   0		DarkGreen
+ 85 107  47		dark olive green
+ 85 107  47		DarkOliveGreen
+143 188 143		dark sea green
+143 188 143		DarkSeaGreen
+ 46 139  87		sea green
+ 46 139  87		SeaGreen
+ 60 179 113		medium sea green
+ 60 179 113		MediumSeaGreen
+ 32 178 170		light sea green
+ 32 178 170		LightSeaGreen
+152 251 152		pale green
+152 251 152		PaleGreen
+  0 255 127		spring green
+  0 255 127		SpringGreen
+124 252   0		lawn green
+124 252   0		LawnGreen
+  0 255   0		green
+  0 255   0		lime
+  0 255   0		x11 green
+  0 255   0		X11Green
+  0 128   0		web green
+  0 128   0		WebGreen
+127 255   0		chartreuse
+  0 250 154		medium spring green
+  0 250 154		MediumSpringGreen
+173 255  47		green yellow
+173 255  47		GreenYellow
+ 50 205  50		lime green
+ 50 205  50		LimeGreen
+154 205  50		yellow green
+154 205  50		YellowGreen
+ 34 139  34		forest green
+ 34 139  34		ForestGreen
+107 142  35		olive drab
+107 142  35		OliveDrab
+189 183 107		dark khaki
+189 183 107		DarkKhaki
+240 230 140		khaki
+238 232 170		pale goldenrod
+238 232 170		PaleGoldenrod
+250 250 210		light goldenrod yellow
+250 250 210		LightGoldenrodYellow
+255 255 224		light yellow
+255 255 224		LightYellow
+255 255   0		yellow
+255 215   0		gold
+238 221 130		light goldenrod
+238 221 130		LightGoldenrod
+218 165  32		goldenrod
+184 134  11		dark goldenrod
+184 134  11		DarkGoldenrod
+188 143 143		rosy brown
+188 143 143		RosyBrown
+205  92  92		indian red
+205  92  92		IndianRed
+139  69  19		saddle brown
+139  69  19		SaddleBrown
+160  82  45		sienna
+205 133  63		peru
+222 184 135		burlywood
+245 245 220		beige
+245 222 179		wheat
+244 164  96		sandy brown
+244 164  96		SandyBrown
+210 180 140		tan
+210 105  30		chocolate
+178  34  34		firebrick
+165  42  42		brown
+233 150 122		dark salmon
+233 150 122		DarkSalmon
+250 128 114		salmon
+255 160 122		light salmon
+255 160 122		LightSalmon
+255 165   0		orange
+255 140   0		dark orange
+255 140   0		DarkOrange
+255 127  80		coral
+240 128 128		light coral
+240 128 128		LightCoral
+255  99  71		tomato
+255  69   0		orange red
+255  69   0		OrangeRed
+255   0   0		red
+255 105 180		hot pink
+255 105 180		HotPink
+255  20 147		deep pink
+255  20 147		DeepPink
+255 192 203		pink
+255 182 193		light pink
+255 182 193		LightPink
+219 112 147		pale violet red
+219 112 147		PaleVioletRed
+176  48  96		maroon
+176  48  96		x11 maroon
+176  48  96		X11Maroon
+128   0   0		web maroon
+128   0   0		WebMaroon
+199  21 133		medium violet red
+199  21 133		MediumVioletRed
+208  32 144		violet red
+208  32 144		VioletRed
+255   0 255		magenta
+255   0 255		fuchsia
+238 130 238		violet
+221 160 221		plum
+218 112 214		orchid
+186  85 211		medium orchid
+186  85 211		MediumOrchid
+153  50 204		dark orchid
+153  50 204		DarkOrchid
+148   0 211		dark violet
+148   0 211		DarkViolet
+138  43 226		blue violet
+138  43 226		BlueViolet
+160  32 240		purple
+160  32 240		x11 purple
+160  32 240		X11Purple
+128   0 128		web purple
+128   0 128		WebPurple
+147 112 219		medium purple
+147 112 219		MediumPurple
+216 191 216		thistle
+255 250 250		snow1
+238 233 233		snow2
+205 201 201		snow3
+139 137 137		snow4
+255 245 238		seashell1
+238 229 222		seashell2
+205 197 191		seashell3
+139 134 130		seashell4
+255 239 219		AntiqueWhite1
+238 223 204		AntiqueWhite2
+205 192 176		AntiqueWhite3
+139 131 120		AntiqueWhite4
+255 228 196		bisque1
+238 213 183		bisque2
+205 183 158		bisque3
+139 125 107		bisque4
+255 218 185		PeachPuff1
+238 203 173		PeachPuff2
+205 175 149		PeachPuff3
+139 119 101		PeachPuff4
+255 222 173		NavajoWhite1
+238 207 161		NavajoWhite2
+205 179 139		NavajoWhite3
+139 121  94		NavajoWhite4
+255 250 205		LemonChiffon1
+238 233 191		LemonChiffon2
+205 201 165		LemonChiffon3
+139 137 112		LemonChiffon4
+255 248 220		cornsilk1
+238 232 205		cornsilk2
+205 200 177		cornsilk3
+139 136 120		cornsilk4
+255 255 240		ivory1
+238 238 224		ivory2
+205 205 193		ivory3
+139 139 131		ivory4
+240 255 240		honeydew1
+224 238 224		honeydew2
+193 205 193		honeydew3
+131 139 131		honeydew4
+255 240 245		LavenderBlush1
+238 224 229		LavenderBlush2
+205 193 197		LavenderBlush3
+139 131 134		LavenderBlush4
+255 228 225		MistyRose1
+238 213 210		MistyRose2
+205 183 181		MistyRose3
+139 125 123		MistyRose4
+240 255 255		azure1
+224 238 238		azure2
+193 205 205		azure3
+131 139 139		azure4
+131 111 255		SlateBlue1
+122 103 238		SlateBlue2
+105  89 205		SlateBlue3
+ 71  60 139		SlateBlue4
+ 72 118 255		RoyalBlue1
+ 67 110 238		RoyalBlue2
+ 58  95 205		RoyalBlue3
+ 39  64 139		RoyalBlue4
+  0   0 255		blue1
+  0   0 238		blue2
+  0   0 205		blue3
+  0   0 139		blue4
+ 30 144 255		DodgerBlue1
+ 28 134 238		DodgerBlue2
+ 24 116 205		DodgerBlue3
+ 16  78 139		DodgerBlue4
+ 99 184 255		SteelBlue1
+ 92 172 238		SteelBlue2
+ 79 148 205		SteelBlue3
+ 54 100 139		SteelBlue4
+  0 191 255		DeepSkyBlue1
+  0 178 238		DeepSkyBlue2
+  0 154 205		DeepSkyBlue3
+  0 104 139		DeepSkyBlue4
+135 206 255		SkyBlue1
+126 192 238		SkyBlue2
+108 166 205		SkyBlue3
+ 74 112 139		SkyBlue4
+176 226 255		LightSkyBlue1
+164 211 238		LightSkyBlue2
+141 182 205		LightSkyBlue3
+ 96 123 139		LightSkyBlue4
+198 226 255		SlateGray1
+185 211 238		SlateGray2
+159 182 205		SlateGray3
+108 123 139		SlateGray4
+202 225 255		LightSteelBlue1
+188 210 238		LightSteelBlue2
+162 181 205		LightSteelBlue3
+110 123 139		LightSteelBlue4
+191 239 255		LightBlue1
+178 223 238		LightBlue2
+154 192 205		LightBlue3
+104 131 139		LightBlue4
+224 255 255		LightCyan1
+209 238 238		LightCyan2
+180 205 205		LightCyan3
+122 139 139		LightCyan4
+187 255 255		PaleTurquoise1
+174 238 238		PaleTurquoise2
+150 205 205		PaleTurquoise3
+102 139 139		PaleTurquoise4
+152 245 255		CadetBlue1
+142 229 238		CadetBlue2
+122 197 205		CadetBlue3
+ 83 134 139		CadetBlue4
+  0 245 255		turquoise1
+  0 229 238		turquoise2
+  0 197 205		turquoise3
+  0 134 139		turquoise4
+  0 255 255		cyan1
+  0 238 238		cyan2
+  0 205 205		cyan3
+  0 139 139		cyan4
+151 255 255		DarkSlateGray1
+141 238 238		DarkSlateGray2
+121 205 205		DarkSlateGray3
+ 82 139 139		DarkSlateGray4
+127 255 212		aquamarine1
+118 238 198		aquamarine2
+102 205 170		aquamarine3
+ 69 139 116		aquamarine4
+193 255 193		DarkSeaGreen1
+180 238 180		DarkSeaGreen2
+155 205 155		DarkSeaGreen3
+105 139 105		DarkSeaGreen4
+ 84 255 159		SeaGreen1
+ 78 238 148		SeaGreen2
+ 67 205 128		SeaGreen3
+ 46 139  87		SeaGreen4
+154 255 154		PaleGreen1
+144 238 144		PaleGreen2
+124 205 124		PaleGreen3
+ 84 139  84		PaleGreen4
+  0 255 127		SpringGreen1
+  0 238 118		SpringGreen2
+  0 205 102		SpringGreen3
+  0 139  69		SpringGreen4
+  0 255   0		green1
+  0 238   0		green2
+  0 205   0		green3
+  0 139   0		green4
+127 255   0		chartreuse1
+118 238   0		chartreuse2
+102 205   0		chartreuse3
+ 69 139   0		chartreuse4
+192 255  62		OliveDrab1
+179 238  58		OliveDrab2
+154 205  50		OliveDrab3
+105 139  34		OliveDrab4
+202 255 112		DarkOliveGreen1
+188 238 104		DarkOliveGreen2
+162 205  90		DarkOliveGreen3
+110 139  61		DarkOliveGreen4
+255 246 143		khaki1
+238 230 133		khaki2
+205 198 115		khaki3
+139 134  78		khaki4
+255 236 139		LightGoldenrod1
+238 220 130		LightGoldenrod2
+205 190 112		LightGoldenrod3
+139 129  76		LightGoldenrod4
+255 255 224		LightYellow1
+238 238 209		LightYellow2
+205 205 180		LightYellow3
+139 139 122		LightYellow4
+255 255   0		yellow1
+238 238   0		yellow2
+205 205   0		yellow3
+139 139   0		yellow4
+255 215   0		gold1
+238 201   0		gold2
+205 173   0		gold3
+139 117   0		gold4
+255 193  37		goldenrod1
+238 180  34		goldenrod2
+205 155  29		goldenrod3
+139 105  20		goldenrod4
+255 185  15		DarkGoldenrod1
+238 173  14		DarkGoldenrod2
+205 149  12		DarkGoldenrod3
+139 101   8		DarkGoldenrod4
+255 193 193		RosyBrown1
+238 180 180		RosyBrown2
+205 155 155		RosyBrown3
+139 105 105		RosyBrown4
+255 106 106		IndianRed1
+238  99  99		IndianRed2
+205  85  85		IndianRed3
+139  58  58		IndianRed4
+255 130  71		sienna1
+238 121  66		sienna2
+205 104  57		sienna3
+139  71  38		sienna4
+255 211 155		burlywood1
+238 197 145		burlywood2
+205 170 125		burlywood3
+139 115  85		burlywood4
+255 231 186		wheat1
+238 216 174		wheat2
+205 186 150		wheat3
+139 126 102		wheat4
+255 165  79		tan1
+238 154  73		tan2
+205 133  63		tan3
+139  90  43		tan4
+255 127  36		chocolate1
+238 118  33		chocolate2
+205 102  29		chocolate3
+139  69  19		chocolate4
+255  48  48		firebrick1
+238  44  44		firebrick2
+205  38  38		firebrick3
+139  26  26		firebrick4
+255  64  64		brown1
+238  59  59		brown2
+205  51  51		brown3
+139  35  35		brown4
+255 140 105		salmon1
+238 130  98		salmon2
+205 112  84		salmon3
+139  76  57		salmon4
+255 160 122		LightSalmon1
+238 149 114		LightSalmon2
+205 129  98		LightSalmon3
+139  87  66		LightSalmon4
+255 165   0		orange1
+238 154   0		orange2
+205 133   0		orange3
+139  90   0		orange4
+255 127   0		DarkOrange1
+238 118   0		DarkOrange2
+205 102   0		DarkOrange3
+139  69   0		DarkOrange4
+255 114  86		coral1
+238 106  80		coral2
+205  91  69		coral3
+139  62  47		coral4
+255  99  71		tomato1
+238  92  66		tomato2
+205  79  57		tomato3
+139  54  38		tomato4
+255  69   0		OrangeRed1
+238  64   0		OrangeRed2
+205  55   0		OrangeRed3
+139  37   0		OrangeRed4
+255   0   0		red1
+238   0   0		red2
+205   0   0		red3
+139   0   0		red4
+255  20 147		DeepPink1
+238  18 137		DeepPink2
+205  16 118		DeepPink3
+139  10  80		DeepPink4
+255 110 180		HotPink1
+238 106 167		HotPink2
+205  96 144		HotPink3
+139  58  98		HotPink4
+255 181 197		pink1
+238 169 184		pink2
+205 145 158		pink3
+139  99 108		pink4
+255 174 185		LightPink1
+238 162 173		LightPink2
+205 140 149		LightPink3
+139  95 101		LightPink4
+255 130 171		PaleVioletRed1
+238 121 159		PaleVioletRed2
+205 104 137		PaleVioletRed3
+139  71  93		PaleVioletRed4
+255  52 179		maroon1
+238  48 167		maroon2
+205  41 144		maroon3
+139  28  98		maroon4
+255  62 150		VioletRed1
+238  58 140		VioletRed2
+205  50 120		VioletRed3
+139  34  82		VioletRed4
+255   0 255		magenta1
+238   0 238		magenta2
+205   0 205		magenta3
+139   0 139		magenta4
+255 131 250		orchid1
+238 122 233		orchid2
+205 105 201		orchid3
+139  71 137		orchid4
+255 187 255		plum1
+238 174 238		plum2
+205 150 205		plum3
+139 102 139		plum4
+224 102 255		MediumOrchid1
+209  95 238		MediumOrchid2
+180  82 205		MediumOrchid3
+122  55 139		MediumOrchid4
+191  62 255		DarkOrchid1
+178  58 238		DarkOrchid2
+154  50 205		DarkOrchid3
+104  34 139		DarkOrchid4
+155  48 255		purple1
+145  44 238		purple2
+125  38 205		purple3
+ 85  26 139		purple4
+171 130 255		MediumPurple1
+159 121 238		MediumPurple2
+137 104 205		MediumPurple3
+ 93  71 139		MediumPurple4
+255 225 255		thistle1
+238 210 238		thistle2
+205 181 205		thistle3
+139 123 139		thistle4
+  0   0   0		gray0
+  0   0   0		grey0
+  3   3   3		gray1
+  3   3   3		grey1
+  5   5   5		gray2
+  5   5   5		grey2
+  8   8   8		gray3
+  8   8   8		grey3
+ 10  10  10		gray4
+ 10  10  10		grey4
+ 13  13  13		gray5
+ 13  13  13		grey5
+ 15  15  15		gray6
+ 15  15  15		grey6
+ 18  18  18		gray7
+ 18  18  18		grey7
+ 20  20  20		gray8
+ 20  20  20		grey8
+ 23  23  23		gray9
+ 23  23  23		grey9
+ 26  26  26		gray10
+ 26  26  26		grey10
+ 28  28  28		gray11
+ 28  28  28		grey11
+ 31  31  31		gray12
+ 31  31  31		grey12
+ 33  33  33		gray13
+ 33  33  33		grey13
+ 36  36  36		gray14
+ 36  36  36		grey14
+ 38  38  38		gray15
+ 38  38  38		grey15
+ 41  41  41		gray16
+ 41  41  41		grey16
+ 43  43  43		gray17
+ 43  43  43		grey17
+ 46  46  46		gray18
+ 46  46  46		grey18
+ 48  48  48		gray19
+ 48  48  48		grey19
+ 51  51  51		gray20
+ 51  51  51		grey20
+ 54  54  54		gray21
+ 54  54  54		grey21
+ 56  56  56		gray22
+ 56  56  56		grey22
+ 59  59  59		gray23
+ 59  59  59		grey23
+ 61  61  61		gray24
+ 61  61  61		grey24
+ 64  64  64		gray25
+ 64  64  64		grey25
+ 66  66  66		gray26
+ 66  66  66		grey26
+ 69  69  69		gray27
+ 69  69  69		grey27
+ 71  71  71		gray28
+ 71  71  71		grey28
+ 74  74  74		gray29
+ 74  74  74		grey29
+ 77  77  77		gray30
+ 77  77  77		grey30
+ 79  79  79		gray31
+ 79  79  79		grey31
+ 82  82  82		gray32
+ 82  82  82		grey32
+ 84  84  84		gray33
+ 84  84  84		grey33
+ 87  87  87		gray34
+ 87  87  87		grey34
+ 89  89  89		gray35
+ 89  89  89		grey35
+ 92  92  92		gray36
+ 92  92  92		grey36
+ 94  94  94		gray37
+ 94  94  94		grey37
+ 97  97  97		gray38
+ 97  97  97		grey38
+ 99  99  99		gray39
+ 99  99  99		grey39
+102 102 102		gray40
+102 102 102		grey40
+105 105 105		gray41
+105 105 105		grey41
+107 107 107		gray42
+107 107 107		grey42
+110 110 110		gray43
+110 110 110		grey43
+112 112 112		gray44
+112 112 112		grey44
+115 115 115		gray45
+115 115 115		grey45
+117 117 117		gray46
+117 117 117		grey46
+120 120 120		gray47
+120 120 120		grey47
+122 122 122		gray48
+122 122 122		grey48
+125 125 125		gray49
+125 125 125		grey49
+127 127 127		gray50
+127 127 127		grey50
+130 130 130		gray51
+130 130 130		grey51
+133 133 133		gray52
+133 133 133		grey52
+135 135 135		gray53
+135 135 135		grey53
+138 138 138		gray54
+138 138 138		grey54
+140 140 140		gray55
+140 140 140		grey55
+143 143 143		gray56
+143 143 143		grey56
+145 145 145		gray57
+145 145 145		grey57
+148 148 148		gray58
+148 148 148		grey58
+150 150 150		gray59
+150 150 150		grey59
+153 153 153		gray60
+153 153 153		grey60
+156 156 156		gray61
+156 156 156		grey61
+158 158 158		gray62
+158 158 158		grey62
+161 161 161		gray63
+161 161 161		grey63
+163 163 163		gray64
+163 163 163		grey64
+166 166 166		gray65
+166 166 166		grey65
+168 168 168		gray66
+168 168 168		grey66
+171 171 171		gray67
+171 171 171		grey67
+173 173 173		gray68
+173 173 173		grey68
+176 176 176		gray69
+176 176 176		grey69
+179 179 179		gray70
+179 179 179		grey70
+181 181 181		gray71
+181 181 181		grey71
+184 184 184		gray72
+184 184 184		grey72
+186 186 186		gray73
+186 186 186		grey73
+189 189 189		gray74
+189 189 189		grey74
+191 191 191		gray75
+191 191 191		grey75
+194 194 194		gray76
+194 194 194		grey76
+196 196 196		gray77
+196 196 196		grey77
+199 199 199		gray78
+199 199 199		grey78
+201 201 201		gray79
+201 201 201		grey79
+204 204 204		gray80
+204 204 204		grey80
+207 207 207		gray81
+207 207 207		grey81
+209 209 209		gray82
+209 209 209		grey82
+212 212 212		gray83
+212 212 212		grey83
+214 214 214		gray84
+214 214 214		grey84
+217 217 217		gray85
+217 217 217		grey85
+219 219 219		gray86
+219 219 219		grey86
+222 222 222		gray87
+222 222 222		grey87
+224 224 224		gray88
+224 224 224		grey88
+227 227 227		gray89
+227 227 227		grey89
+229 229 229		gray90
+229 229 229		grey90
+232 232 232		gray91
+232 232 232		grey91
+235 235 235		gray92
+235 235 235		grey92
+237 237 237		gray93
+237 237 237		grey93
+240 240 240		gray94
+240 240 240		grey94
+242 242 242		gray95
+242 242 242		grey95
+245 245 245		gray96
+245 245 245		grey96
+247 247 247		gray97
+247 247 247		grey97
+250 250 250		gray98
+250 250 250		grey98
+252 252 252		gray99
+252 252 252		grey99
+255 255 255		gray100
+255 255 255		grey100
+169 169 169		dark grey
+169 169 169		DarkGrey
+169 169 169		dark gray
+169 169 169		DarkGray
+  0   0 139		dark blue
+  0   0 139		DarkBlue
+  0 139 139		dark cyan
+  0 139 139		DarkCyan
+139   0 139		dark magenta
+139   0 139		DarkMagenta
+139   0   0		dark red
+139   0   0		DarkRed
+144 238 144		light green
+144 238 144		LightGreen
+220  20  60		crimson
+ 75   0 130		indigo
+128 128   0		olive
+102  51 153		rebecca purple
+102  51 153		RebeccaPurple
+192 192 192		silver
+  0 128 128		teal

--- a/src/themes/xresources.rs
+++ b/src/themes/xresources.rs
@@ -1,10 +1,12 @@
-use log::debug;
 use regex::Regex;
 
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use crate::errors::*;
+use crate::themes::color::{Color, Rgba};
+
+make_log_macro!(debug, "xresources");
 
 #[cfg(not(test))]
 use std::{env, path::PathBuf};
@@ -20,74 +22,325 @@ fn read_xresources() -> std::io::Result<String> {
 #[cfg(test)]
 use tests::read_xresources;
 
-static COLOR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^\s*\*(?<name>[^: ]+)\s*:\s*(?<color>#[A-Fa-f0-9]{6,8}).*$").unwrap()
-});
+// Defines: static XORG_COLORS: ::phf::Map<&'static str, Color>
+include!(concat!(env!("OUT_DIR"), "/xorg_rgb_codegen.rs"));
 
-static COLORS: LazyLock<Result<HashMap<String, String>, Error>> = LazyLock::new(|| {
+static COLORS: LazyLock<Result<HashMap<String, Result<Color>>>> = LazyLock::new(|| {
+    let regex =
+        Regex::new(r"^(\s*\*|#define\s+)(?<name>[^:\s]+)\s*:?\s*(?<color>[^\n]*).*$").unwrap();
     let content = read_xresources().error("could not read .Xresources")?;
     debug!(".Xresources content:\n{}", content);
-    Ok(HashMap::from_iter(content.lines().filter_map(|line| {
-        COLOR_REGEX
-            .captures(line)
-            .map(|caps| (caps["name"].to_string(), caps["color"].to_string()))
-    })))
+    let mut color_map: HashMap<String, Result<Color>> = HashMap::new();
+    for line in content.lines() {
+        let Some(caps) = regex.captures(line) else {
+            continue;
+        };
+
+        let name = caps["name"].to_lowercase();
+        let color_str = caps["color"].trim();
+        let hex_err_msg = || format!("'{color_str}' is not a valid RGB color");
+        let color = if let Some(color_hex) = color_str.strip_prefix('#') {
+            if color_hex.len() == 3 {
+                let r = u8::from_str_radix(&color_hex[0..1], 16).or_error(hex_err_msg)? << 4;
+                let g = u8::from_str_radix(&color_hex[1..2], 16).or_error(hex_err_msg)? << 4;
+                let b = u8::from_str_radix(&color_hex[2..3], 16).or_error(hex_err_msg)? << 4;
+                Ok(Color::Rgba(Rgba { r, g, b, a: 255 }))
+            } else if color_hex.len() == 6 {
+                Ok(Color::Rgba(Rgba::from_hex(
+                    (u32::from_str_radix(color_hex, 16).or_error(hex_err_msg)? << 8) + 255,
+                )))
+            } else if color_hex.len() == 9 {
+                let r = (u16::from_str_radix(&color_hex[0..3], 16).or_error(hex_err_msg)? as f64
+                    / 4095.0
+                    * 255.0)
+                    .round() as u8;
+                let g = (u16::from_str_radix(&color_hex[3..6], 16).or_error(hex_err_msg)? as f64
+                    / 4095.0
+                    * 255.0)
+                    .round() as u8;
+                let b = (u16::from_str_radix(&color_hex[6..9], 16).or_error(hex_err_msg)? as f64
+                    / 4095.0
+                    * 255.0)
+                    .round() as u8;
+                Ok(Color::Rgba(Rgba { r, g, b, a: 255 }))
+            } else if color_hex.len() == 12 {
+                let r = (u16::from_str_radix(&color_hex[0..4], 16).or_error(hex_err_msg)? as f64
+                    / 65535.0
+                    * 255.0)
+                    .round() as u8;
+                let g = (u16::from_str_radix(&color_hex[4..8], 16).or_error(hex_err_msg)? as f64
+                    / 65535.0
+                    * 255.0)
+                    .round() as u8;
+                let b = (u16::from_str_radix(&color_hex[8..12], 16).or_error(hex_err_msg)? as f64
+                    / 65535.0
+                    * 255.0)
+                    .round() as u8;
+                Ok(Color::Rgba(Rgba { r, g, b, a: 255 }))
+            } else {
+                Err(Error::new(format!(
+                    "color '{name}' has an invalid length hex code: '{color_str}'"
+                )))
+            }
+        } else if let Some((color_space, color_values)) = color_str.split_once(":") {
+            let mut color_value_split = color_values.split("/");
+            let cv1 = color_value_split
+                .next()
+                .error("Not enough / separated values")?;
+            let cv2 = color_value_split
+                .next()
+                .error("Not enough / separated values")?;
+            let cv3 = color_value_split
+                .next()
+                .error("Not enough / separated values")?;
+            match color_space {
+                "rgb" => {
+                    let r = ((u16::from_str_radix(cv1, 16).or_error(hex_err_msg)? as f64)
+                        / (((1 << (4 * cv1.len())) - 1) as f64)
+                        * 255.0)
+                        .round() as u8;
+                    let g = ((u16::from_str_radix(cv2, 16).or_error(hex_err_msg)? as f64)
+                        / (((1 << (4 * cv2.len())) - 1) as f64)
+                        * 255.0)
+                        .round() as u8;
+                    let b = ((u16::from_str_radix(cv3, 16).or_error(hex_err_msg)? as f64)
+                        / (((1 << (4 * cv3.len())) - 1) as f64)
+                        * 255.0)
+                        .round() as u8;
+                    Ok(Color::Rgba(Rgba { r, g, b, a: 255 }))
+                }
+                "rgbi" => {
+                    let r =
+                        (255.0 * cv1.parse::<f64>().error("red value is not a valid float")?) as u8;
+                    let g = (255.0
+                        * cv2
+                            .parse::<f64>()
+                            .error("green value is not a valid float")?)
+                        as u8;
+                    let b = (255.0
+                        * cv3
+                            .parse::<f64>()
+                            .error("blue value is not a valid float")?)
+                        as u8;
+
+                    Ok(Color::Rgba(Rgba { r, g, b, a: 255 }))
+                }
+                "CIEXYZ" | "CIEuvY" | "CIExyY" | "CIELab" | "CIELuv" | "TekHVC" => Err(Error::new(
+                    format!("color '{name}' is in an unimplemented color space '{color_space}'"),
+                )),
+                _ => Err(Error::new(format!(
+                    "color '{name}' is in an unrecognized color space '{color_space}'"
+                ))),
+            }
+        } else {
+            let color_str = color_str.to_lowercase();
+            if let Some(res) = color_map.get(&color_str) {
+                res.clone()
+            } else if let Some(color) = XORG_COLORS.get(&color_str) {
+                Ok(*color)
+            } else {
+                Err(Error::new(format!(
+                    "unable to resolve '{color_str}' for color '{name}'"
+                )))
+            }
+        };
+        color_map.insert(name, color);
+    }
+
+    Ok(color_map)
 });
 
-pub fn get_color(name: &str) -> Result<Option<&String>, Error> {
-    COLORS
-        .as_ref()
-        .map(|cmap| cmap.get(name))
-        .map_err(Clone::clone)
+pub fn get_color(name: &str) -> Result<Color> {
+    let name = name.to_lowercase();
+    COLORS.as_ref().map_err(Clone::clone).and_then(|cmap| {
+        if let Some(res) = cmap.get(&name) {
+            res.clone()
+        } else if let Some(color) = XORG_COLORS.get(&name) {
+            Ok(*color)
+        } else {
+            Err(Error::new(format!(
+                "color '{name}' not defined in ~/.Xresources"
+            )))
+        }
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Result;
 
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn read_xresources() -> Result<String> {
-        static XRESOURCES: &str = "\
-        ! this is a comment\n\
-        \n\
-        *color4 : #feedda\n\
-    \n\
-        *background: #ee33aa99\n\
-        ";
+    pub(crate) fn read_xresources() -> std::io::Result<String> {
+        static XRESOURCES: &str = include_str!("../../testdata/xresources.txt");
         Ok(XRESOURCES.to_string())
     }
 
     #[test]
-    fn test_reading_colors() {
-        let colors = COLORS.as_ref().unwrap();
-        assert_eq!(colors.get("color4"), Some(&"#feedda".to_string()));
-        assert_eq!(colors.get("background"), Some(&"#ee33aa99".to_string()));
-        assert_eq!(2, colors.len());
+    fn test_xorg_defined_color() {
+        assert_eq!(
+            get_color("lemonchiffon").unwrap(),
+            "#fffacd".parse::<Color>().unwrap()
+        );
+
+        assert_eq!(
+            get_color("LemonChiffon").unwrap(),
+            "#fffacd".parse::<Color>().unwrap()
+        );
+
+        assert_eq!(
+            get_color("Lemon Chiffon").unwrap(),
+            "#fffacd".parse::<Color>().unwrap()
+        );
     }
 
     #[test]
-    fn test_deserializing_xcolors() {
-        use super::super::color::*;
-        let mut parsed_color = "x:color4".parse::<Color>().unwrap();
+    fn test_color_ref_to_xorg_defined_color() {
         assert_eq!(
-            parsed_color,
-            Color::Rgba(Rgba {
-                r: 254,
-                g: 237,
-                b: 218,
-                a: 255
-            })
+            get_color("color0").unwrap(),
+            "#fffacd".parse::<Color>().unwrap()
         );
-        parsed_color = "x:background".parse::<Color>().unwrap();
+    }
+
+    #[test]
+    fn test_color_ref_to_xresources_defined_color() {
         assert_eq!(
-            parsed_color,
-            Color::Rgba(Rgba {
-                r: 238,
-                g: 51,
-                b: 170,
-                a: 153,
-            })
+            get_color("color1").unwrap(),
+            "#dc322f".parse::<Color>().unwrap()
         );
+    }
+
+    #[test]
+    fn test_color_ref_to_xorg_redefined_colors() {
+        assert_eq!(
+            get_color("color2").unwrap(),
+            "#859900".parse::<Color>().unwrap()
+        );
+
+        assert_eq!(
+            get_color("color3").unwrap(),
+            "#b58900".parse::<Color>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_legacy_12_bit_rgb_color() {
+        assert_eq!(
+            get_color("color4").unwrap(),
+            "#2080d0".parse::<Color>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_legacy_24_bit_rgb_color() {
+        assert_eq!(
+            get_color("color5").unwrap(),
+            "#d33682".parse::<Color>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_legacy_36_bit_rgb_color() {
+        assert_eq!(
+            get_color("color6").unwrap(),
+            "#2aa198".parse::<Color>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_legacy_48_bit_rgb_color() {
+        assert_eq!(
+            get_color("color7").unwrap(),
+            "#ede8d5".parse::<Color>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_12_bit_rgb_color() {
+        assert_eq!(
+            get_color("color8").unwrap(),
+            "#cc4411".parse::<Color>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_24_bit_rgb_color() {
+        assert_eq!(
+            get_color("color9").unwrap(),
+            "#002b36".parse::<Color>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_36_bit_rgb_color() {
+        assert_eq!(
+            get_color("color10").unwrap(),
+            "#586e76".parse::<Color>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_48_bit_rgb_color() {
+        assert_eq!(
+            get_color("color11").unwrap(),
+            "#829496".parse::<Color>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_rgbi_color() {
+        assert_eq!(
+            get_color("color12").unwrap(),
+            "#ddb787".parse::<Color>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_invalid_legacy_rgb_color() {
+        let color13 = get_color("color13");
+        assert!(matches!(
+            color13,
+            Err(Error {
+                message:
+                    Some(msg) ,
+                cause: None,
+            })
+            if msg == "color 'color13' has an invalid length hex code: '#6c71c4ff'"
+        ));
+    }
+
+    #[test]
+    fn test_color_in_unimplemented_colorspace() {
+        let color14 = get_color("color14");
+        assert!(matches!(
+            color14,
+            Err(Error {
+                message: Some(msg),
+                cause: None,
+            })  if msg == "color 'color14' is in an unimplemented color space 'CIEXYZ'"
+        ));
+    }
+
+    #[test]
+    fn test_color_in_unknown_colorspace() {
+        let color15 = get_color("color15");
+        assert!(matches!(
+            color15,
+            Err(Error {
+                message: Some(msg),
+                cause: None,
+            })  if msg == "color 'color15' is in an unrecognized color space 'Unknown'"
+        ));
+    }
+
+    #[test]
+    fn test_undefined_color() {
+        let not_a_color = get_color("not_a_color");
+        assert!(matches!(
+            not_a_color,
+            Err(Error {
+                message: Some(msg),
+                cause: None,
+            })  if msg == "color 'not_a_color' not defined in ~/.Xresources"
+        ));
     }
 }

--- a/testdata/xresources.txt
+++ b/testdata/xresources.txt
@@ -1,0 +1,67 @@
+! Colors
+
+#define S_yellow        #b58900
+#define S_red           #dc322f
+#define S_green         #ffffff
+#define S_green         #859900
+
+! x11 defined color
+! #fffacd
+*color0:                  lemonchiffon
+
+! defined color
+*color1:                  S_red
+
+! redefined color
+*color2:                  S_green
+
+! redfined color after this point
+*color3:                  S_yellow
+#define S_yellow        #ffffff
+
+! legacy rgb 12-bit
+! #2080d0
+*color4:                  #28d
+
+! legacy rgb 24-bit
+*color5:                  #d33682
+
+! legacy rgb 36-bit
+! #2aa198
+*color6:                  #2a0a1998f
+
+! legacy rgb 48-bit
+! #eee8d5
+*color7:                  #ee00e8aad5ff
+
+! rgb 12-bit
+! #cc4411
+*color8:                  rgb:c/4/1
+
+! rgb 24-bit
+! #002b36
+*color9:                  rgb:0/2b/36
+
+! rgb 36-bit
+! #586e76
+*color10:                 rgb:580/6ea/75f
+
+! rgb 48-bit
+! #829496
+*color11:                 rgb:8300/94aa/96ff
+
+! rgbi
+! The input format for these values is an optional sign, a string of numbers
+! possibly containing a decimal point, and an optional exponent field containing
+! an E or e followed by a possibly signed integer string.
+! #ddb787
+*color12:                 rgbi:.87/+.072e+1/5.3E-1
+
+! invalid length legacy rgb
+*color13:                 #6c71c4ff
+
+! Unimplemented colorspace
+*color14:                 CIEXYZ:.1/.2/.3
+
+! Unknown colorspace
+*color15:                 Unknown:.2/.3/.4


### PR DESCRIPTION
As observed in #2230:

> I found https://man.archlinux.org/man/X.7#COLOR_NAMES and it looks
> like #RRGGBB is one of several deprecated formats for specifying a
> color. I can't tell about the case, though. We allow 6-8 characters
> though, when it looks like it should be 3, 6, 9, or 12 nibbles.
> However I think we can only use 6 characters (and that we shouldn't
> accept 8 characters (#RRGGBBAA) as alpha is not allowed and it could be
> a substring of #RRRGGGBBB or #RRRRGGGGBBBB.)

> We could allow converting up #RGB to #R0G0B0 as X would do though.

This removes the support for #RRGGBBAA format, while allowing for using `#define`s, `rgb:<r>/<g>/<b>`, `rgbi:<r>/<g>/<b>`, as well as colors defined in `rgb.txt`.

This does not support processing `#include`.