### PR TITLE
freebsd build

### DIFF
--- a/.github/workflows/pre-commit-freebsd.yml
+++ b/.github/workflows/pre-commit-freebsd.yml
@@ -1,0 +1,25 @@
+name: pre-commit-freebsd
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        hook: [
+                cargo-fmt,
+                cargo-clippy,
+                cargo-test,
+              ]
+    steps:
+    - uses: actions/checkout@v6
+    - name: Test in FreeBSD
+      uses: vmactions/freebsd-vm@v1
+      with:
+          run: |
+            pkg update
+            pkg install -y git py311-pre-commit rust
+            git config --global --add safe.directory "$GITHUB_WORKSPACE"
+            pre-commit run ${{ matrix.hook }} --all-files

--- a/.github/workflows/pre-commit-freebsd.yml
+++ b/.github/workflows/pre-commit-freebsd.yml
@@ -1,0 +1,25 @@
+name: pre-commit-freebsd
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        hook: [
+                cargo-fmt,
+                cargo-clippy,
+                cargo-test,
+              ]
+    steps:
+    - uses: actions/checkout@v6
+    - name: Test in FreeBSD
+      uses: vmactions/freebsd-vm@v1
+      with:
+          run: |
+            pkg update
+            pkg install -y git py312-pre-commit rust
+            git config --global --add safe.directory "$GITHUB_WORKSPACE"
+            pre-commit run ${{ matrix.hook }} --all-files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,23 @@ rustdoc-args = ["--cfg", "docsrs"]
 [workspace.dependencies]
 clap = { version = "4.0", default-features = false, features = ["std", "derive", "help", "usage"] }
 
+# Linux-specific dependencies
+[target.'cfg(target_os = "linux")'.dependencies]
+calibright = { version = "0.1.13", features = ["watch"] }
+inotify = "0.11"
+neli = { version = "0.6", features = ["async"] }
+neli-wifi = { version = "0.6", features = ["async"] }
+notmuch = { version = "0.8", optional = true }
+pipewire = { version = "0.10", default-features = false, optional = true }
+sensors = "0.2.2"
+swayipc-async = "3.0.0"
+
 [dependencies]
 async-trait = "0.1"
 backon = { version = "1.2", default-features = false, features = ["tokio-sleep"] }
 base64 = { version = "0.22.1" }
 bitflags = "2.9"
 bytes = "1.11"
-calibright = { version = "0.1.13", features = ["watch"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "unstable-locales"] }
 chrono-tz = { version = "0.10", features = ["serde"] }
 clap = { workspace = true }
