### PR TITLE
Fix mullvad vpn

### DIFF
--- a/src/blocks/vpn.rs
+++ b/src/blocks/vpn.rs
@@ -10,6 +10,7 @@
 //! `interval` | Update interval in seconds. | `10`
 //! `format_connected` | A string to customise the output in case the network is connected. See below for available placeholders. | `" VPN: $icon "`
 //! `format_disconnected` | A string to customise the output in case the network is disconnected. See below for available placeholders. | `" VPN: $icon "`
+//! `format_connecting` | A string to customise the output in case the network is in a connecting state. See below for available placeholders. | `" VPN: $icon "`
 //! `state_connected` | The widgets state if the vpn network is connected. | `info`
 //! `state_disconnected` | The widgets state if the vpn network is disconnected | `idle`
 //!
@@ -55,6 +56,7 @@
 //! interval = 10
 //! format_connected = "VPN: $icon "
 //! format_disconnected = "VPN: $icon "
+//! format_connecting = "VPN: $icon "
 //! state_connected = "good"
 //! state_disconnected = "warning"
 //! ```
@@ -73,6 +75,7 @@
 //!
 //! - `net_vpn`
 //! - `net_wired`
+//! - `net_wireless` (for connecting state)
 //! - `net_down`
 //! - country code flags (if supported by font)
 //!
@@ -108,6 +111,7 @@ pub struct Config {
     pub interval: Seconds,
     pub format_connected: FormatConfig,
     pub format_disconnected: FormatConfig,
+    pub format_connecting: FormatConfig,
     pub state_connected: State,
     pub state_disconnected: State,
 }
