### PR TITLE
block[speedtest]: Use networkquality-rs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       image: archlinux
     steps:
     - name: Get required packages
-      run: pacman --noconfirm --noprogressbar -Syu base-devel clang git libpipewire libpulse lm_sensors notmuch openssl rsync
+      run: pacman --noconfirm --noprogressbar -Syu base-devel clang cmake git libpipewire libpulse lm_sensors notmuch openssl rsync
     - uses: dtolnay/rust-toolchain@stable
     - name: Version information
       run: rustc --version; cargo --version

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Get required packages and config git
       run: |
-        pacman --noconfirm --noprogressbar -Syu base-devel clang git libpipewire libpulse lm_sensors notmuch openssl rsync
+        pacman --noconfirm --noprogressbar -Syu base-devel clang cmake git libpipewire libpulse lm_sensors notmuch openssl rsync
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +99,9 @@ name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -199,6 +217,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +282,31 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "boring"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47bf58283ad1560da95ab8dcbb6c71e18a89df30e6011e3582ddf755abe55c4a"
+dependencies = [
+ "bitflags",
+ "boring-sys",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+]
+
+[[package]]
+name = "boring-sys"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6993efa9d9f0ebf3b0c02c8e868cfe37d0854cd021d51204480a91ce23d6e444"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -336,6 +394,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "charset"
@@ -433,6 +502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +561,15 @@ name = "cpufeatures"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -572,7 +659,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -664,7 +751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -723,18 +810,30 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
+ "foreign-types-macros",
  "foreign-types-shared",
 ]
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "foreign-types-macros"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -764,6 +863,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -886,15 +1001,23 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
- "wasip2",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -947,12 +1070,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -984,6 +1106,15 @@ name = "httparse"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -1026,22 +1157,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1062,11 +1178,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1102,6 +1216,10 @@ dependencies = [
  "nix",
  "nom 8.0.0",
  "notmuch",
+ "nq-core",
+ "nq-latency",
+ "nq-rpm",
+ "nq-tokio-network",
  "num-traits",
  "oauth2",
  "pipewire",
@@ -1658,6 +1776,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "maildir"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,16 +1818,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"
@@ -1715,23 +1842,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1846,6 +1956,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "nq-core"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git#421eb9598eb1306417e9fda87b296f2f4dc26eec"
+dependencies = [
+ "anyhow",
+ "boring",
+ "bytes",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-boring",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "nq-latency"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git#421eb9598eb1306417e9fda87b296f2f4dc26eec"
+dependencies = [
+ "anyhow",
+ "http",
+ "http-body-util",
+ "nq-core",
+ "nq-stats",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "nq-load-generator"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git#421eb9598eb1306417e9fda87b296f2f4dc26eec"
+dependencies = [
+ "anyhow",
+ "http",
+ "nq-core",
+ "nq-stats",
+ "rand 0.8.6",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "nq-rpm"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git#421eb9598eb1306417e9fda87b296f2f4dc26eec"
+dependencies = [
+ "anyhow",
+ "humansize",
+ "nq-core",
+ "nq-load-generator",
+ "nq-stats",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "nq-stats"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git#421eb9598eb1306417e9fda87b296f2f4dc26eec"
+dependencies = [
+ "nq-core",
+ "tracing",
+]
+
+[[package]]
+name = "nq-tokio-network"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git#421eb9598eb1306417e9fda87b296f2f4dc26eec"
+dependencies = [
+ "anyhow",
+ "http",
+ "hyper",
+ "nq-core",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,7 +2077,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.15",
  "http",
- "rand",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",
@@ -1886,24 +2088,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
 
 [[package]]
 name = "openssl-macros"
@@ -1918,21 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "option-ext"
@@ -2112,6 +2297,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,9 +2369,9 @@ checksum = "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2140,7 +2381,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2150,7 +2402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2160,6 +2412,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2210,29 +2477,26 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2240,6 +2504,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2276,6 +2541,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,7 +2562,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2301,10 +2572,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2313,6 +2607,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2350,11 +2645,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.26"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2372,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2481,7 +2776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.15",
  "digest",
 ]
 
@@ -2674,27 +2969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "system-deps"
 version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,10 +2994,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2778,6 +3052,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,6 +3084,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-boring"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b0cb8797d5f375289c1d478929ac08f98c535d6d000dcd01de05ad703782cd"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,16 +3103,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -3031,12 +3321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,15 +3356,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3212,6 +3487,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3233,7 +3527,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3256,35 +3550,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"
@@ -3385,12 +3650,6 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +99,9 @@ name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -199,6 +217,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +282,31 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "boring"
+version = "4.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0e3bc837369e9e662d3845c374ac3771b054d4bc2dee5457591198d16d684c"
+dependencies = [
+ "bitflags",
+ "boring-sys",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+]
+
+[[package]]
+name = "boring-sys"
+version = "4.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15aad385759d3da2737772aefb391332227bef7cb71fb85c106cadd9d1e63a98"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -336,6 +394,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "charset"
@@ -433,6 +502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +561,15 @@ name = "cpufeatures"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -723,18 +810,30 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
+ "foreign-types-macros",
  "foreign-types-shared",
 ]
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "foreign-types-macros"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -764,6 +863,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -892,9 +1007,29 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -986,6 +1121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,22 +1170,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1062,11 +1191,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1102,6 +1229,10 @@ dependencies = [
  "nix",
  "nom 8.0.0",
  "notmuch",
+ "nq-core",
+ "nq-latency",
+ "nq-rpm",
+ "nq-tokio-network",
  "num-traits",
  "oauth2",
  "pipewire",
@@ -1658,6 +1789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "maildir"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,16 +1831,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"
@@ -1715,23 +1855,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1846,6 +1969,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "nq-core"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git?rev=cbad8dc970ca0d3f68a50d76c78a253317cffd22#cbad8dc970ca0d3f68a50d76c78a253317cffd22"
+dependencies = [
+ "anyhow",
+ "boring",
+ "bytes",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rand 0.9.5",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-boring",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "nq-latency"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git?rev=cbad8dc970ca0d3f68a50d76c78a253317cffd22#cbad8dc970ca0d3f68a50d76c78a253317cffd22"
+dependencies = [
+ "anyhow",
+ "http",
+ "http-body-util",
+ "nq-core",
+ "nq-stats",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "nq-load-generator"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git?rev=cbad8dc970ca0d3f68a50d76c78a253317cffd22#cbad8dc970ca0d3f68a50d76c78a253317cffd22"
+dependencies = [
+ "anyhow",
+ "http",
+ "nq-core",
+ "nq-stats",
+ "rand 0.8.6",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "nq-rpm"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git?rev=cbad8dc970ca0d3f68a50d76c78a253317cffd22#cbad8dc970ca0d3f68a50d76c78a253317cffd22"
+dependencies = [
+ "anyhow",
+ "humansize",
+ "nq-core",
+ "nq-load-generator",
+ "nq-stats",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "nq-stats"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git?rev=cbad8dc970ca0d3f68a50d76c78a253317cffd22#cbad8dc970ca0d3f68a50d76c78a253317cffd22"
+dependencies = [
+ "nq-core",
+ "tracing",
+]
+
+[[package]]
+name = "nq-tokio-network"
+version = "3.3.0"
+source = "git+https://github.com/cloudflare/networkquality-rs.git?rev=cbad8dc970ca0d3f68a50d76c78a253317cffd22#cbad8dc970ca0d3f68a50d76c78a253317cffd22"
+dependencies = [
+ "anyhow",
+ "http",
+ "hyper",
+ "nq-core",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,7 +2090,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.15",
  "http",
- "rand",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",
@@ -1886,24 +2101,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
 
 [[package]]
 name = "openssl-macros"
@@ -1921,18 +2131,6 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -2112,6 +2310,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,14 +2387,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2150,7 +2431,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2160,6 +2451,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2210,29 +2525,26 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2240,6 +2552,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2276,6 +2589,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,10 +2620,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2313,6 +2655,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2481,7 +2824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.15",
  "digest",
 ]
 
@@ -2674,27 +3017,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "system-deps"
 version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,6 +3100,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,6 +3132,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-boring"
+version = "4.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b5955a3dc76ca07e3401e07d35f98c968e28f1a6126b552a51fa4bccd75528"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,16 +3151,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -3031,12 +3369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3212,6 +3544,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,35 +3607,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,16 @@ neli-wifi = { version = "0.6", features = ["async"] }
 nix = { version = "0.29", features = ["fs", "process"] }
 nom = "8.0.0"
 notmuch = { version = "0.8", optional = true }
-oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"] }
+nq-core = { git = "https://github.com/cloudflare/networkquality-rs.git", rev = "cbad8dc970ca0d3f68a50d76c78a253317cffd22" }
+nq-latency = { git = "https://github.com/cloudflare/networkquality-rs.git", rev = "cbad8dc970ca0d3f68a50d76c78a253317cffd22" }
+nq-rpm = { git = "https://github.com/cloudflare/networkquality-rs.git", rev = "cbad8dc970ca0d3f68a50d76c78a253317cffd22" }
+nq-tokio-network = { git = "https://github.com/cloudflare/networkquality-rs.git", rev = "cbad8dc970ca0d3f68a50d76c78a253317cffd22" }
 num-traits = "0.2"
+oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"] }
 pipewire = { version = "0.10", default-features = false, optional = true }
 quick-xml = { version = "0.37", features = ["serialize"] }
 regex = "1.5"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features=false, features = ["json", "rustls-tls"] }
 sensors = "0.2.2"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -82,8 +86,8 @@ toml = { version = "0.8", features = ["preserve_order"] }
 unicode-segmentation = "1.10.1"
 wayrs-client = { version = "1.0", features = ["tokio"] }
 wayrs-protocols = { version = "0.14", features = ["wlr-foreign-toplevel-management-unstable-v1"] }
-zbus = { version = "5", default-features = false, features = ["tokio"] }
 x11rb-async = { version = "0.13.1", features = ["xkb"] }
+zbus = { version = "5", default-features = false, features = ["tokio"] }
 
 [dependencies.tokio]
 version = "1.43"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,16 @@ neli-wifi = { version = "0.6", features = ["async"] }
 nix = { version = "0.29", features = ["fs", "process"] }
 nom = "8.0.0"
 notmuch = { version = "0.8", optional = true }
+nq-core = { git = "https://github.com/cloudflare/networkquality-rs.git" }
+nq-latency = { git = "https://github.com/cloudflare/networkquality-rs.git" }
+nq-rpm = { git = "https://github.com/cloudflare/networkquality-rs.git" }
+nq-tokio-network = { git = "https://github.com/cloudflare/networkquality-rs.git" }
 num-traits = "0.2"
 oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"] }
 pipewire = { version = "0.10", default-features = false, optional = true }
 quick-xml = { version = "0.37", features = ["serialize"] }
 regex = "1.5"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features=false, features = ["json", "rustls-tls"] }
 sensors = "0.2.2"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -13,6 +13,8 @@ ignoreRegExpList:
   - /#\[zbus::proxy\([\w\s=\.",\/]*\)\]/gm
   # Ignore unicode characters
   - /(\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})/g
+  # Ignore words with a bolded prefix
+  - /\*\*\w*\*\*\w*/g
 words:
   - aarch
   - alacritty

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -1,6 +1,14 @@
-//! Ping, download, and upload speeds
+//! Ping, jitter,download, and upload speeds
 //!
-//! This block which requires [`speedtest-cli`](https://github.com/sivel/speedtest-cli).
+//! This block uses Cloudflare's [networkquality-rs](https://github.com/cloudflare/networkquality-rs) (nq) library to run a speedtest and report the ping, jitter, download speed, and upload speed.
+//!
+//! The block can be configured to use custom endpoints for the speedtest, but by default Cloudflare's nq endpoints are used.
+//!
+//!  For example setting `config_url` to `"https://mensura.cdn-apple.com/.well-known/nq"` will use Apple's nq endpoints instead of Cloudflare's.
+//!
+//! nq is based on the IETF draft: ["Responsiveness under Working Conditions"](https://datatracker.ietf.org/doc/html/draft-ietf-ippm-responsiveness-03).
+//!
+//! The draft defines "responsiveness", measured in **R**ound trips **P**er **M**inute (RPM), as a useful measurement of network quality.
 //!
 //! # Configuration
 //!
@@ -8,10 +16,21 @@
 //! ----|--------|--------
 //! `format` | A string to customise the output of this block. See below for available placeholders. | `" ^icon_ping $ping ^icon_net_down $speed_down ^icon_net_up $speed_up "`
 //! `interval` | Update interval in seconds | `1800`
+//! `config_url` | The endpoint to get the responsiveness config from. See [`SpeedtestArgs::config_url`] for the expected format of the configuration JSON returned by this endpoint. | `None`
+//! `large_download_url` | The large file endpoint which should be multiple GBs. | `"https://h3.speed.cloudflare.com/__down?bytes=10000000000"`
+//! `small_download_url` | The small file endpoint which should be very small, only a few bytes. | `"https://h3.speed.cloudflare.com/__down?bytes=10"`
+//! `upload_url` | The upload url which accepts an arbitrary amount of data. | `"https://h3.speed.cloudflare.com/__up"`
+//! `moving_average_distance` | The number of intervals to use when calculating the moving average. | `4`
+//! `std_tolerance` | How far a measurement is allowed to be from the previous moving average before the measurement is considered unstable. | `0.05`
+//! `trimmed_mean_percent` | Determines which percentile to use for averaging when calculating the trimmed mean of throughputs or RPM scores. A value of `0.95` means to only use values in the 95th percentile to calculate an average. | `0.95`
+//! `max_loaded_connections` | The maximum number of loaded connections that the test can use to saturate the network. | `16`
+//! `interval_duration_ms` | The duration between test intervals in milliseconds (ms). | `500` (0.5 seconds)
+//! `test_duration_ms` | The overall test duration in milliseconds (ms). | `12_000` (12 seconds)
 //!
 //! Placeholder  | Value          | Type   | Unit
 //! -------------|----------------|--------|---------------
 //! `ping`       | Ping delay     | Number | Seconds
+//! `jitter`     | Jitter         | Number | Seconds
 //! `speed_down` | Download speed | Number | Bits per second
 //! `speed_up`   | Upload speed   | Number | Bits per second
 //!
@@ -40,41 +59,102 @@
 //! - `net_down`
 //! - `net_up`
 
+use std::sync::Arc;
+
+use nq_core::{Network, Time, TokioTime};
+use nq_latency::{Latency, LatencyConfig, LatencyResult};
+use nq_rpm::{Responsiveness, ResponsivenessConfig, ResponsivenessResult};
+use nq_tokio_network::TokioNetwork;
+use reqwest::Url;
+use serde::{Deserialize, Deserializer};
+use tokio_util::sync::CancellationToken;
+
 use super::prelude::*;
-use tokio::process::Command;
+
+make_log_macro!(debug, "speedtest");
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
     pub format: FormatConfig,
     #[default(1800.into())]
     pub interval: Seconds,
+    #[serde(flatten)]
+    pub speedtest_args: SpeedtestArgs,
+}
+
+#[derive(Debug, Deserialize, SmartDefault)]
+#[serde(deny_unknown_fields, default)]
+pub struct SpeedtestArgs {
+    /// The endpoint to get the responsiveness config from. Should be JSON in
+    /// the form:
+    ///
+    /// ```json
+    /// {
+    ///     "version": number,
+    ///     "test_endpoint": string?,
+    ///     "urls": {
+    ///         "small_https_download_url": string,
+    ///         "large_https_download_url": string,
+    ///         "https_upload_url": string
+    ///     }
+    /// }
+    /// ```
+    #[serde(deserialize_with = "deserialize_url_opt")]
+    pub config_url: Option<Url>,
+    /// The large file endpoint which should be multiple GBs.
+    #[default("https://h3.speed.cloudflare.com/__down?bytes=10000000000".parse().unwrap())]
+    pub large_download_url: Url,
+    /// The small file endpoint which should be very small, only a few bytes.
+    #[default("https://h3.speed.cloudflare.com/__down?bytes=10".parse().unwrap())]
+    #[serde(deserialize_with = "deserialize_url")]
+    pub small_download_url: Url,
+    /// The upload url which accepts an arbitrary amount of data.
+    #[default("https://h3.speed.cloudflare.com/__up".parse().unwrap())]
+    #[serde(deserialize_with = "deserialize_url")]
+    pub upload_url: Url,
+    /// The number of intervals to use when calculating the moving average.
+    #[default(4)]
+    pub moving_average_distance: usize,
+    /// How far a measurement is allowed to be from the previous moving average
+    /// before the measurement is considered unstable.
+    #[default(0.05)]
+    pub std_tolerance: f64,
+    /// Determines which percentile to use for averaging when calculating the
+    /// trimmed mean of throughputs or RPM scores. A value of `0.95` means to
+    /// only use values in the 95th percentile to calculate an average.
+    #[default(0.95)]
+    pub trimmed_mean_percent: f64,
+    /// The maximum number of loaded connections that the test can use to
+    /// saturate the network.
+    #[default(16)]
+    pub max_loaded_connections: usize,
+    /// The duration between test intervals.
+    #[default(Duration::from_millis(500))]
+    #[serde(deserialize_with = "deserialize_duration_ms")]
+    pub interval_duration_ms: Duration,
+    /// The overall test duration.
+    #[default(Duration::from_millis(12_000))]
+    #[serde(deserialize_with = "deserialize_duration_ms")]
+    pub test_duration_ms: Duration,
 }
 
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config
-        .format
-        .with_default(" ^icon_ping $ping ^icon_net_down $speed_down ^icon_net_up $speed_up ")?;
+    let format = config.format.with_default(
+        " ^icon_ping $ping.eng(prefix:m) ^icon_net_down $speed_down ^icon_net_up $speed_up ",
+    )?;
 
-    let mut command = Command::new("speedtest-cli");
-    command.arg("--json");
+    debug!("{:?}", config.speedtest_args);
 
     loop {
-        let output = command
-            .output()
-            .await
-            .error("failed to run 'speedtest-cli'")?
-            .stdout;
-        let output =
-            std::str::from_utf8(&output).error("'speedtest-cli' produced non-UTF8 output")?;
-        let output: SpeedtestCliOutput =
-            serde_json::from_str(output).error("'speedtest-cli' produced wrong JSON")?;
+        let results = run_speedtest(&config.speedtest_args).await?;
 
         let mut widget = Widget::new().with_format(format.clone());
         widget.set_values(map! {
-            "ping" => Value::seconds(output.ping * 1e-3),
-            "speed_down" => Value::bits(output.download),
-            "speed_up" => Value::bits(output.upload),
+            "ping" => Value::seconds(results.unloaded_latency_seconds),
+            "jitter" => Value::seconds(results.jitter_seconds),
+            "speed_down" => Value::bits(results.download),
+            "speed_up" => Value::bits(results.upload),
         });
         api.set_widget(widget)?;
 
@@ -84,13 +164,192 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         }
     }
 }
+#[derive(Debug, Deserialize)]
+struct RpmUrls {
+    #[serde(alias = "small_download_url", deserialize_with = "deserialize_url")]
+    small_https_download_url: Url,
+    #[serde(alias = "large_download_url", deserialize_with = "deserialize_url")]
+    large_https_download_url: Url,
+    #[serde(alias = "upload_url", deserialize_with = "deserialize_url")]
+    https_upload_url: Url,
+}
 
-#[derive(Deserialize, Debug, Clone, Copy)]
-struct SpeedtestCliOutput {
-    /// Download speed in bits per second
-    download: f64,
-    /// Upload speed in bits per second
-    upload: f64,
-    /// Ping time in ms
-    ping: f64,
+#[derive(Deserialize)]
+struct RpmServerConfig {
+    urls: RpmUrls,
+}
+
+/// Run a responsiveness test.
+async fn run_speedtest(cli_config: &SpeedtestArgs) -> Result<Report> {
+    debug!("running responsiveness test");
+
+    let rpm_urls = match cli_config.config_url.clone() {
+        Some(config_url) => {
+            debug!("fetching configuration from {config_url}");
+            let urls = REQWEST_CLIENT
+                .get(config_url)
+                .send()
+                .await
+                .error("Failed to send request with reqwest")?
+                .json::<RpmServerConfig>()
+                .await
+                .error("Failed to parse JSON from rpm config endpoint")?
+                .urls;
+            debug!("retrieved configuration urls: {urls:?}");
+
+            urls
+        }
+        None => {
+            let urls = RpmUrls {
+                small_https_download_url: cli_config.small_download_url.clone(),
+                large_https_download_url: cli_config.large_download_url.clone(),
+                https_upload_url: cli_config.upload_url.clone(),
+            };
+            debug!("using default configuration urls: {urls:?}");
+
+            urls
+        }
+    };
+
+    // first get unloaded RTT measurements
+    debug!("determining unloaded latency");
+    let rtt_result = test_latency(LatencyConfig {
+        url: rpm_urls.small_https_download_url.clone(),
+
+        runs: 20,
+    })
+    .await?;
+    debug!(
+        "unloaded latency: {:?} s. jitter: {:?} s",
+        rtt_result.median(),
+        rtt_result.jitter(),
+    );
+
+    let config = ResponsivenessConfig {
+        large_download_url: rpm_urls.large_https_download_url,
+        small_download_url: rpm_urls.small_https_download_url,
+        upload_url: rpm_urls.https_upload_url,
+        moving_average_distance: cli_config.moving_average_distance,
+        interval_duration: cli_config.interval_duration_ms,
+        test_duration: cli_config.test_duration_ms,
+        trimmed_mean_percent: cli_config.trimmed_mean_percent,
+        std_tolerance: cli_config.std_tolerance,
+        max_loaded_connections: cli_config.max_loaded_connections,
+    };
+
+    debug!("running download test");
+    let download_result = test_network_speed(&config, true).await?;
+
+    debug!("running upload test");
+    let upload_result = test_network_speed(&config, false).await?;
+
+    debug!("generating report");
+    Report::from_rtt_and_rpm_results(&rtt_result, &download_result, &upload_result)
+}
+
+async fn test_network_speed(
+    config: &ResponsivenessConfig,
+    download: bool,
+) -> Result<ResponsivenessResult> {
+    let shutdown = CancellationToken::new();
+    let time: Arc<dyn Time> = Arc::new(TokioTime::new());
+    let network: Arc<dyn Network> =
+        Arc::new(TokioNetwork::new(Arc::clone(&time), shutdown.clone()));
+
+    let rpm =
+        Responsiveness::new(config.clone(), download).map_err(|e| Error::new(e.to_string()))?;
+    let result = rpm
+        .run_test(network, time, shutdown.clone())
+        .await
+        .map_err(|e| Error::new(e.to_string()))?;
+
+    debug!("shutting down network speed test");
+    let _ = tokio::time::timeout(tokio::time::Duration::from_secs(1), async {
+        shutdown.cancel();
+    })
+    .await;
+
+    Ok(result)
+}
+
+async fn test_latency(config: LatencyConfig) -> Result<LatencyResult> {
+    let shutdown = CancellationToken::new();
+    let time: Arc<dyn Time> = Arc::new(TokioTime::new());
+    let network: Arc<dyn Network> =
+        Arc::new(TokioNetwork::new(Arc::clone(&time), shutdown.clone()));
+
+    let rtt = Latency::new(config);
+    let result = rtt
+        .run_test(network, time, shutdown.clone())
+        .await
+        .map_err(|e| Error::new(e.to_string()))?;
+
+    debug!("shutting down latency test");
+    let _ = tokio::time::timeout(tokio::time::Duration::from_secs(1), async {
+        shutdown.cancel();
+    })
+    .await;
+
+    Ok(result)
+}
+
+#[derive(Deserialize)]
+struct Report {
+    //rtt results
+    unloaded_latency_seconds: f64,
+    jitter_seconds: f64,
+    //rpm results
+    download: usize,
+    upload: usize,
+}
+
+impl Report {
+    fn from_rtt_and_rpm_results(
+        rtt_result: &LatencyResult,
+        download_rpm_result: &ResponsivenessResult,
+        upload_rpm_result: &ResponsivenessResult,
+    ) -> Result<Self> {
+        let unloaded_latency_seconds = rtt_result.median().error("no median RTT available")?;
+        let jitter_seconds = rtt_result.jitter().error("no jitter available")?;
+
+        let download = download_rpm_result
+            .throughput()
+            .error("no download throughput available")?;
+        let upload = upload_rpm_result
+            .throughput()
+            .error("no upload throughput available")?;
+
+        Ok(Report {
+            unloaded_latency_seconds,
+            jitter_seconds,
+            download,
+            upload,
+        })
+    }
+}
+
+fn deserialize_url_opt<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let url_opt = Option::<String>::deserialize(deserializer)?;
+    url_opt
+        .map(|url| url.parse().map_err(serde::de::Error::custom))
+        .transpose()
+}
+
+fn deserialize_url<'de, D>(deserializer: D) -> Result<Url, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let url = String::deserialize(deserializer)?;
+    url.parse().map_err(serde::de::Error::custom)
+}
+
+fn deserialize_duration_ms<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let duration_ms = u64::deserialize(deserializer)?;
+    Ok(Duration::from_millis(duration_ms))
 }

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -1,6 +1,14 @@
-//! Ping, download, and upload speeds
+//! Ping, jitter,download, and upload speeds
 //!
-//! This block which requires [`speedtest-cli`](https://github.com/sivel/speedtest-cli).
+//! This block uses Cloudflare's [networkquality-rs](https://github.com/cloudflare/networkquality-rs) (nq) library to run a speedtest and report the ping, jitter, download speed, and upload speed.
+//!
+//! The block can be configured to use custom endpoints for the speedtest, but by default Cloudflare's nq endpoints are used.
+//!
+//!  For example setting `config_url` to `"https://mensura.cdn-apple.com/.well-known/nq"` will use Apple's nq endpoints instead of Cloudflare's.
+//!
+//! nq is based on the IETF draft: ["Responsiveness under Working Conditions"](https://datatracker.ietf.org/doc/html/draft-ietf-ippm-responsiveness-03).
+//!
+//! The draft defines "responsiveness", measured in **R**ound trips **P**er **M**inute (RPM), as a useful measurement of network quality.
 //!
 //! # Configuration
 //!
@@ -8,10 +16,21 @@
 //! ----|--------|--------
 //! `format` | A string to customise the output of this block. See below for available placeholders. | `" ^icon_ping $ping ^icon_net_down $speed_down ^icon_net_up $speed_up "`
 //! `interval` | Update interval in seconds | `1800`
+//! `config_url` | The endpoint to get the responsiveness config from. See [`SpeedtestArgs::config_url`] for the expected format of the configuration JSON returned by this endpoint. | `None`
+//! `large_download_url` | The large file endpoint which should be multiple GBs. | `"https://h3.speed.cloudflare.com/__down?bytes=10000000000"`
+//! `small_download_url` | The small file endpoint which should be very small, only a few bytes. | `"https://h3.speed.cloudflare.com/__down?bytes=10"`
+//! `upload_url` | The upload url which accepts an arbitrary amount of data. | `"https://h3.speed.cloudflare.com/__up"`
+//! `moving_average_distance` | The number of intervals to use when calculating the moving average. | `4`
+//! `std_tolerance` | How far a measurement is allowed to be from the previous moving average before the measurement is considered unstable. | `0.05`
+//! `trimmed_mean_percent` | Determines which percentile to use for averaging when calculating the trimmed mean of throughputs or RPM scores. A value of `0.95` means to only use values in the 95th percentile to calculate an average. | `0.95`
+//! `max_loaded_connections` | The maximum number of loaded connections that the test can use to saturate the network. | `16`
+//! `interval_duration_ms` | The duration between test intervals in milliseconds (ms). | `500` (0.5 seconds)
+//! `test_duration_ms` | The overall test duration in milliseconds (ms). | `12_000` (12 seconds)
 //!
 //! Placeholder  | Value          | Type   | Unit
 //! -------------|----------------|--------|---------------
 //! `ping`       | Ping delay     | Number | Seconds
+//! `jitter`     | Jitter         | Number | Seconds
 //! `speed_down` | Download speed | Number | Bits per second
 //! `speed_up`   | Upload speed   | Number | Bits per second
 //!
@@ -40,41 +59,106 @@
 //! - `net_down`
 //! - `net_up`
 
+use std::sync::Arc;
+
+use nq_core::{ConnectionType, Network, Time, TokioTime};
+use nq_latency::{Latency, LatencyConfig, LatencyResult};
+use nq_rpm::{Responsiveness, ResponsivenessConfig, ResponsivenessResult};
+use nq_tokio_network::TokioNetwork;
+use reqwest::Url;
+use serde::{Deserialize, Deserializer};
+use tokio_util::sync::CancellationToken;
+
 use super::prelude::*;
-use tokio::process::Command;
+
+make_log_macro!(debug, "speedtest");
 
 #[derive(Deserialize, Debug, SmartDefault)]
-#[serde(deny_unknown_fields, default)]
+#[serde(default)]
 pub struct Config {
     pub format: FormatConfig,
     #[default(1800.into())]
     pub interval: Seconds,
+    #[serde(flatten)]
+    pub speedtest_args: SpeedtestArgs,
+}
+
+#[derive(Debug, Deserialize, SmartDefault)]
+#[serde(deny_unknown_fields, default)]
+pub struct SpeedtestArgs {
+    /// The endpoint to get the responsiveness config from. Should be JSON in
+    /// the form:
+    ///
+    /// ```json
+    /// {
+    ///     "version": number,
+    ///     "test_endpoint": string?,
+    ///     "urls": {
+    ///         "small_https_download_url": string,
+    ///         "large_https_download_url": string,
+    ///         "https_upload_url": string
+    ///     }
+    /// }
+    /// ```
+    #[serde(deserialize_with = "deserialize_url_opt")]
+    pub config_url: Option<Url>,
+    /// The large file endpoint which should be multiple GBs.
+    #[default("https://h3.speed.cloudflare.com/__down?bytes=10000000000".parse().unwrap())]
+    pub large_download_url: Url,
+    /// The small file endpoint which should be very small, only a few bytes.
+    #[default("https://h3.speed.cloudflare.com/__down?bytes=10".parse().unwrap())]
+    #[serde(deserialize_with = "deserialize_url")]
+    pub small_download_url: Url,
+    /// The upload url which accepts an arbitrary amount of data.
+    #[default("https://h3.speed.cloudflare.com/__up".parse().unwrap())]
+    #[serde(deserialize_with = "deserialize_url")]
+    pub upload_url: Url,
+    /// The number of intervals to use when calculating the moving average.
+    #[default(4)]
+    pub moving_average_distance: usize,
+    /// How far a measurement is allowed to be from the previous moving average
+    /// before the measurement is considered unstable.
+    #[default(0.05)]
+    pub std_tolerance: f64,
+    /// Determines which percentile to use for averaging when calculating the
+    /// trimmed mean of throughputs or RPM scores. A value of `0.95` means to
+    /// only use values in the 95th percentile to calculate an average.
+    #[default(0.95)]
+    pub trimmed_mean_percent: f64,
+    /// The maximum number of loaded connections that the test can use to
+    /// saturate the network.
+    #[default(16)]
+    pub max_loaded_connections: usize,
+    /// The duration between test intervals.
+    #[default(Duration::from_millis(500))]
+    #[serde(deserialize_with = "deserialize_duration_ms")]
+    pub interval_duration_ms: Duration,
+    /// The overall test duration.
+    #[default(Duration::from_millis(12_000))]
+    #[serde(deserialize_with = "deserialize_duration_ms")]
+    pub test_duration_ms: Duration,
+    /// Create an HTTP/1.1, HTTP/2, or HTTP/3 connection.
+    #[default(ConnectionType::H2)]
+    #[serde(deserialize_with = "deserialize_conn_type")]
+    pub conn_type: ConnectionType,
 }
 
 pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config
-        .format
-        .with_default(" ^icon_ping $ping ^icon_net_down $speed_down ^icon_net_up $speed_up ")?;
+    let format = config.format.with_default(
+        " ^icon_ping $ping.eng(prefix:m) ^icon_net_down $speed_down ^icon_net_up $speed_up ",
+    )?;
 
-    let mut command = Command::new("speedtest-cli");
-    command.arg("--json");
+    debug!("{:?}", config.speedtest_args);
 
     loop {
-        let output = command
-            .output()
-            .await
-            .error("failed to run 'speedtest-cli'")?
-            .stdout;
-        let output =
-            std::str::from_utf8(&output).error("'speedtest-cli' produced non-UTF8 output")?;
-        let output: SpeedtestCliOutput =
-            serde_json::from_str(output).error("'speedtest-cli' produced wrong JSON")?;
+        let results = run_speedtest(&config.speedtest_args).await?;
 
         let mut widget = Widget::new().with_format(format.clone());
         widget.set_values(map! {
-            "ping" => Value::seconds(output.ping * 1e-3),
-            "speed_down" => Value::bits(output.download),
-            "speed_up" => Value::bits(output.upload),
+            "ping" => Value::seconds(results.unloaded_latency_seconds),
+            "jitter" => Value::seconds(results.jitter_seconds),
+            "speed_down" => Value::bits(results.download),
+            "speed_up" => Value::bits(results.upload),
         });
         api.set_widget(widget)?;
 
@@ -84,13 +168,221 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         }
     }
 }
