### PR TITLE
net block: allow defining absolute up and down bandwidth

### DIFF
--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -197,6 +197,12 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     "device" => Value::text(device.iface.name),
                 });
 
+                if speed_down / max_network_speeds.down > 0.8 || speed_up / max_network_speeds.up > 0.8 {
+                    widget.state = State::Info;
+                } else {
+                    widget.state = State::Idle;
+                }
+
                 api.set_widget(widget)?;
             }
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -214,7 +214,7 @@ pub fn format_bar_graph(content: &[f64], max: f64) -> String {
 
     content
         .iter()
-        .map(|x| BARS[(x / max * 8.).clamp(0., 8.) as usize])
+        .map(|x| BARS[(x / max * 8.).ceil().clamp(0., 8.) as usize])
         .collect()
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -214,7 +214,7 @@ pub fn format_bar_graph(content: &[f64], max: f64) -> String {
 
     content
         .iter()
-        .map(|x| BARS[(x / max * 8.).ceil().clamp(0., 8.) as usize])
+        .map(|x| BARS[(x / max * 8.).round().clamp(0., 8.) as usize])
         .collect()
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -204,25 +204,17 @@ macro_rules! make_log_macro {
     };
 }
 
-pub fn format_bar_graph(content: &[f64]) -> String {
+pub fn format_bar_graph(content: &[f64], max: f64) -> String {
     // (x * one eighth block) https://en.wikipedia.org/wiki/Block_Elements
-    static BARS: [char; 8] = [
+    static BARS: [char; 9] = [
+        ' ',
         '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}', '\u{2585}', '\u{2586}', '\u{2587}',
         '\u{2588}',
     ];
 
-    // Find min and max
-    let mut min = f64::INFINITY;
-    let mut max = f64::NEG_INFINITY;
-    for &v in content {
-        min = min.min(v);
-        max = max.max(v);
-    }
-
-    let range = max - min;
     content
         .iter()
-        .map(|x| BARS[((x - min) / range * 7.).clamp(0., 7.) as usize])
+        .map(|x| BARS[(x / max * 8.).clamp(0., 8.) as usize])
         .collect()
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -206,15 +206,15 @@ macro_rules! make_log_macro {
 
 pub fn format_bar_graph(content: &[f64], max: f64) -> String {
     // (x * one eighth block) https://en.wikipedia.org/wiki/Block_Elements
-    static BARS: [char; 9] = [
-        ' ',
+    static BARS: [char; 10] = [
+        ' ', '_',
         '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}', '\u{2585}', '\u{2586}', '\u{2587}',
         '\u{2588}',
     ];
 
     content
         .iter()
-        .map(|x| BARS[(x / max * 8.).round().clamp(0., 8.) as usize])
+        .map(|x| BARS[(x / max * 9.).ceil().clamp(0., 9.) as usize])
         .collect()
 }
 


### PR DESCRIPTION
Hey there 👋,

thanks for the awesome bar, I am using it for quite some time and I happy with it :-)

Regarding, the network graph, for me, the current implementation is not very intuitive. The main reason is that it is relative and the base is constantly changing. I am usually interested in the network load in relation to my network capability, such that a bit "more" noise does not show up as spikes.

This PR adds the capability to define your network up and down speed. I am using this implementation on my site for quite some time already. It works stable and reliable on my site.

I am open for discussion, because although this is much more intuitive to me, it does not have to be the case for everyone. I still believe that for most users, it will be more intuitive. Let's discuss improvements / alternatives if you don't agree.

Here is an example:
```toml
[[block]]
block = "net"
network_speed_down = 100.0  # 100 Mbit/s down
network_speed_up = 20.0     # 20 Mbit/s up
```

The result would be:
- With 50 Mbit/s traffic:   `graph_down` shows 50% of full bar (not 100% due to spike)