### PR TITLE
Accept any i3status-rs feature combination for manpage generation

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,10 +3,19 @@ name = "xtask"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = ["i3status-rs/default"]
+pulseaudio = ["i3status-rs/pulseaudio"]
+pipewire = ["i3status-rs/pipewire"]
+notmuch = ["i3status-rs/notmuch"]
+maildir = ["i3status-rs/maildir"]
+icu_calendar = ["i3status-rs/icu_calendar"]
+debug_borders = ["i3status-rs/debug_borders"]
+
 [dependencies]
 anyhow = "1.0"
 clap = "4.1"
 clap_mangen = "0.2"
 pandoc = "0.8"
 
-i3status-rs = { path = ".." }
+i3status-rs = { path = "..", default-features = false }


### PR DESCRIPTION
Currently, xtask depends on i3status-rs with only the default features
enabled.  Running xtask then causes unnecessary rebuilds, if i3status-rs
was built with another configuration.
We can avoid these by forwarding the features of i3status-rs to xtask,
applying them to both packages (resolver >= "2") and ensuring a
consistent environment between Cargo invocations.

For example:
```
myflags=(
	--release
	--features notmuch
	--no-default-features
)
cargo build ${myflags[@]} --package i3status-rs --package xtask
cargo run ${myflags[@]} --package xtask -- generate-manpage
```

See-also: https://doc.rust-lang.org/cargo/reference/features.html#resolver-version-2-command-line-flags