### PR TITLE
Rework handling of imperial units.

### DIFF
--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -141,7 +141,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             "name" => Value::text(info.name.clone()),
             "utilization" => Value::percents(info.utilization),
             "memory" => Value::bytes(if show_mem_total {info.mem_total} else {info.mem_used}).with_instance(MEM_BTN),
-            "temperature" => Value::degrees(info.temperature),
+            "temperature" => Value::degrees_c(info.temperature),
             "fan_speed" => Value::percents(info.fan_speed).with_instance(FAN_BTN).underline(fan_controlled).italic(fan_controlled),
             "clocks" => Value::hertz(info.clocks),
             "power" => Value::watts(info.power_draw),

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -56,6 +56,7 @@
 //! - `thermometer`
 
 use super::prelude::*;
+use crate::util::celsius_to_fahrenheit;
 use sensors::FeatureType::SENSORS_FEATURE_TEMP;
 use sensors::Sensors;
 use sensors::SubfeatureType::SENSORS_SUBFEATURE_TEMP_INPUT;
@@ -94,7 +95,14 @@ impl TemperatureScale {
     pub fn from_celsius(self, val: f64) -> f64 {
         match self {
             Self::Celsius => val,
-            Self::Fahrenheit => val * 1.8 + 32.0,
+            Self::Fahrenheit => celsius_to_fahrenheit(val),
+        }
+    }
+
+    pub fn as_value(self, val: f64) -> Value {
+        match self {
+            Self::Celsius => Value::degrees_c(val),
+            Self::Fahrenheit => Value::degrees_f(val),
         }
     }
 }
