### PR TITLE
fix: use lowercase k as the SI unit prefix for kilo

### DIFF
--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -11,7 +11,7 @@
 //! `warning` | A value which will trigger warning block state | `20.0`
 //! `alert` | A value which will trigger critical block state | `10.0`
 //! `info_type` | Determines which information will affect the block state. Possible values are `"available"`, `"free"` and `"used"` | `"available"`
-//! `alert_unit` | The unit of `alert` and `warning` options. If not set, percents are used. Possible values are `"B"`, `"KB"`, `"KiB"`, `"MB"`, `"MiB"`, `"GB"`, `"Gib"`, `"TB"` and `"TiB"` | `None`
+//! `alert_unit` | The unit of `alert` and `warning` options. If not set, percents are used. Possible values are `"B"`, `"kB"`, `"KB"`, `"KiB"`, `"MB"`, `"MiB"`, `"GB"`, `"Gib"`, `"TB"` and `"TiB"` | `None`
 //! `backend` | The backend to use when querying disk usage. Possible values are `"vfs"` (like `du(1)`) and `"btrfs"` | `"vfs"`
 //!
 //! Placeholder  | Value                                                              | Type   | Unit
@@ -121,7 +121,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         Some("TB") => Some(Prefix::Tera),
         Some("GB") => Some(Prefix::Giga),
         Some("MB") => Some(Prefix::Mega),
-        Some("KB") => Some(Prefix::Kilo),
+        Some("KB") | Some("kB") => Some(Prefix::Kilo),
         // Binary
         Some("TiB") => Some(Prefix::Tebi),
         Some("GiB") => Some(Prefix::Gibi),

--- a/src/formatting/formatter/eng.rs
+++ b/src/formatting/formatter/eng.rs
@@ -250,7 +250,7 @@ mod tests {
                 &config,
             )
             .unwrap();
-        assert_eq!(result, "1.0KB");
+        assert_eq!(result, "1.0kB");
 
         let result = fmt
             .format(
@@ -307,7 +307,7 @@ mod tests {
                 &config,
             )
             .unwrap();
-        assert_eq!(result, "999KB");
+        assert_eq!(result, "999kB");
 
         let result = fmt
             .format(

--- a/src/formatting/prefix.rs
+++ b/src/formatting/prefix.rs
@@ -23,7 +23,7 @@ pub enum Prefix {
     /// `1i`
     /// `1i` is a special prefix which means "one but binary". `1i` is to `1` as `Ki` is to `K`.
     OneButBinary,
-    /// `K`
+    /// `k`
     Kilo,
     /// `Ki`
     Kibi,
@@ -138,7 +138,7 @@ impl fmt::Display for Prefix {
             Self::Micro => "u",
             Self::Milli => "m",
             Self::One | Self::OneButBinary => "",
-            Self::Kilo => "K",
+            Self::Kilo => "k",
             Self::Kibi => "Ki",
             Self::Mega => "M",
             Self::Mebi => "Mi",
@@ -160,7 +160,7 @@ impl FromStr for Prefix {
             "m" => Ok(Prefix::Milli),
             "1" => Ok(Prefix::One),
             "1i" => Ok(Prefix::OneButBinary),
-            "K" => Ok(Prefix::Kilo),
+            "K" | "k" => Ok(Prefix::Kilo),
             "Ki" => Ok(Prefix::Kibi),
             "M" => Ok(Prefix::Mega),
             "Mi" => Ok(Prefix::Mebi),
@@ -221,6 +221,7 @@ fn parse_prefix(input: &str) -> IResult<&str, Prefix> {
             value(Prefix::Milli, tag("m")),
             value(Prefix::OneButBinary, tag("i")),
             value(Prefix::Kilo, tag("K")),
+            value(Prefix::Kilo, tag("k")),
             value(Prefix::Mega, tag("M")),
             value(Prefix::Giga, tag("G")),
             value(Prefix::Tera, tag("T")),
@@ -335,6 +336,9 @@ mod tests {
     #[test]
     fn value_prefix() -> Result<()> {
         assert_eq!(ValuePrefix::from_str("1")?.result(), 1.0);
+        assert_eq!(ValuePrefix::from_str("1k")?.result(), 1000.0);
+        assert_eq!(ValuePrefix::from_str("1K")?.result(), 1000.0);
+        assert_eq!(ValuePrefix::from_str("1Ki")?.result(), 1024.0);
         assert_eq!(ValuePrefix::from_str("1G")?.result(), 1e9);
         assert_eq!(ValuePrefix::from_str("1e9")?.result(), 1e9);
         assert_eq!(ValuePrefix::from_str("10e9")?.result(), 10e9);


### PR DESCRIPTION
The SI unit prefix for kilo is lowercase "k" (see <https://en.wikipedia.org/wiki/Metric_prefix>), so adjust parsing and formatting accordingly. For backward compatibility, uppercase "K" still works for parsing.