### PR TITLE
Disable ixdtf dependency for icu_datetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
  "iana-time-zone",
  "icalendar",
  "icu_datetime",
- "icu_locale_core",
+ "icu_locale",
  "indexmap",
  "inotify",
  "itertools 0.13.0",
@@ -1229,7 +1229,6 @@ dependencies = [
  "icu_locale",
  "icu_locale_core",
  "icu_provider",
- "ixdtf",
  "tinystr",
  "zerovec",
 ]
@@ -1442,7 +1441,6 @@ dependencies = [
  "icu_locale_core",
  "icu_provider",
  "icu_time_data",
- "ixdtf",
  "serde",
  "zerotrie",
  "zerovec",
@@ -1568,12 +1566,6 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "ixdtf"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1"
 
 [[package]]
 name = "js-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pulseaudio = ["libpulse-binding"]
 pipewire = ["dep:pipewire"]
 notmuch = ["dep:notmuch"]
 maildir = ["dep:maildir", "glob"]
-icu_calendar = ["dep:icu_datetime", "dep:icu_locale_core"]
+icu_calendar = ["dep:icu_datetime", "dep:icu_locale"]
 debug_borders = []                # Make widgets' borders visible
 
 [package.metadata.docs.rs]
@@ -47,8 +47,8 @@ futures = { version = "0.3.31", default-features = false }
 glob = { version = "0.3.1", optional = true }
 iana-time-zone = "0.1.60"
 icalendar = { version = "0.17.9", features = ["chrono-tz", "recurrence"] }
-icu_datetime = { version = "2.2", optional = true }
-icu_locale_core = { version = "2.2", optional = true }
+icu_datetime = { version = "2.2", optional = true, default-features = false, features = ["compiled_data"] }
+icu_locale = { version = "2.2", optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
 inotify = "0.11"
 itertools = "0.13"

--- a/src/formatting/formatter/datetime.rs
+++ b/src/formatting/formatter/datetime.rs
@@ -23,7 +23,7 @@ pub enum DatetimeFormatter {
     #[cfg(feature = "icu_calendar")]
     Icu {
         fieldset: icu_datetime::fieldsets::enums::CompositeDateTimeFieldSet,
-        locale: icu_locale_core::Locale,
+        locale: icu_locale::Locale,
     },
 }
 
@@ -73,7 +73,7 @@ impl DatetimeFormatter {
                         None => None,
                         _ => Err(Error::new("Invalid precision value"))?,
                     };
-                    let locale = icu_locale_core::Locale::from_str(locale)
+                    let locale = icu_locale::Locale::from_str(locale)
                         .ok()
                         .error("invalid locale")?;
                     let fieldset = match format {


### PR DESCRIPTION
ixdtf is a parser for Internet eXtended DateTime Format, but it's not used.