### PR TITLE
docs: fix Intel GPU Usage in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -197,7 +197,7 @@ signal = 4
 
 ### Intel GPU Usage
 
-Shows usage of the Render/3D pipeline of intel GPUs in percent, rounded to 2 decimal places. Requires `intel_gpu_top` installed and added to `/etc/sudoers` with `NOPASSWD` (Instructions see [here](https://unix.stackexchange.com/questions/18830/how-to-run-a-specific-program-as-root-without-a-password-prompt)).Other engines (video decode, blitter, etc.) are available under the `engines` key in `sudo intel_gpu_top -J` output. 
+Shows usage of the Render/3D pipeline of intel GPUs in percent, rounded to 2 decimal places. Requires `intel_gpu_top` installed and added to `/etc/sudoers` with `NOPASSWD` (Instructions see [here](https://unix.stackexchange.com/questions/18830/how-to-run-a-specific-program-as-root-without-a-password-prompt)). Other engines (e.g. video decode) are available under the `engines` key in `sudo intel_gpu_top -J` output.
 
 **Note:**
 The second sample is used intentionally — intel_gpu_top consistently reports an artificially high spike on its first measurement due to initialization.

--- a/examples/README.md
+++ b/examples/README.md
@@ -197,12 +197,15 @@ signal = 4
 
 ### Intel GPU Usage
 
-Shows usage of the Render/3D pipeline of intel GPUs in percent. Requires `intel_gpu_top` installed and added to `/etc/sudoers` with `NOPASSWD` (Instructions see [here](https://unix.stackexchange.com/questions/18830/how-to-run-a-specific-program-as-root-without-a-password-prompt)). Video decode pipeline would be `awk '{print $14 "%"}'`.
+Shows usage of the Render/3D pipeline of intel GPUs in percent, rounded to 2 decimal places. Requires `intel_gpu_top` installed and added to `/etc/sudoers` with `NOPASSWD` (Instructions see [here](https://unix.stackexchange.com/questions/18830/how-to-run-a-specific-program-as-root-without-a-password-prompt)).Other engines (video decode, blitter, etc.) are available under the `engines` key in `sudo intel_gpu_top -J` output. 
+
+**Note:**
+The second sample is used intentionally — intel_gpu_top consistently reports an artificially high spike on its first measurement due to initialization.
 
 ```toml
 [[block]]
 block = "custom"
-command = ''' sudo intel_gpu_top -l | head -n4 | tail -n1 | awk '{print $8 "%"}' '''
+command = ''' sudo intel_gpu_top -J -n2 | jq '.[1].engines["Render/3D"].busy' | xargs printf "%.2f%%" '''
 interval = 5
 ```
 


### PR DESCRIPTION
The example for Intel GPU usage parses the Render/3D value from the 8th field of `intel_gpu_top -l` output. Since this was introduced, the Render/3D field has shifted to the 9th position, breaking the example:

```shell
oleh@gentoooleh ~ $ sudo intel_gpu_top -l -n 1
 Freq MHz      IRQ RC6     Power W     IMC MiB/s             RCS             BCS             VCS            VECS 
 req  act       /s   %   gpu   pkg     rd     wr       %  se  wa       %  se  wa       %  se  wa       %  se  wa 
 388  388      582  50  0.95 36.54   3436   2309   42.43   0   0    0.00   0   0    0.00   0   0    0.00   0   0 
```

To prevent future field position shifts, I propose to utilize JSON output from `intel_gpu_top -J` and extract the Render/3D value by key with `jq`: `[1].engines["Render/3D"].busy`.

Note: the first sample in the JSON array always contains a high Render/3D spike, so the second sample (`[1]`) is used instead to get an accurate numbers. I also added this note to the file.