+#[derive(Debug, Deserialize)]
+struct RpmUrls {
+    #[serde(alias = "small_download_url", deserialize_with = "deserialize_url")]
+    small_https_download_url: Url,
+    #[serde(alias = "large_download_url", deserialize_with = "deserialize_url")]
+    large_https_download_url: Url,
+    #[serde(alias = "upload_url", deserialize_with = "deserialize_url")]
+    https_upload_url: Url,
+}
 
-#[derive(Deserialize, Debug, Clone, Copy)]
-struct SpeedtestCliOutput {
-    /// Download speed in bits per second
-    download: f64,
-    /// Upload speed in bits per second
-    upload: f64,
-    /// Ping time in ms
-    ping: f64,
+#[derive(Deserialize)]
+struct RpmServerConfig {
+    urls: RpmUrls,
+}
+
+/// Run a responsiveness test.
+async fn run_speedtest(cli_config: &SpeedtestArgs) -> Result<Report> {
+    debug!("running responsiveness test");
+
+    let rpm_urls = match cli_config.config_url.clone() {
+        Some(config_url) => {
+            debug!("fetching configuration from {config_url}");
+            let urls = REQWEST_CLIENT
+                .get(config_url)
+                .send()
+                .await
+                .error("Failed to send request with reqwest")?
+                .json::<RpmServerConfig>()
+                .await
+                .error("Failed to parse JSON from rpm config endpoint")?
+                .urls;
+            debug!("retrieved configuration urls: {urls:?}");
+
+            urls
+        }
+        None => {
+            let urls = RpmUrls {
+                small_https_download_url: cli_config.small_download_url.clone(),
+                large_https_download_url: cli_config.large_download_url.clone(),
+                https_upload_url: cli_config.upload_url.clone(),
+            };
+            debug!("using default configuration urls: {urls:?}");
+
+            urls
+        }
+    };
+
+    // first get unloaded RTT measurements
+    debug!("determining unloaded latency");
+    let rtt_result = test_latency(LatencyConfig {
+        url: rpm_urls.small_https_download_url.clone(),
+
+        runs: 20,
+        scoped_headers: None,
+    })
+    .await?;
+    debug!(
+        "unloaded latency: {:?} s. jitter: {:?} s",
+        rtt_result.median(),
+        rtt_result.jitter(),
+    );
+
+    let config = ResponsivenessConfig {
+        large_download_url: rpm_urls.large_https_download_url,
+        small_download_url: rpm_urls.small_https_download_url,
+        upload_url: rpm_urls.https_upload_url,
+        moving_average_distance: cli_config.moving_average_distance,
+        interval_duration: cli_config.interval_duration_ms,
+        test_duration: cli_config.test_duration_ms,
+        trimmed_mean_percent: cli_config.trimmed_mean_percent,
+        std_tolerance: cli_config.std_tolerance,
+        max_loaded_connections: cli_config.max_loaded_connections,
+        conn_type: cli_config.conn_type,
+        // When determine_load_only is false, sends a foreign probe which is a GET on a newly created connection.
+        //
+        // > An HTTP GET request on a connection separate from the load-generating
+        // > connections ("foreign probes"). This probe type mimics the time it
+        // > takes for a web browser to connect to a new web server and request the
+        // > first element of a web page (e.g., "index.html"), or the startup time
+        // > for a video streaming client to launch and begin fetching media.
+        //
+        // https://datatracker.ietf.org/doc/html/draft-ietf-ippm-responsiveness-03#section-4.3-3.1.1
+        determine_load_only: false,
+        scoped_headers: None,
+    };
+
+    debug!("running download test");
+    let download_result = test_network_speed(&config, true).await?;
+
+    debug!("running upload test");
+    let upload_result = test_network_speed(&config, false).await?;
+
+    debug!("generating report");
+    Report::from_rtt_and_rpm_results(&rtt_result, &download_result, &upload_result)
+}
+
+async fn test_network_speed(
+    config: &ResponsivenessConfig,
+    download: bool,
+) -> Result<ResponsivenessResult> {
+    let shutdown = CancellationToken::new();
+    let time: Arc<dyn Time> = Arc::new(TokioTime::new());
+    let network: Arc<dyn Network> =
+        Arc::new(TokioNetwork::new(Arc::clone(&time), shutdown.clone()));
+
+    let rpm =
+        Responsiveness::new(config.clone(), download).map_err(|e| Error::new(e.to_string()))?;
+    let result = rpm
+        .run_test(network, time, shutdown.clone())
+        .await
+        .map_err(|e| Error::new(e.to_string()))?;
+
+    debug!("shutting down network speed test");
+    let _ = tokio::time::timeout(tokio::time::Duration::from_secs(1), async {
+        shutdown.cancel();
+    })
+    .await;
+
+    Ok(result)
+}
+
+async fn test_latency(config: LatencyConfig) -> Result<LatencyResult> {
+    let shutdown = CancellationToken::new();
+    let time: Arc<dyn Time> = Arc::new(TokioTime::new());
+    let network: Arc<dyn Network> =
+        Arc::new(TokioNetwork::new(Arc::clone(&time), shutdown.clone()));
+
+    let rtt = Latency::new(config);
+    let result = rtt
+        .run_test(network, time, shutdown.clone())
+        .await
+        .map_err(|e| Error::new(e.to_string()))?;
+
+    debug!("shutting down latency test");
+    let _ = tokio::time::timeout(tokio::time::Duration::from_secs(1), async {
+        shutdown.cancel();
+    })
+    .await;
+
+    Ok(result)
+}
+
+#[derive(Deserialize)]
+struct Report {
+    //rtt results
+    unloaded_latency_seconds: f64,
+    jitter_seconds: f64,
+    //rpm results
+    download: usize,
+    upload: usize,
+}
+
+impl Report {
+    fn from_rtt_and_rpm_results(
+        rtt_result: &LatencyResult,
+        download_rpm_result: &ResponsivenessResult,
+        upload_rpm_result: &ResponsivenessResult,
+    ) -> Result<Self> {
+        let unloaded_latency_seconds = rtt_result.median().error("no median RTT available")?;
+        let jitter_seconds = rtt_result.jitter().error("no jitter available")?;
+
+        let download = download_rpm_result
+            .throughput()
+            .error("no download throughput available")?;
+        let upload = upload_rpm_result
+            .throughput()
+            .error("no upload throughput available")?;
+
+        Ok(Report {
+            unloaded_latency_seconds,
+            jitter_seconds,
+            download,
+            upload,
+        })
+    }
+}
+
+fn deserialize_url_opt<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let url_opt = Option::<String>::deserialize(deserializer)?;
+    url_opt
+        .map(|url| url.parse().map_err(serde::de::Error::custom))
+        .transpose()
+}
+
+fn deserialize_url<'de, D>(deserializer: D) -> Result<Url, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let url = String::deserialize(deserializer)?;
+    url.parse().map_err(serde::de::Error::custom)
+}
+
+fn deserialize_duration_ms<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let duration_ms = u64::deserialize(deserializer)?;
+    Ok(Duration::from_millis(duration_ms))
+}
+
+fn deserialize_conn_type<'de, D>(deserializer: D) -> Result<ConnectionType, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let conn_type_str = String::deserialize(deserializer)?;
+    match conn_type_str.to_lowercase().as_str() {
+        "h1" => Ok(ConnectionType::H1 { use_tls: true }),
+        "h2" => Ok(ConnectionType::H2),
+        "h3" => Ok(ConnectionType::H3),
+        _ => Err(serde::de::Error::custom(format!(
+            "Invalid connection type: {}. Must be one of: h1, h2, h3",
+            conn_type_str
+        ))),
+    }
 }


### PR DESCRIPTION
The speedtest block was using [speedtest-cli](https://github.com/sivel/speedtest-cli) which has been become archived and is no longer maintained.

This commit replaces speedtest-cli with [networkquality-rs](https://github.com/cloudflare/networkquality-rs).

Note that this requires `cmake` to be installed.
I had to switch over to `rustls` as not doing so causes linking errors.
The new version of `reqwest` moved to `rustls`, so we'll move in that direction anyways.

The nq crates are not published on crates.io so they are being checked out directly from github.

Resolves #2245