@@ -116,6 +120,9 @@ enum Status {
     Connected {
         country: Option<String>,
         country_flag: Option<String>,
+        profile: Option<String>,
+    },
+    Connecting {
         profile: Option<String>,
     },
     Disconnected {
@@ -129,6 +136,7 @@ impl Status {
         match self {
             Status::Connected { .. } => "net_vpn".into(),
             Status::Disconnected { .. } => "net_wired".into(),
+            Status::Connecting { .. } => "net_wireless".into(),
             Status::Error(_) => "net_down".into(),
         }
     }
@@ -140,6 +148,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
     let format_connected = config.format_connected.with_default(" VPN: $icon ")?;
     let format_disconnected = config.format_disconnected.with_default(" VPN: $icon ")?;
+    let format_connecting = config.format_connecting.with_default(" VPN: $icon ")?;
 
     let driver: Box<dyn Driver> = match config.driver {
         DriverType::Mullvad => Box::new(MullvadDriver::new().await),
@@ -175,6 +184,14 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 });
                 widget.set_format(format_disconnected.clone());
                 config.state_disconnected
+            }
+            Status::Connecting { profile } => {
+                widget.set_values(map!(
+                        "icon" => Value::icon(status.icon()),
+                        [if let Some(profile) = profile] "profile" => Value::text(profile.into()),
+                ));
+                widget.set_format(format_connecting.clone());
+                State::Info
             }
             Status::Error(error) => {
                 widget.set_values(map!(

--- a/src/blocks/vpn/mullvad.rs
+++ b/src/blocks/vpn/mullvad.rs
@@ -1,4 +1,3 @@
-use regex::Regex;
 use std::process::Stdio;
 use tokio::process::Command;
 
@@ -7,15 +6,11 @@ use crate::util::country_flag_from_iso_code;
 
 use super::{Driver, Status};
 
-pub struct MullvadDriver {
-    regex_country_code: Regex,
-}
+pub struct MullvadDriver {}
 
 impl MullvadDriver {
     pub async fn new() -> MullvadDriver {
-        MullvadDriver {
-            regex_country_code: Regex::new("Connected to ([a-z]{2}).*, ([A-Z][a-z]*).*\n").unwrap(),
-        }
+        MullvadDriver {}
     }
 
     async fn run_network_command(arg: &str) -> Result<()> {
@@ -43,36 +38,35 @@ impl MullvadDriver {
 impl Driver for MullvadDriver {
     async fn get_status(&self) -> Result<Status> {
         let stdout = Command::new("mullvad")
-            .args(["status"])
+            .args(["status", "-j"])
             .output()
             .await
             .error("Problem running mullvad command")?
             .stdout;
 
-        let status = String::from_utf8(stdout).error("mullvad produced non-UTF8 output")?;
+        let status: MullvadCliStatus =
+            serde_json::from_slice(&stdout).error("'mullvad status' produced wrong JSON")?;
 
-        if status.contains("Disconnected") {
-            return Ok(Status::Disconnected { profile: None });
-        } else if status.contains("Connected") {
-            let (country_flag, country) = self
-                .regex_country_code
-                .captures_iter(&status)
-                .next()
-                .map(|capture| {
-                    let country_code = capture[1].to_uppercase();
-                    let country = capture[2].to_owned();
-                    let country_flag = country_flag_from_iso_code(&country_code);
-                    (Some(country_flag), Some(country))
+        match status {
+            MullvadCliStatus::Disconnected => Ok(Status::Disconnected { profile: None }),
+            MullvadCliStatus::Connected { details } => {
+                let country_code = details
+                    .location
+                    .hostname
+                    .map(|hostname| hostname[0..2].to_uppercase());
+
+                let country_flag = country_code
+                    .as_ref()
+                    .map(|code| country_flag_from_iso_code(code));
+
+                Ok(Status::Connected {
+                    country: country_code,
+                    country_flag,
+                    profile: None,
                 })
-                .unwrap_or((None, None));
-
-            return Ok(Status::Connected {
-                country,
-                country_flag,
-                profile: None,
-            });
+            }
+            _ => Ok(Status::Error(None)),
         }
-        Ok(Status::Error(None))
     }
 
     async fn toggle_connection(&self, status: &Status) -> Result<()> {
@@ -83,4 +77,27 @@ impl Driver for MullvadDriver {
         }
         Ok(())
     }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(tag = "state")]
+#[serde(rename_all = "snake_case")]
+enum MullvadCliStatus {
+    Connected { details: Details },
+
+    Disconnected,
+
+    Connecting,
+
+    Disconnecting,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct Details {
+    location: Location,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct Location {
+    hostname: Option<String>,
 }

--- a/src/blocks/vpn/mullvad.rs
+++ b/src/blocks/vpn/mullvad.rs
@@ -25,6 +25,9 @@ impl MullvadDriver {
             .error(format!("Problem running mullvad command: {arg}"))?;
 
         if code.success() {
+            // Sleep 1 sec here to allow the mullvad-daemon some time to update the status
+            // before get_status is called again.
+            sleep(Duration::from_secs(1)).await;
             Ok(())
         } else {
             Err(Error::new(format!(
@@ -48,7 +51,9 @@ impl Driver for MullvadDriver {
             serde_json::from_slice(&stdout).error("'mullvad status' produced wrong JSON")?;
 
         match status {
-            MullvadCliStatus::Disconnected => Ok(Status::Disconnected { profile: None }),
+            MullvadCliStatus::Disconnected | MullvadCliStatus::Disconnecting => {
+                Ok(Status::Disconnected { profile: None })
+            }
             MullvadCliStatus::Connected { details } => {
                 let country_code = details
                     .location
@@ -65,13 +70,15 @@ impl Driver for MullvadDriver {
                     profile: None,
                 })
             }
-            _ => Ok(Status::Error(None)),
+            MullvadCliStatus::Connecting => Ok(Status::Connecting { profile: None }),
         }
     }
 
     async fn toggle_connection(&self, status: &Status) -> Result<()> {
         match status {
-            Status::Connected { .. } => Self::run_network_command("disconnect").await?,
+            Status::Connected { .. } | Status::Connecting { .. } => {
+                Self::run_network_command("disconnect").await?;
+            }
             Status::Disconnected { .. } => Self::run_network_command("connect").await?,
             Status::Error(_) => (),
         }

--- a/src/blocks/vpn/mullvad.rs
+++ b/src/blocks/vpn/mullvad.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use std::process::Stdio;
 use tokio::process::Command;
 
@@ -44,11 +45,20 @@ impl Driver for MullvadDriver {
             .args(["status", "-j"])
             .output()
             .await
-            .error("Problem running mullvad command")?
+            .error("Problem running `mullvad status -j`")?
             .stdout;
 
+        let json_status_output = String::from_utf8_lossy(&stdout);
+
+        // As of 2026-04-29 there's a bug in the `mullvad status -j` command in that it sometimes
+        // prints non-JSON data before the JSON output so we must filter that out here.
+        let json_status = json_status_output
+            .lines()
+            .skip_while(|line| !line.starts_with("{"))
+            .join("\n");
+
         let status: MullvadCliStatus =
-            serde_json::from_slice(&stdout).error("'mullvad status' produced wrong JSON")?;
+            serde_json::from_str(&json_status).error("`mullvad status -j` produced wrong JSON")?;
 
         match status {
             MullvadCliStatus::Disconnected | MullvadCliStatus::Disconnecting => {
@@ -71,6 +81,19 @@ impl Driver for MullvadDriver {
                 })
             }
             MullvadCliStatus::Connecting => Ok(Status::Connecting { profile: None }),
+            MullvadCliStatus::Error { details } => {
+                let error = details.and_then(|details| details.cause).and_then(|cause| {
+                    if let Some(reason) = cause.reason
+                        && let Some(details) = cause.details
+                    {
+                        Some(format!("{}: {}", reason, details))
+                    } else {
+                        None
+                    }
+                });
+
+                Ok(Status::Error(error))
+            }
         }
     }
 
@@ -97,6 +120,8 @@ enum MullvadCliStatus {
     Connecting,
 
     Disconnecting,
+
+    Error { details: Option<ErrorDetails> },
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -107,4 +132,15 @@ struct Details {
 #[derive(Deserialize, Debug, Clone)]
 struct Location {
     hostname: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct ErrorDetails {
+    cause: Option<ErrorCause>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct ErrorCause {
+    reason: Option<String>,
+    details: Option<String>,
 }

--- a/src/blocks/vpn/mullvad.rs
+++ b/src/blocks/vpn/mullvad.rs
@@ -1,4 +1,4 @@
-use itertools::Itertools;
+use itertools::Itertools as _;
 use std::process::Stdio;
 use tokio::process::Command;
 

--- a/src/blocks/vpn/nordvpn.rs
+++ b/src/blocks/vpn/nordvpn.rs
@@ -86,7 +86,7 @@ impl Driver for NordVpnDriver {
         match status {
             Status::Connected { .. } => Self::run_network_command("disconnect").await?,
             Status::Disconnected { .. } => Self::run_network_command("connect").await?,
-            Status::Error(_) => (),
+            Status::Connecting { .. } | Status::Error(_) => (),
         }
         Ok(())
     }

--- a/src/blocks/vpn/tailscale.rs
+++ b/src/blocks/vpn/tailscale.rs
@@ -79,7 +79,7 @@ impl Driver for TailscaleDriver {
         match status {
             Status::Connected { .. } => Self::run_network_command("down").await?,
             Status::Disconnected { .. } => Self::run_network_command("up").await?,
-            Status::Error(_) => (),
+            Status::Connecting { .. } | Status::Error(_) => (),
         }
         Ok(())
     }

--- a/src/blocks/vpn/warp.rs
+++ b/src/blocks/vpn/warp.rs
@@ -53,7 +53,7 @@ impl Driver for WarpDriver {
         match status {
             Status::Connected { .. } => Self::run_network_command("disconnect").await?,
             Status::Disconnected { .. } => Self::run_network_command("connect").await?,
-            Status::Error { .. } => (),
+            Status::Connecting { .. } | Status::Error(_) => (),
         }
         Ok(())
     }


### PR DESCRIPTION
The Mullvad status parsing was done by calling `mullvad status` and parsing this output which has changed so the country code was not extracted correctly.

This PR changes that instead parse the JSON output from `mullvad status -j`, which should be more robust.

It also adds a connecting state to the VPN block so that the error icon is not shown when the VPN is connecting. Note that I only implemented the connecting state for Mullvad, so the other VPNs will behave as they did before and show the error icon when connecting.

Closes: https://github.com/greshake/i3status-rust/issues/1882