@@ -50,24 +60,18 @@ icalendar = { version = "0.17.9", features = ["chrono-tz", "recurrence"] }
 icu_datetime = { version = "2.2", optional = true, default-features = false, features = ["compiled_data"] }
 icu_locale = { version = "2.2", optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
-inotify = "0.11"
 itertools = "0.13"
 libc = "0.2"
 libpulse-binding = { version = "2.0", default-features = false, optional = true }
 log = "0.4"
 maildir = { version = "0.6", optional = true }
-neli = { version = "0.6", features = ["async"] }
-neli-wifi = { version = "0.6", features = ["async"] }
 nix = { version = "0.29", features = ["fs", "process"] }
 nom = "8.0.0"
-notmuch = { version = "0.8", optional = true }
 oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"] }
 num-traits = "0.2"
-pipewire = { version = "0.10", default-features = false, optional = true }
 quick-xml = { version = "0.37", features = ["serialize"] }
 regex = "1.5"
 reqwest = { version = "0.12", features = ["json"] }
-sensors = "0.2.2"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 shellexpand = "3.0"
@@ -75,7 +79,6 @@ signal-hook = "0.3"
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 smart-default = "0.7"
 sunrise = "3.0"
-swayipc-async = "3.0.0"
 thiserror = "2.0"
 tokio-util = { version = "0.7", features = ["codec"] }
 toml = { version = "0.8", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,23 @@ rustdoc-args = ["--cfg", "docsrs"]
 [workspace.dependencies]
 clap = { version = "4.0", default-features = false, features = ["std", "derive", "help", "usage"] }
 
+# Linux-specific dependencies
+[target.'cfg(target_os = "linux")'.dependencies]
+calibright = { version = "0.1.13", features = ["watch"] }
+inotify = "0.11"
+neli = { version = "0.6", features = ["async"] }
+neli-wifi = { version = "0.6", features = ["async"] }
+notmuch = { version = "0.8", optional = true }
+pipewire = { version = "0.10", default-features = false, optional = true }
+sensors = "0.2.2"
+swayipc-async = "3.0.0"
+
 [dependencies]
 async-trait = "0.1"
 backon = { version = "1.2", default-features = false, features = ["tokio-sleep"] }
 base64 = { version = "0.22.1" }
 bitflags = "2.9"
 bytes = "1.11"
-calibright = { version = "0.1.13", features = ["watch"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "unstable-locales"] }
 chrono-tz = { version = "0.10", features = ["serde"] }
 clap = { workspace = true }
@@ -50,24 +60,18 @@ icalendar = { version = "0.17.9", features = ["chrono-tz", "recurrence"] }
 icu_datetime = { version = "2.2", optional = true, default-features = false, features = ["compiled_data"] }
 icu_locale = { version = "2.2", optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
-inotify = "0.11"
 itertools = "0.13"
 libc = "0.2"
 libpulse-binding = { version = "2.0", default-features = false, optional = true }
 log = "0.4"
 maildir = { version = "0.6", optional = true }
-neli = { version = "0.6", features = ["async"] }
-neli-wifi = { version = "0.6", features = ["async"] }
 nix = { version = "0.29", features = ["fs", "process"] }
 nom = "8.0.0"
-notmuch = { version = "0.8", optional = true }
 num-traits = "0.2"
 oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"] }
-pipewire = { version = "0.10", default-features = false, optional = true }
 quick-xml = { version = "0.37", features = ["serialize"] }
 regex = "1.5"
 reqwest = { version = "0.12", features = ["json"] }
-sensors = "0.2.2"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 shellexpand = "3.0"
@@ -75,7 +79,6 @@ signal-hook = "0.3"
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 smart-default = "0.7"
 sunrise = "3.0"
-swayipc-async = "3.0.0"
 thiserror = "2.0"
 tokio-util = { version = "0.7", features = ["codec"] }
 toml = { version = "0.8", features = ["preserve_order"] }

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -187,6 +187,7 @@ words:
   - vals
   - VCALENDAR
   - VEVENT
+  - vmactions
   - wayrs
   - wdoll
   - WLAN

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -50,12 +50,15 @@ pub(super) const RESTART_BLOCK_BTN: &str = "restart_block_btn";
 macro_rules! define_blocks {
     {
         $(
+            $(#[cfg(target_os = $target_os: literal)])?
             $(#[cfg(feature = $feat: literal)])?
             $(#[deprecated($($dep_k: ident = $dep_v: literal),+)])?
             $block: ident $(,)?
         )*
     } => {
         $(
+            $(#[cfg(target_os = $target_os)])?
+            $(#[cfg_attr(docsrs, doc(cfg(target_os = $target_os)))])?
             $(#[cfg(feature = $feat)])?
             $(#[cfg_attr(docsrs, doc(cfg(feature = $feat)))])?
             $(#[deprecated($($dep_k = $dep_v),+)])?
@@ -65,6 +68,7 @@ macro_rules! define_blocks {
         #[derive(Debug)]
         pub enum BlockConfig {
             $(
+                $(#[cfg(target_os = $target_os)])?
                 $(#[cfg(feature = $feat)])?
                 #[allow(non_camel_case_types)]
                 #[allow(deprecated)]
@@ -77,6 +81,7 @@ macro_rules! define_blocks {
             pub fn name(&self) -> &'static str {
                 match self {
                     $(
+                        $(#[cfg(target_os = $target_os)])?
                         $(#[cfg(feature = $feat)])?
                         Self::$block { .. } => stringify!($block),
                     )*
@@ -87,6 +92,7 @@ macro_rules! define_blocks {
             pub fn spawn(self, api: CommonApi, futures: &mut FuturesUnordered<BoxedFuture<()>>) {
                 match self {
                     $(
+                        $(#[cfg(target_os = $target_os)])?
                         $(#[cfg(feature = $feat)])?
                         #[allow(deprecated)]
                         Self::$block(config) => futures.push(async move {
@@ -147,12 +153,21 @@ macro_rules! define_blocks {
 
                 match block_name {
                     $(
+                        $(#[cfg(target_os = $target_os)])?
                         $(#[cfg(feature = $feat)])?
                         #[allow(deprecated)]
                         stringify!($block) => match $block::Config::deserialize(table) {
                             Ok(config) => Ok(BlockConfig::$block(config)),
                             Err(err) => Ok(BlockConfig::Err(stringify!($block), crate::errors::Error::new(err.to_string()))),
                         }
+                        $(
+                            #[cfg(not(target_os = $target_os))]
+                            stringify!($block) => Err(D::Error::custom(format!(
+                                "block {} is only available on {}",
+                                stringify!($block),
+                                $target_os,
+                            ))),
+                        )?
                         $(
                             #[cfg(not(feature = $feat))]
                             stringify!($block) => Err(D::Error::custom(format!(
@@ -171,17 +186,21 @@ macro_rules! define_blocks {
 
 define_blocks!(
     amd_gpu,
+    #[cfg(target_os = "linux")]
     backlight,
     battery,
     bluetooth,
     calendar,
     cpu,
+    #[cfg(target_os = "linux")]
     custom,
     custom_dbus,
     disk_iostats,
+    #[cfg(target_os = "linux")]
     disk_space,
     docker,
     external_ip,
+    #[cfg(target_os = "linux")]
     focused_window,
     github,
     hueshift,
@@ -192,27 +211,36 @@ define_blocks!(
     menu,
     memory,
     music,
+    #[cfg(target_os = "linux")]
     net,
     notify,
+    #[cfg(target_os = "linux")]
     #[cfg(feature = "notmuch")]
     notmuch,
     nvidia_gpu,
     packages,
     pomodoro,
+    #[cfg(target_os = "linux")]
     privacy,
     rofication,
     service_status,
+    #[cfg(target_os = "linux")]
     scratchpad,
+    #[cfg(target_os = "linux")]
     sound,
     speedtest,
+    #[cfg(target_os = "linux")]
     keyboard_layout,
+    #[cfg(target_os = "linux")]
     taskwarrior,
+    #[cfg(target_os = "linux")]
     temperature,
     time,
     tea_timer,
     toggle,
     uptime,
     vpn,
+    #[cfg(target_os = "linux")]
     watson,
     weather,
     xrandr,

--- a/src/blocks/prelude.rs
+++ b/src/blocks/prelude.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(target_os = "linux"), allow(unused_imports))]
 pub use super::{BlockAction, CommonApi};
 
 pub(crate) use crate::REQWEST_CLIENT;

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,7 @@ pub struct BlockConfigEntry {
 #[serde(default)]
 pub struct CommonBlockConfig {
     pub click: ClickHandler,
+    #[cfg(target_os = "linux")]
     pub signal: Option<i32>,
     pub icons_format: Option<String>,
     pub theme_overrides: Option<ThemeOverrides>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,9 @@ pub mod escape;
 pub mod formatting;
 pub mod geolocator;
 pub mod icons;
+#[cfg(target_os = "linux")]
 mod netlink;
-#[cfg(feature = "pipewire")]
+#[cfg(all(feature = "pipewire", target_os = "linux"))]
 pub mod pipewire;
 pub mod protocol;
 mod signals;
@@ -154,6 +155,7 @@ pub struct Block {
 
     click_handler: ClickHandler,
     default_actions: &'static [(MouseButton, Option<&'static str>, &'static str)],
+    #[cfg(target_os = "linux")]
     signal: Option<i32>,
     shared_config: SharedConfig,
 
@@ -298,6 +300,7 @@ impl BarState {
 
             click_handler: block_config.common.click,
             default_actions: &[],
+            #[cfg(target_os = "linux")]
             signal: block_config.common.signal,
             shared_config,
 
@@ -453,6 +456,7 @@ impl BarState {
                     }
                 }
                 Signal::Usr2 => restart(),
+                #[cfg(target_os = "linux")]
                 Signal::Custom(signal) => {
                     for block in &self.blocks {
                         if block.signal == Some(signal) {

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,5 +1,4 @@
 use futures::stream::StreamExt as _;
-use libc::{SIGRTMAX, SIGRTMIN};
 use signal_hook::consts::{SIGUSR1, SIGUSR2};
 use signal_hook_tokio::Signals;
 
@@ -9,12 +8,14 @@ use crate::BoxedStream;
 pub enum Signal {
     Usr1,
     Usr2,
+    #[cfg(target_os = "linux")]
     Custom(i32),
 }
 
 /// Returns an infinite stream of `Signal`s
+#[cfg(target_os = "linux")]
 pub fn signals_stream() -> BoxedStream<Signal> {
-    let (sigmin, sigmax) = (SIGRTMIN(), SIGRTMAX());
+    let (sigmin, sigmax) = (libc::SIGRTMIN(), libc::SIGRTMAX());
     let signals = Signals::new((sigmin..sigmax).chain([SIGUSR1, SIGUSR2])).unwrap();
     signals
         .map(move |signal| match signal {
@@ -23,4 +24,18 @@ pub fn signals_stream() -> BoxedStream<Signal> {
             x => Signal::Custom(x - sigmin),
         })
         .boxed()
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn signals_stream() -> BoxedStream<Signal> {
+    {
+        let signals = Signals::new([SIGUSR1, SIGUSR2]).unwrap();
+        signals
+            .filter_map(async move |signal| match signal {
+                SIGUSR1 => Some(Signal::Usr1),
+                SIGUSR2 => Some(Signal::Usr2),
+                _ => None,
+            })
+            .boxed()
+    }
 }


### PR DESCRIPTION
@hasufell

I ended up making an attempt to make i3status-rust work on FreeBSD.

The two main differences that this introduced is that it doesn't seem like FreeBSD allows for the custom signals used on linux and some of the blocks/dependencies aren't compatible with FreeBSD.

Note that if a block failed, I disabled it entirely instead of going through each one and determining if it was only a certain driver/backend/service that needed to be disabled on non-linux systems. It's also possible that I wasn't able to build some of the features like notmuch or pipewire because I am missing a system library. If that's the case we can update the `pkg install` line to not need to fence off as many features.

@ammgws, any thoughts on adding this in and allowing folks to improve what's available to non-linux systems down the line? I wouldn't think that there's any non `target_os = "linux"` users today that this would impact.