@@ -190,9 +198,9 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
         widget.set_values(map! {
             "icon" => Value::icon_progression_bound("thermometer", max_temp, good, warn),
-            "average" => Value::degrees(avg_temp),
-            "min" => Value::degrees(min_temp),
-            "max" => Value::degrees(max_temp),
+            "average" => config_scale.as_value(avg_temp),
+            "min" => config_scale.as_value(min_temp),
+            "max" => config_scale.as_value(max_temp),
         });
 
         api.set_widget(widget)?;

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -278,8 +278,8 @@ impl WeatherResult {
             "location" => Value::text(self.location),
             //current_weather
             "icon" => Value::icon(self.current_weather.icon.to_icon_str()),
-            "temp" => Value::degrees(self.current_weather.temp),
-            "apparent" => Value::degrees(self.current_weather.apparent),
+            "temp" => Value::degrees_c(self.current_weather.temp),
+            "apparent" => Value::degrees_c(self.current_weather.apparent),
             "humidity" => Value::percents(self.current_weather.humidity),
             "weather" => Value::text(self.current_weather.weather),
             "weather_verbose" => Value::text(self.current_weather.weather_verbose),
@@ -295,8 +295,8 @@ impl WeatherResult {
                 ({$($suffix: literal => $src: expr),* $(,)?}) => {
                     map!{ @extend values
                         $(
-                            concat!("temp_f", $suffix) => Value::degrees($src.temp),
-                            concat!("apparent_f", $suffix) => Value::degrees($src.apparent),
+                            concat!("temp_f", $suffix) => Value::degrees_c($src.temp),
+                            concat!("apparent_f", $suffix) => Value::degrees_c($src.apparent),
                             concat!("humidity_f", $suffix) => Value::percents($src.humidity),
                             concat!("wind_f", $suffix) => Value::number($src.wind),
                             concat!("wind_kmh_f", $suffix) => Value::number($src.wind_kmh),

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -19,6 +19,7 @@
 //! `interval` | Update interval, in seconds. | `600`
 //! `autolocate` | Gets your location using the ipapi.co IP location service (no API key required). If the API call fails then the block will fallback to service specific location config. | `false`
 //! `autolocate_interval` | Update interval for `autolocate` in seconds or "once" | `interval`
+//! `units` | Either `"metric"` (°C, m/s) or `"imperial"` (°F, mph). If set, will supersede any `units` setting in the service-specific config. | `"metric"`
 //!
 //! # OpenWeatherMap Options
 //!
@@ -32,7 +33,7 @@
 //! `city_id` | OpenWeatherMap's ID for the city. (Deprecated) | Yes* | None
 //! `place` | OpenWeatherMap 'By {city name},{state code},{country code}' search query. See [here](https://openweathermap.org/api/geocoding-api#direct_name). Consumes an additional API call | Yes* | None
 //! `zip` | OpenWeatherMap 'By {zip code},{country code}' search query. See [here](https://openweathermap.org/api/geocoding-api#direct_zip). Consumes an additional API call | Yes* | None
-//! `units` | Either `"metric"` or `"imperial"`. | No | `"metric"`
+//! `units` *DEPRECATED* | Either `"metric"` or `"imperial"`. | No | `"metric"`
 //! `lang` | Language code. See [here](https://openweathermap.org/current#multi). Currently only affects `weather_verbose` key. | No | `"en"`
 //! `forecast_hours` | How many hours should be forecast (must be increments of 3 hours, max 120 hours) | No | 12
 //!
@@ -63,7 +64,7 @@
 //! `name` | `nws`. | Yes | None
 //! `coordinates` | GPS latitude longitude coordinates as a tuple, example: `["39.2362","9.3317"]` | Required if `autolocate = false` | None
 //! `forecast_hours` | How many hours should be forecast | No | 12
-//! `units` | Either `"metric"` or `"imperial"`. | No | `"metric"`
+//! `units` *DEPRECATED* | Either `"metric"` or `"imperial"`. | No | `"metric"`
 //!
 //! Forecasts gather statistics from each hour between now and the `forecast_hours` value, and
 //! provide predicted weather at the set number of hours into the future.
@@ -76,14 +77,14 @@
 //! `icon{,_ffin}`                               | Icon representing the weather                                                 | Icon     | -
 //! `weather{,_ffin}`                            | Textual brief description of the weather, e.g. "Raining"                      | Text     | -
 //! `weather_verbose{,_ffin}`                    | Textual verbose description of the weather, e.g. "overcast clouds"            | Text     | -
-//! `temp{,_{favg,fmin,fmax,ffin}}`              | Temperature                                                                   | Number   | degrees
-//! `apparent{,_{favg,fmin,fmax,ffin}}`          | Australian Apparent Temperature                                               | Number   | degrees
+//! `temp{,_{favg,fmin,fmax,ffin}}`              | Temperature (°C or °F, based on `units`)                                      | Number   | degrees
+//! `apparent{,_{favg,fmin,fmax,ffin}}`          | Australian Apparent Temperature (°C or °F, based on `units`)                  | Number   | degrees
 //! `humidity{,_{favg,fmin,fmax,ffin}}`          | Humidity                                                                      | Number   | %
-//! `wind{,_{favg,fmin,fmax,ffin}}`              | Wind speed                                                                    | Number   | -
+//! `wind{,_{favg,fmin,fmax,ffin}}`              | Wind speed (m/s or mph, based on `units`)                                     | Number   | -
 //! `wind_kmh{,_{favg,fmin,fmax,ffin}}`          | Wind speed. The wind speed in km/h                                            | Number   | -
 //! `direction{,_{favg,fmin,fmax,ffin}}`         | Wind direction, e.g. "NE"                                                     | Text     | -
-//! `sunrise`                                    | Time of sunrise (may be absent if it's a polar day or polar night)[^polar]            | DateTime | -
-//! `sunset`                                     | Time of sunset (may be absent if it's a polar day or polar night)[^polar]             | DateTime | -
+//! `sunrise`                                    | Time of sunrise (may be absent if it's a polar day or polar night)[^polar]    | DateTime | -
+//! `sunset`                                     | Time of sunset (may be absent if it's a polar day or polar night)[^polar]     | DateTime | -
 //!
 //! [^polar]: On polar days and polar nights, sunrise or sunset may not occur on a given day, and thus the corresponding value may be absent.
 //! This behaviour depends on the weather service used.
@@ -148,10 +149,10 @@
 use chrono::{DateTime, Utc};
 use sunrise::{SolarDay, SolarEvent};
 
+use super::prelude::*;
 use crate::formatting::Format;
 pub(super) use crate::geolocator::IPAddressInfo;
-
-use super::prelude::*;
+use crate::util::{celsius_to_fahrenheit, kmh_to_mph, kmh_to_mps};
 
 pub mod met_no;
 pub mod nws;
@@ -169,6 +170,7 @@ pub struct Config {
     #[serde(default)]
     pub autolocate: bool,
     pub autolocate_interval: Option<Seconds>,
+    pub units: Option<UnitSystem>,
 }
 
 fn default_interval() -> Seconds {
@@ -241,7 +243,6 @@ struct WeatherMoment {
     temp: f64,
     apparent: f64,
     humidity: f64,
-    wind: f64,
     wind_kmh: f64,
     wind_direction: Option<f64>,
 }
@@ -250,7 +251,6 @@ struct ForecastAggregate {
     temp: f64,
     apparent: f64,
     humidity: f64,
-    wind: f64,
     wind_kmh: f64,
     wind_direction: Option<f64>,
 }
@@ -259,7 +259,6 @@ struct ForecastAggregateSegment {
     temp: Option<f64>,
     apparent: Option<f64>,
     humidity: Option<f64>,
-    wind: Option<f64>,
     wind_kmh: Option<f64>,
     wind_direction: Option<f64>,
 }
@@ -273,17 +272,17 @@ struct WeatherResult {
 }
 
 impl WeatherResult {
-    fn into_values(self) -> Values {
+    fn into_values(self, unit_system: &UnitSystem) -> Values {
         let mut values = map! {
             "location" => Value::text(self.location),
             //current_weather
             "icon" => Value::icon(self.current_weather.icon.to_icon_str()),
-            "temp" => Value::degrees_c(self.current_weather.temp),
-            "apparent" => Value::degrees_c(self.current_weather.apparent),
+            "temp" => unit_system.temperature_value(self.current_weather.temp),
+            "apparent" => unit_system.temperature_value(self.current_weather.apparent),
             "humidity" => Value::percents(self.current_weather.humidity),
             "weather" => Value::text(self.current_weather.weather),
             "weather_verbose" => Value::text(self.current_weather.weather_verbose),
-            "wind" => Value::number(self.current_weather.wind),
+            "wind" => unit_system.wind_speed_value(self.current_weather.wind_kmh),
             "wind_kmh" => Value::number(self.current_weather.wind_kmh),
             "direction" => Value::text(convert_wind_direction(self.current_weather.wind_direction).into()),
             [if let Some(sunrise) = self.sunrise] "sunrise" => Value::datetime(sunrise, None),
@@ -295,10 +294,10 @@ impl WeatherResult {
                 ({$($suffix: literal => $src: expr),* $(,)?}) => {
                     map!{ @extend values
                         $(
-                            concat!("temp_f", $suffix) => Value::degrees_c($src.temp),
-                            concat!("apparent_f", $suffix) => Value::degrees_c($src.apparent),
+                            concat!("temp_f", $suffix) => unit_system.temperature_value($src.temp),
+                            concat!("apparent_f", $suffix) => unit_system.temperature_value($src.apparent),
                             concat!("humidity_f", $suffix) => Value::percents($src.humidity),
-                            concat!("wind_f", $suffix) => Value::number($src.wind),
+                            concat!("wind_f", $suffix) => unit_system.wind_speed_value($src.wind_kmh),
                             concat!("wind_kmh_f", $suffix) => Value::number($src.wind_kmh),
                             concat!("direction_f", $suffix) => Value::text(convert_wind_direction($src.wind_direction).into()),
                         )*
@@ -338,8 +337,6 @@ impl Forecast {
         let mut apparent_count = 0.0;
         let mut humidity_avg = 0.0;
         let mut humidity_count = 0.0;
-        let mut wind_north_avg = 0.0;
-        let mut wind_east_avg = 0.0;
         let mut wind_kmh_north_avg = 0.0;
         let mut wind_kmh_east_avg = 0.0;
         let mut wind_count = 0.0;
@@ -347,7 +344,6 @@ impl Forecast {
             temp: f64::MIN,
             apparent: f64::MIN,
             humidity: f64::MIN,
-            wind: f64::MIN,
             wind_kmh: f64::MIN,
             wind_direction: None,
         };
@@ -355,7 +351,6 @@ impl Forecast {
             temp: f64::MAX,
             apparent: f64::MAX,
             humidity: f64::MAX,
-            wind: f64::MAX,
             wind_kmh: f64::MAX,
             wind_direction: None,
         };
@@ -379,27 +374,21 @@ impl Forecast {
                 humidity_count += 1.0;
             }
 
-            if let Some(wind) = val.wind
-                && let Some(wind_kmh) = val.wind_kmh
-            {
+            if let Some(wind_kmh) = val.wind_kmh {
                 if let Some(degrees) = val.wind_direction {
                     let (sin, cos) = degrees.to_radians().sin_cos();
-                    wind_north_avg += wind * cos;
-                    wind_east_avg += wind * sin;
                     wind_kmh_north_avg += wind_kmh * cos;
                     wind_kmh_east_avg += wind_kmh * sin;
                     wind_count += 1.0;
                 }
 
-                if wind > max.wind {
+                if wind_kmh > max.wind_kmh {
                     max.wind_direction = val.wind_direction;
-                    max.wind = wind;
                     max.wind_kmh = wind_kmh;
                 }
 
-                if wind < min.wind {
+                if wind_kmh < min.wind_kmh {
                     min.wind_direction = val.wind_direction;
-                    min.wind = wind;
                     min.wind_kmh = wind_kmh;
                 }
             }
@@ -410,15 +399,14 @@ impl Forecast {
         apparent_avg /= apparent_count;
 
         // Calculate the wind results separately, discarding invalid wind values
-        let (wind_avg, wind_kmh_avg, wind_direction_avg) = if wind_count == 0.0 {
-            (0.0, 0.0, None)
+        let (wind_kmh_avg, wind_direction_avg) = if wind_count == 0.0 {
+            (0.0, None)
         } else {
             (
-                wind_east_avg.hypot(wind_north_avg) / wind_count,
                 wind_kmh_east_avg.hypot(wind_kmh_north_avg) / wind_count,
                 Some(
-                    wind_east_avg
-                        .atan2(wind_north_avg)
+                    wind_kmh_east_avg
+                        .atan2(wind_kmh_north_avg)
                         .to_degrees()
                         .rem_euclid(360.0),
                 ),
@@ -429,7 +417,6 @@ impl Forecast {
             temp: temp_avg,
             apparent: apparent_avg,
             humidity: humidity_avg,
-            wind: wind_avg,
             wind_kmh: wind_kmh_avg,
             wind_direction: wind_direction_avg,
         };
@@ -447,15 +434,22 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         None => None,
     };
 
-    let provider: Box<dyn WeatherProvider + Send + Sync> = match &config.service {
-        WeatherService::MetNo(service_config) => Box::new(met_no::Service::new(service_config)?),
-        WeatherService::OpenWeatherMap(service_config) => {
-            Box::new(open_weather_map::Service::new(config.autolocate, service_config).await?)
-        }
-        WeatherService::Nws(service_config) => {
-            Box::new(nws::Service::new(config.autolocate, service_config).await?)
-        }
-    };
+    let (provider, service_units): (Box<dyn WeatherProvider + Send + Sync>, UnitSystem) =
+        match &config.service {
+            WeatherService::MetNo(service_config) => (
+                Box::new(met_no::Service::new(service_config)?),
+                UnitSystem::default(),
+            ),
+            WeatherService::OpenWeatherMap(service_config) => (
+                Box::new(open_weather_map::Service::new(config.autolocate, service_config).await?),
+                service_config.units,
+            ),
+            WeatherService::Nws(service_config) => (
+                Box::new(nws::Service::new(config.autolocate, service_config).await?),
+                service_config.units,
+            ),
+        };
+    let units = config.units.unwrap_or(service_units);
 
     let autolocate_interval = config.autolocate_interval.unwrap_or(config.interval);
     let need_forecast = need_forecast(&format, format_alt.as_ref());
@@ -472,7 +466,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
         let fetch = || provider.get_weather(location.as_ref(), need_forecast);
         let data = fetch.retry(ExponentialBuilder::default()).await?;
-        let data_values = data.into_values();
+        let data_values = data.into_values(&units);
 
         loop {
             let mut widget = Widget::new().with_format(format.clone());
@@ -536,7 +530,7 @@ fn calculate_sunrise_sunset(
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, SmartDefault)]
 #[serde(rename_all = "lowercase")]
-enum UnitSystem {
+pub enum UnitSystem {
     #[default]
     Metric,
     Imperial,
@@ -547,6 +541,22 @@ impl AsRef<str> for UnitSystem {
         match self {
             UnitSystem::Metric => "metric",
             UnitSystem::Imperial => "imperial",
+        }
+    }
+}
+
+impl UnitSystem {
+    fn temperature_value(&self, temp_celsius: f64) -> Value {
+        match self {
+            UnitSystem::Metric => Value::degrees_c(temp_celsius),
+            UnitSystem::Imperial => Value::degrees_f(celsius_to_fahrenheit(temp_celsius)),
+        }
+    }
+
+    fn wind_speed_value(&self, speed_kmh: f64) -> Value {
+        match self {
+            UnitSystem::Metric => Value::number(kmh_to_mps(speed_kmh)),
+            UnitSystem::Imperial => Value::number(kmh_to_mph(speed_kmh)),
         }
     }
 }
@@ -589,7 +599,6 @@ mod tests {
                         temp: None,
                         apparent: None,
                         humidity: None,
-                        wind: Some(1.0),
                         wind_kmh: Some(3.6),
                         wind_direction: Some(degrees),
                     },
@@ -597,14 +606,12 @@ mod tests {
                         temp: None,
                         apparent: None,
                         humidity: None,
-                        wind: Some(2.0),
                         wind_kmh: Some(7.2),
                         wind_direction: Some(degrees),
                     },
                 ],
                 WeatherMoment::default(),
             );
-            assert!((forecast.avg.wind - 1.5).abs() < 0.1);
             assert!((forecast.avg.wind_kmh - 5.4).abs() < 0.1);
             assert!((forecast.avg.wind_direction.unwrap() - degrees).abs() < 0.1);
 
@@ -624,7 +631,6 @@ mod tests {
                         temp: None,
                         apparent: None,
                         humidity: None,
-                        wind: Some(1.0),
                         wind_kmh: Some(3.6),
                         wind_direction: Some(low),
                     },
@@ -632,7 +638,6 @@ mod tests {
                         temp: None,
                         apparent: None,
                         humidity: None,
-                        wind: Some(1.0),
                         wind_kmh: Some(3.6),
                         wind_direction: Some(high),
                     },
@@ -659,7 +664,6 @@ mod tests {
                         temp: None,
                         apparent: None,
                         humidity: None,
-                        wind: Some(1.0),
                         wind_kmh: Some(3.6),
                         wind_direction: Some(low),
                     },
@@ -667,7 +671,6 @@ mod tests {
                         temp: None,
                         apparent: None,
                         humidity: None,
-                        wind: Some(2.0),
                         wind_kmh: Some(7.2),
                         wind_direction: Some(high),
                     },

--- a/src/blocks/weather/met_no.rs
+++ b/src/blocks/weather/met_no.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::util::mps_to_kmh;
 
 type LegendsStore = HashMap<String, LegendsResult>;
 
@@ -103,8 +104,7 @@ impl ForecastTimeStep {
             humidity,
             weather: translated.clone(),
             weather_verbose: translated,
-            wind: wind_speed,
-            wind_kmh: wind_speed * 3.6,
+            wind_kmh: mps_to_kmh(wind_speed),
             wind_direction: instant.wind_from_direction,
             icon: weather_to_icon(summary, is_night),
         }
@@ -130,8 +130,7 @@ impl ForecastTimeStep {
             temp: instant.air_temperature,
             apparent,
             humidity: instant.relative_humidity,
-            wind: instant.wind_speed,
-            wind_kmh: instant.wind_speed.map(|t| t * 3.6),
+            wind_kmh: instant.wind_speed.map(mps_to_kmh),
             wind_direction: instant.wind_from_direction,
         }
     }

--- a/src/blocks/weather/nws.rs
+++ b/src/blocks/weather/nws.rs
@@ -12,11 +12,10 @@
 //!
 
 use super::*;
+use crate::util::{fahrenheit_to_celsius, kmh_to_mps, mph_to_kmh};
 use serde::Deserialize;
 
 const API_URL: &str = "https://api.weather.gov/";
-
-const MPH_TO_KPH: f64 = 1.609344;
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(tag = "name", rename_all = "lowercase", deny_unknown_fields, default)]
@@ -25,7 +24,7 @@ pub struct Config {
     #[default(12)]
     forecast_hours: usize,
     #[serde(default)]
-    units: UnitSystem,
+    pub(super) units: UnitSystem,
 }
 
 #[derive(Clone, Debug)]
@@ -51,7 +50,6 @@ impl<'a> Service<'a> {
                 Self::get_location_query(
                     coords.0.parse().error("Unable to convert string to f64")?,
                     coords.1.parse().error("Unable to convert string to f64")?,
-                    config.units,
                 )
                 .await?,
             )
@@ -59,7 +57,7 @@ impl<'a> Service<'a> {
         Ok(Self { config, location })
     }
 
-    async fn get_location_query(lat: f64, lon: f64, units: UnitSystem) -> Result<LocationInfo> {
+    async fn get_location_query(lat: f64, lon: f64) -> Result<LocationInfo> {
         let points_url = format!("{API_URL}/points/{lat},{lon}");
 
         let response: ApiPoints = REQWEST_CLIENT
@@ -70,11 +68,7 @@ impl<'a> Service<'a> {
             .json()
             .await
             .error("Failed to parse zone resolution request")?;
-        let mut query = response.properties.forecast_hourly;
-        query.push_str(match units {
-            UnitSystem::Metric => "?units=si",
-            UnitSystem::Imperial => "?units=us",
-        });
+        let query = response.properties.forecast_hourly + "?units=si";
         let location = response.properties.relative_location.properties;
         let name = format!("{}, {}", location.city, location.state);
         Ok(LocationInfo {
@@ -176,39 +170,28 @@ impl ApiForecast {
         .to_string()
     }
 
-    fn wind_speed(&self) -> f64 {
-        if self.wind_speed.unit_code.ends_with("km_h-1") {
-            // m/s
-            self.wind_speed.value / 3.6
-        } else {
-            // mph
-            self.wind_speed.value
-        }
-    }
-
     fn wind_kmh(&self) -> f64 {
         if self.wind_speed.unit_code.ends_with("km_h-1") {
             self.wind_speed.value
         } else {
-            self.wind_speed.value * MPH_TO_KPH
+            mph_to_kmh(self.wind_speed.value)
+        }
+    }
+
+    fn temp(&self) -> f64 {
+        if self.temperature.unit_code.ends_with("degC") {
+            self.temperature.value
+        } else {
+            fahrenheit_to_celsius(self.temperature.value)
         }
     }
 
     fn apparent_temp(&self) -> f64 {
-        let temp = if self.temperature.unit_code.ends_with("degC") {
-            self.temperature.value
-        } else {
-            (self.temperature.value - 32.0) * 5.0 / 9.0
-        };
+        let temp = self.temp();
         let humidity = self.relative_humidity.value;
         // wind_speed in m/s
-        let wind_speed = self.wind_kmh() / 3.6;
-        let apparent = australian_apparent_temp(temp, humidity, wind_speed);
-        if self.temperature.unit_code.ends_with("degC") {
-            apparent
-        } else {
-            (apparent * 9.0 / 5.0) + 32.0
-        }
+        let wind_speed = kmh_to_mps(self.wind_kmh());
+        australian_apparent_temp(temp, humidity, wind_speed)
     }
 
     fn to_moment(&self) -> WeatherMoment {
@@ -218,10 +201,9 @@ impl ApiForecast {
             icon,
             weather,
             weather_verbose: self.short_forecast.clone(),
-            temp: self.temperature.value,
+            temp: self.temp(),
             apparent: self.apparent_temp(),
             humidity: self.relative_humidity.value,
-            wind: self.wind_speed(),
             wind_kmh: self.wind_kmh(),
             wind_direction: self.wind_direction(),
         }
@@ -229,10 +211,9 @@ impl ApiForecast {
 
     fn to_aggregate(&self) -> ForecastAggregateSegment {
         ForecastAggregateSegment {
-            temp: Some(self.temperature.value),
+            temp: Some(self.temp()),
             apparent: Some(self.apparent_temp()),
             humidity: Some(self.relative_humidity.value),
-            wind: Some(self.wind_speed()),
             wind_kmh: Some(self.wind_kmh()),
             wind_direction: self.wind_direction(),
         }
@@ -247,7 +228,7 @@ impl WeatherProvider for Service<'_> {
         need_forecast: bool,
     ) -> Result<WeatherResult> {
         let location = if let Some(coords) = autolocated {
-            Self::get_location_query(coords.latitude, coords.longitude, self.config.units).await?
+            Self::get_location_query(coords.latitude, coords.longitude).await?
         } else {
             self.location.clone().error("No location was provided")?
         };

--- a/src/blocks/weather/open_weather_map.rs
+++ b/src/blocks/weather/open_weather_map.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::util::mps_to_kmh;
 use chrono::{DateTime, Utc};
 use reqwest::Url;
 use serde::{Deserializer, de};
@@ -24,7 +25,7 @@ pub struct Config {
     zip: Option<String>,
     coordinates: Option<(String, String)>,
     #[serde(default)]
-    units: UnitSystem,
+    pub(super) units: UnitSystem,
     #[default("en")]
     lang: String,
     #[default(12)]
@@ -53,7 +54,6 @@ where
 
 pub(super) struct Service<'a> {
     api_key: &'a String,
-    units: &'a UnitSystem,
     lang: &'a String,
     location_query: Option<LocationSpecifier>,
     forecast_hours: usize,
@@ -112,7 +112,6 @@ impl<'a> Service<'a> {
         })?;
         Ok(Self {
             api_key,
-            units: &config.units,
             lang: &config.lang,
             location_query: get_location_query(autolocate, config).await?,
             forecast_hours: config.forecast_hours,
@@ -226,15 +225,7 @@ struct ApiInstantResponse {
 }
 
 impl ApiInstantResponse {
-    fn wind_kmh(&self, units: &UnitSystem) -> f64 {
-        self.wind.speed
-            * match units {
-                UnitSystem::Metric => 3.6,
-                UnitSystem::Imperial => 3.6 * 0.447,
-            }
-    }
-
-    fn to_moment(&self, units: &UnitSystem, current_data: &ApiCurrentResponse) -> WeatherMoment {
+    fn to_moment(&self, current_data: &ApiCurrentResponse) -> WeatherMoment {
         let is_night = current_data.sys.sunrise >= self.dt || self.dt >= current_data.sys.sunset;
 
         WeatherMoment {
@@ -244,19 +235,17 @@ impl ApiInstantResponse {
             temp: self.main.temp,
             apparent: self.main.feels_like,
             humidity: self.main.humidity,
-            wind: self.wind.speed,
-            wind_kmh: self.wind_kmh(units),
+            wind_kmh: mps_to_kmh(self.wind.speed),
             wind_direction: self.wind.deg,
         }
     }
 
-    fn to_aggregate(&self, units: &UnitSystem) -> ForecastAggregateSegment {
+    fn to_aggregate(&self) -> ForecastAggregateSegment {
         ForecastAggregateSegment {
             temp: Some(self.main.temp),
             apparent: Some(self.main.feels_like),
             humidity: Some(self.main.humidity),
-            wind: Some(self.wind.speed),
-            wind_kmh: Some(self.wind_kmh(units)),
+            wind_kmh: Some(mps_to_kmh(self.wind.speed)),
             wind_direction: self.wind.deg,
         }
     }
@@ -271,8 +260,8 @@ struct ApiCurrentResponse {
 }
 
 impl ApiCurrentResponse {
-    fn to_moment(&self, units: &UnitSystem) -> WeatherMoment {
-        self.instant.to_moment(units, self)
+    fn to_moment(&self) -> WeatherMoment {
+        self.instant.to_moment(self)
     }
 }
 
@@ -331,7 +320,7 @@ impl WeatherProvider for Service<'_> {
 
         let common_query_params = [
             ("appid", self.api_key.as_str()),
-            ("units", self.units.as_ref()),
+            ("units", "metric"),
             ("lang", self.lang.as_str()),
         ];
 
@@ -347,7 +336,7 @@ impl WeatherProvider for Service<'_> {
             .await
             .error("Current weather request failed")?;
 
-        let current_weather = current_data.to_moment(self.units);
+        let current_weather = current_data.to_moment();
 
         let sunrise = Some(
             DateTime::<Utc>::from_timestamp(current_data.sys.sunrise, 0)
@@ -392,14 +381,14 @@ impl WeatherProvider for Service<'_> {
             .list
             .iter()
             .take(self.forecast_hours)
-            .map(|f| f.to_aggregate(self.units))
+            .map(|f| f.to_aggregate())
             .collect();
 
         let fin = forecast_data
             .list
             .last()
             .error("no weather available")?
-            .to_moment(self.units, &current_data);
+            .to_moment(&current_data);
 
         let forecast = Some(Forecast::new(&data_agg, fin));
 

--- a/src/formatting/unit.rs
+++ b/src/formatting/unit.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use super::prefix::Prefix;
 use crate::errors::*;
+use crate::util::{celsius_to_fahrenheit, fahrenheit_to_celsius};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Unit {
@@ -12,8 +13,13 @@ pub enum Unit {
     Bits,
     /// `%`
     Percents,
-    /// `deg`
-    Degrees,
+    /// `deg` (deprecated - use `degC` or `degF`)
+    #[deprecated = "Use DegreesC or DegreesF instead"]
+    DegreesUnspecified,
+    /// `degC`
+    DegreesC,
+    /// `degF`
+    DegreesF,
     /// `s`
     Seconds,
     /// `W`
@@ -30,7 +36,8 @@ impl fmt::Display for Unit {
             Self::Bytes => "B",
             Self::Bits => "b",
             Self::Percents => "%",
-            Self::Degrees => "°",
+            #[expect(deprecated)]
+            Self::DegreesUnspecified | Self::DegreesC | Self::DegreesF => "°",
             Self::Seconds => "s",
             Self::Watts => "W",
             Self::Hertz => "Hz",
@@ -47,7 +54,10 @@ impl FromStr for Unit {
             "B" => Ok(Unit::Bytes),
             "b" => Ok(Unit::Bits),
             "%" => Ok(Unit::Percents),
-            "deg" => Ok(Unit::Degrees),
+            #[expect(deprecated)]
+            "deg" => Ok(Unit::DegreesUnspecified),
+            "degC" => Ok(Unit::DegreesC),
+            "degF" => Ok(Unit::DegreesF),
             "s" => Ok(Unit::Seconds),
             "W" => Ok(Unit::Watts),
             "Hz" => Ok(Unit::Hertz),
@@ -63,6 +73,11 @@ impl Unit {
             (x, y) if x == y => Ok(value),
             (Self::Bytes, Self::Bits) => Ok(value * 8.),
             (Self::Bits, Self::Bytes) => Ok(value / 8.),
+            #[expect(deprecated)]
+            (Self::DegreesC, Self::DegreesUnspecified)
+            | (Self::DegreesF, Self::DegreesUnspecified) => Ok(value),
+            (Self::DegreesC, Self::DegreesF) => Ok(celsius_to_fahrenheit(value)),
+            (Self::DegreesF, Self::DegreesC) => Ok(fahrenheit_to_celsius(value)),
             _ => Err(Error::new(format!("Failed to convert '{self}' to '{unit}"))),
         }
     }
@@ -70,7 +85,12 @@ impl Unit {
     pub fn clamp_prefix(self, prefix: Prefix) -> Prefix {
         match self {
             Self::Bytes | Self::Bits => prefix.max(Prefix::One),
-            Self::Percents | Self::Degrees | Self::None => Prefix::One,
+            #[expect(deprecated)]
+            Self::Percents
+            | Self::DegreesUnspecified
+            | Self::DegreesC
+            | Self::DegreesF
+            | Self::None => Prefix::One,
             _ => prefix,
         }
     }

--- a/src/formatting/value.rs
+++ b/src/formatting/value.rs
@@ -114,8 +114,11 @@ impl Value {
     pub fn percents(val: impl IntoF64) -> Self {
         Self::number_unit(val, Unit::Percents)
     }
-    pub fn degrees(val: impl IntoF64) -> Self {
-        Self::number_unit(val, Unit::Degrees)
+    pub fn degrees_c(val: impl IntoF64) -> Self {
+        Self::number_unit(val, Unit::DegreesC)
+    }
+    pub fn degrees_f(val: impl IntoF64) -> Self {
+        Self::number_unit(val, Unit::DegreesF)
     }
     pub fn seconds(val: impl IntoF64) -> Self {
         Self::number_unit(val, Unit::Seconds)

--- a/src/util.rs
+++ b/src/util.rs
@@ -274,6 +274,16 @@ pub fn country_flag_from_iso_code(country_code: &str) -> String {
     String::from_utf8(vec![0xf0, 0x9f, 0x87, b1, 0xf0, 0x9f, 0x87, b2]).unwrap()
 }
 
+#[inline]
+pub fn celsius_to_fahrenheit(c: f64) -> f64 {
+    c * (9.0 / 5.0) + 32.0
+}
+
+#[inline]
+pub fn fahrenheit_to_celsius(f: f64) -> f64 {
+    (f - 32.0) * (5.0 / 9.0)
+}
+
 /// A shortcut for `Default::default()`
 /// See <https://github.com/rust-lang/rust/issues/73014>
 #[inline]

--- a/src/util.rs
+++ b/src/util.rs
@@ -284,6 +284,28 @@ pub fn fahrenheit_to_celsius(f: f64) -> f64 {
     (f - 32.0) * (5.0 / 9.0)
 }
 
+#[inline]
+pub fn mps_to_kmh(mps: f64) -> f64 {
+    mps * 3.6
+}
+
+#[inline]
+pub fn kmh_to_mps(kmh: f64) -> f64 {
+    kmh / 3.6
+}
+
+const KM_PER_MILE: f64 = 1.609344;
+
+#[inline]
+pub fn kmh_to_mph(kmh: f64) -> f64 {
+    kmh / KM_PER_MILE
+}
+
+#[inline]
+pub fn mph_to_kmh(mph: f64) -> f64 {
+    mph * KM_PER_MILE
+}
+
 /// A shortcut for `Default::default()`
 /// See <https://github.com/rust-lang/rust/issues/73014>
 #[inline]


### PR DESCRIPTION
This pull request covers two related, but separate changes:

## 1. Split `deg` unit into `degC` and `degF`.

The first change splits the existing `Unit::Degrees` into two separate units: `DegreesC` and `DegreesF`. These units can be inter-converted using the already-existing conversion mechanism in the `eng` formatter. This will allow temperatures represented internally in Celsius to be displayed in Fahrenheit, and vice-versa.

## 2. Move `units` to top level of `weather` block.

The second change extracts the `units` setting, previously provided by the OpenWeatherMap and NWS providers, and promotes it to be a first-class setting on the `weather` block. The weather providers now retrieve information exclusively in SI units (Celsius degrees and km/h), and conversion to the correct units for display is handled by the `weather` block during the conversion process to widget values. This simplifies switching between weather providers, allows users of Fahrenheit to make use of the met.no provider, and fixes issue #2282 regarding the NWS provider's handling of imperial units.