### PR TITLE
fix(memory): remove double subtraction of ZFS ARC shrinkable size

### DIFF
--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -149,9 +149,6 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         // See: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
         let mem_used = mem_total - mem_avail;
 
-        // account for ZFS ARC cache
-        let mem_used = mem_used - zfs_shrinkable_size;
-
         let swap_total = mem_state.swap_total as f64;
         let swap_free = mem_state.swap_free as f64;
         let swap_cached = mem_state.swap_cached as f64;


### PR DESCRIPTION
Fix negative `mem_used_percents` values on systems with ZFS.                                           
                                                                                                         
  Since commit fe7d62128 (v0.35.0), `zfs_shrinkable_size` is subtracted twice:                           
  1. Line 137: added to `mem_avail` (`let mem_avail = mem_avail + zfs_shrinkable_size`)                  
  2. Line 150: `mem_used = mem_total - mem_avail` (already accounts for ZFS)                             
  3. Line 153: subtracted again (`mem_used = mem_used - zfs_shrinkable_size`)                            
                                                                                                         
  This results in:                                                                                       
  mem_used = mem_total - mem_avail - 2 × zfs_shrinkable_size                                             
                                                                                                         
  On systems with large ZFS ARC cache, this causes `mem_used_percents` to display negative values (e.g., 
  -23%).   