### PR TITLE
Add ical support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### New Blocks and Features
 
+* `calendar`: added support for direct iCalendar (`.ics`) feeds
 * `packages`: added support for `zypper` (#2254)
 
 ### Bug Fixes and Improvements

--- a/src/blocks/calendar.rs
+++ b/src/blocks/calendar.rs
@@ -378,19 +378,14 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     }
                     Err(err) => match err {
                         CalendarError::AuthRequired => {
-                            let authorization = source
-                                .authorize()
-                                .await
-                                .error("Authorization failed")?;
+                            let authorization =
+                                source.authorize().await.error("Authorization failed")?;
                             match authorization {
                                 Authorize::AskUser(authorize) if retries == 0 => {
                                     widget.set_format(redirect_format.clone());
                                     api.set_widget(widget.clone())?;
                                     open_browser(config, &authorize.url).await?;
-                                    source
-                                        .ask_user(authorize)
-                                        .await
-                                        .error("Ask user failed")?;
+                                    source.ask_user(authorize).await.error("Ask user failed")?;
                                 }
                                 _ => {
                                     return Err(Error::new(
@@ -554,23 +549,19 @@ impl Source {
         let end = now
             .checked_add_signed(within)
             .ok_or_else(|| CalendarError::Parsing("Calendar search window is too large".into()))?;
-        let mut events = match self {
-            Self::CalDav { client, calendars } => {
-                let mut events = vec![];
-                for calendar in client
-                    .calendars()
-                    .await?
-                    .into_iter()
-                    .filter(|calendar| {
+        let mut events =
+            match self {
+                Self::CalDav { client, calendars } => {
+                    let mut events = vec![];
+                    for calendar in client.calendars().await?.into_iter().filter(|calendar| {
                         calendars.is_empty() || calendars.contains(&calendar.name)
-                    })
-                {
-                    events.extend(client.events(&calendar, now, end).await?);
+                    }) {
+                        events.extend(client.events(&calendar, now, end).await?);
+                    }
+                    events
                 }
-                events
-            }
-            Self::Ics(client) => client.events(now, end).await?,
-        };
+                Self::Ics(client) => client.events(now, end).await?,
+            };
         events.sort_by_key(|e| e.start_at);
         Ok(next_overlapping_events(events))
     }
@@ -629,8 +620,7 @@ impl OverlappingEvents {
                     .skip(position + 1)
                     .find(|e| {
                         let is_ongoing = e.start_at < now && e.end_at > now;
-                        let is_warning =
-                            e.start_at - warning_threshold < now && now < e.start_at;
+                        let is_warning = e.start_at - warning_threshold < now && now < e.start_at;
                         same_event(e, current) || is_warning || is_ongoing
                     })
                     .cloned()
@@ -643,16 +633,15 @@ impl OverlappingEvents {
     }
 }
 
-fn next_overlapping_events(events: Vec<Event>) -> OverlappingEvents {
-    let mut events = events.into_iter();
-    let Some(first) = events.next() else {
+fn next_overlapping_events(mut events: Vec<Event>) -> OverlappingEvents {
+    let Some(first_end) = events.first().map(|event| event.end_at) else {
         return OverlappingEvents::default();
     };
-    let first_end = first.end_at;
-    let overlapping = std::iter::once(first)
-        .chain(events.take_while(|event| event.start_at < first_end))
-        .collect();
-    OverlappingEvents::new(overlapping)
+    let overlapping_len = events
+        .partition_point(|event| event.start_at < first_end)
+        .max(1);
+    events.truncate(overlapping_len);
+    OverlappingEvents::new(events)
 }
 
 fn same_event(left: &Event, right: &Event) -> bool {
@@ -691,11 +680,7 @@ pub enum CalendarError {
 mod tests {
     use super::*;
 
-    fn event(
-        uid: &str,
-        start: chrono::DateTime<Utc>,
-        end: chrono::DateTime<Utc>,
-    ) -> Event {
+    fn event(uid: &str, start: chrono::DateTime<Utc>, end: chrono::DateTime<Utc>) -> Event {
         Event {
             uid: uid.into(),
             summary: None,

--- a/src/blocks/calendar.rs
+++ b/src/blocks/calendar.rs
@@ -1,6 +1,7 @@
 //! Calendar
 //!
-//! This block displays upcoming calendar events retrieved from a CalDav ICalendar server.
+//! This block displays upcoming calendar events retrieved from a CalDAV server or an iCalendar
+//! (`.ics`) feed.
 //!
 //! # Configuration
 //!
@@ -21,9 +22,10 @@
 //!
 //! Key | Values | Default
 //! ----|--------|--------
-//! `url` | CalDav calendar server URL | N/A
+//! `type` | Source protocol: `"caldav"` or `"ics"` | `"caldav"`
+//! `url` | CalDAV server or ICS feed URL | N/A
 //! `auth` | Authentication configuration (unauthenticated, basic, or oauth2) | `unauthenticated`
-//! `calendars` | List of calendar names to monitor. If empty, all calendars will be fetched. | `[]`
+//! `calendars` | CalDAV only: list of calendar names to monitor. If empty, all calendars will be fetched. | `[]`
 //!
 //! Note: Currently only one source is supported
 //!
@@ -32,6 +34,47 @@
 //! `open_link` | Opens the HTML link of the event | Left
 //!
 //! # Examples
+//!
+//! ## ICS Feed
+//!
+//! A Google Calendar ICS URL can be used directly for read-only access, without OAuth or a Google
+//! Cloud project.
+//!
+//! ### Getting the URL from Google Calendar
+//!
+//! 1. Open Google Calendar in a desktop browser and select **Settings**.
+//! 2. Under **Settings for my calendars**, select the calendar to display.
+//! 3. Open **Integrate calendar**.
+//! 4. Copy **Secret address in iCal format** and use it as the source `url` below.
+//!
+//! Do not use **Calendar ID**, **Public URL to this calendar**, or the embed code. **Public address
+//! in iCal format** only works when the calendar is public; use **Secret address in iCal format**
+//! to keep the calendar private.
+//!
+//! The secret address grants read-only access to the calendar. Treat it like a password, do not
+//! share it, and ensure that the i3status-rust configuration file is only readable by your user.
+//! If it is exposed, reset the address in Google Calendar to invalidate the old URL. For work or
+//! school accounts, an administrator may disable secret addresses.
+//!
+//! See [Google Calendar Help](https://support.google.com/calendar/answer/37648) for Google's
+//! current instructions.
+//!
+//! ```toml
+//! [[block]]
+//! block = "calendar"
+//! fetch_interval = 900
+//! events_within_hours = 48
+//! [[block.source]]
+//! type = "ics"
+//! url = "https://calendar.google.com/calendar/ical/.../basic.ics"
+//! ```
+//!
+//! ICS feeds are downloaded in full on every refresh, so use a longer `fetch_interval` for large
+//! calendars. Responses larger than 32 MiB are rejected. Event time zones must use recognized
+//! IANA `TZID` values; embedded custom `VTIMEZONE` definitions are not interpreted. Recurrences
+//! whose estimated expansion exceeds 100,000 frequency intervals are not expanded, and expansion
+//! is limited to 4,096 instances per event. Event series that use
+//! `RECURRENCE-ID;RANGE=THISANDFUTURE` are skipped because that override mode is not supported.
 //!
 //! ## Unauthenticated
 //!
@@ -91,9 +134,12 @@
 //! credentials_path = "~/.config/i3status-rust/example_credentials.toml"
 //! ```
 //!
-//! ## OAuth2 Authentication (Google Calendar)
+//! ## Google CalDAV with OAuth2 Authentication
 //!
-//! To access the CalDav API of Google, follow these steps to enable the API and obtain the `client_id` and `client_secret`:
+//! This section configures Google's CalDAV API. For read-only access without Google Cloud, use the
+//! ICS feed example above instead.
+//!
+//! To access the CalDAV API of Google, follow these steps to enable the API and obtain the `client_id` and `client_secret`:
 //! 1. **Go to the Google Cloud Console**: Navigate to the [Google Cloud Console](https://console.cloud.google.com/).
 //! 2. **Create a New Project**: If you don't already have a project, click on the project dropdown and select "New Project". Give your project a name and click "Create".
 //! 3. **Enable the CalDAV API**: In the project dashboard, go to the "APIs & Services" > "Library". Search for "CalDAV API" and click on it, then click "Enable".
@@ -167,7 +213,7 @@
 //! # Icons Used
 //! - `calendar`
 
-use chrono::{Duration, Local, Utc};
+use chrono::{Duration, Utc};
 use oauth2::{AuthUrl, ClientId, ClientSecret, Scope, TokenUrl};
 use reqwest::Url;
 
@@ -176,16 +222,16 @@ use crate::{subprocess::spawn_process, util::has_command};
 
 mod auth;
 mod caldav;
+mod ical;
+mod ics;
 
 use self::auth::{Authorize, AuthorizeUrl, OAuth2Flow, TokenStore, TokenStoreError};
-use self::caldav::Event;
+use self::ical::Event;
 
 use super::prelude::*;
 
 use std::path::Path;
 use std::sync::Arc;
-
-use caldav::Client;
 
 #[derive(Deserialize, Debug, SmartDefault, Clone)]
 #[serde(deny_unknown_fields, default)]
@@ -232,9 +278,19 @@ pub enum AuthConfig {
     OAuth2(OAuth2Config),
 }
 
+#[derive(Deserialize, Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceType {
+    #[default]
+    CalDav,
+    Ics,
+}
+
 #[derive(Deserialize, Debug, SmartDefault, Clone)]
 #[serde(deny_unknown_fields, default)]
 pub struct SourceConfig {
+    #[serde(rename = "type")]
+    pub source_type: SourceType,
     pub url: String,
     pub auth: AuthConfig,
     pub calendars: Vec<String>,
@@ -279,12 +335,9 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
     api.set_default_actions(&[(MouseButton::Left, None, "open_link")])?;
 
-    let source_config = match config.source.len() {
-        0 => return Err(Error::new("A calendar source must be supplied")),
-        1 => config
-            .source
-            .first()
-            .expect("There must be a first entry since the length is 1"),
+    let source_config = match config.source.as_slice() {
+        [] => return Err(Error::new("A calendar source must be supplied")),
+        [source] => source,
         _ => {
             return Err(Error::new(
                 "Currently only one calendar source is supported",
@@ -326,18 +379,16 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     Err(err) => match err {
                         CalendarError::AuthRequired => {
                             let authorization = source
-                                .client
                                 .authorize()
                                 .await
                                 .error("Authorization failed")?;
-                            match &authorization {
-                                Authorize::AskUser(AuthorizeUrl { url, .. }) if retries == 0 => {
+                            match authorization {
+                                Authorize::AskUser(authorize) if retries == 0 => {
                                     widget.set_format(redirect_format.clone());
                                     api.set_widget(widget.clone())?;
-                                    open_browser(config, url).await?;
+                                    open_browser(config, &authorize.url).await?;
                                     source
-                                        .client
-                                        .ask_user(authorization)
+                                        .ask_user(authorize)
                                         .await
                                         .error("Ask user failed")?;
                                 }
@@ -359,10 +410,9 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             }
         }
 
-        if let Some(event) = next_events.current().cloned()
-            && let Some(start_date) = event.start_at
-            && let Some(end_date) = event.end_at
-        {
+        if let Some(event) = next_events.current().cloned() {
+            let start_date = event.start_at;
+            let end_date = event.end_at;
             let warn_datetime = start_date - warning_threshold;
             if warn_datetime < Utc::now() && Utc::now() < start_date {
                 widget.state = State::Warning;
@@ -410,14 +460,30 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     }
 }
 
-struct Source {
-    pub client: caldav::Client,
-    pub config: SourceConfig,
+enum Source {
+    CalDav {
+        client: caldav::Client,
+        calendars: Vec<String>,
+    },
+    Ics(ics::Client),
 }
 
 impl Source {
     async fn new(config: SourceConfig) -> Result<Self> {
-        let auth = match &config.auth {
+        let SourceConfig {
+            source_type,
+            url,
+            auth: auth_config,
+            calendars,
+        } = config;
+
+        if source_type == SourceType::Ics && !calendars.is_empty() {
+            return Err(Error::new(
+                "`calendars` is only supported for CalDAV calendar sources",
+            ));
+        }
+
+        let auth = match auth_config {
             AuthConfig::Unauthenticated => auth::Auth::Unauthenticated,
             AuthConfig::Basic(BasicAuthConfig {
                 credentials,
@@ -428,7 +494,7 @@ impl Source {
                         .await
                         .error("Failed to read basic credentials file")?
                 } else {
-                    credentials.clone()
+                    credentials
                 };
                 let BasicCredentials {
                     username: Some(username),
@@ -440,12 +506,12 @@ impl Source {
                 auth::Auth::basic(username, password)
             }
             AuthConfig::OAuth2(oauth2) => {
-                let credentials = if let Some(path) = &oauth2.credentials_path {
+                let credentials = if let Some(path) = oauth2.credentials_path {
                     util::async_deserialize_toml_file(path.expand()?.to_string())
                         .await
                         .error("Failed to read oauth2 credentials file")?
                 } else {
-                    oauth2.credentials.clone()
+                    oauth2.credentials
                 };
                 let OAuth2Credentials {
                     client_id: Some(client_id),
@@ -454,10 +520,8 @@ impl Source {
                 else {
                     return Err(Error::new("Oauth2 credentials are not configured"));
                 };
-                let auth_url =
-                    AuthUrl::new(oauth2.auth_url.clone()).error("Invalid authorization url")?;
-                let token_url =
-                    TokenUrl::new(oauth2.token_url.clone()).error("Invalid token url")?;
+                let auth_url = AuthUrl::new(oauth2.auth_url).error("Invalid authorization url")?;
+                let token_url = TokenUrl::new(oauth2.token_url).error("Invalid token url")?;
 
                 let flow = OAuth2Flow::new(
                     ClientId::new(client_id),
@@ -468,15 +532,17 @@ impl Source {
                 );
                 let token_store =
                     TokenStore::new(Path::new(&oauth2.auth_token.expand()?.to_string()));
-                auth::Auth::oauth2(flow, token_store, oauth2.scopes.clone())
+                auth::Auth::oauth2(flow, token_store, oauth2.scopes)
             }
         };
-        Ok(Self {
-            client: Client::new(
-                Url::parse(&config.url).error("Invalid CalDav server url")?,
-                auth,
-            ),
-            config,
+
+        let url = Url::parse(&url).error("Invalid calendar source URL")?;
+        Ok(match source_type {
+            SourceType::CalDav => Self::CalDav {
+                client: caldav::Client::new(url, auth),
+                calendars,
+            },
+            SourceType::Ics => Self::Ics(ics::Client::new(url, auth)),
         })
     }
 
@@ -484,50 +550,43 @@ impl Source {
         &mut self,
         within: Duration,
     ) -> Result<OverlappingEvents, CalendarError> {
-        let calendars: Vec<_> = self
-            .client
-            .calendars()
-            .await?
-            .into_iter()
-            .filter(|c| self.config.calendars.is_empty() || self.config.calendars.contains(&c.name))
-            .collect();
-        let mut events: Vec<Event> = vec![];
-        for calendar in calendars {
-            let calendar_events: Vec<_> = self
-                .client
-                .events(
-                    &calendar,
-                    Local::now()
-                        .date_naive()
-                        .and_hms_opt(0, 0, 0)
-                        .expect("A valid time")
-                        .and_local_timezone(Local)
-                        .earliest()
-                        .expect("A valid datetime")
-                        .to_utc(),
-                    Utc::now() + within,
-                )
-                .await?
-                .into_iter()
-                .filter(|e| {
-                    let not_started = e.start_at.is_some_and(|d| d > Utc::now());
-                    let is_ongoing = e.start_at.is_some_and(|d| d < Utc::now())
-                        && e.end_at.is_some_and(|d| d > Utc::now());
-                    not_started || is_ongoing
-                })
-                .collect();
-            events.extend(calendar_events);
-        }
-
-        events.sort_by_key(|e| e.start_at);
-        let Some(next_event) = events.first().cloned() else {
-            return Ok(OverlappingEvents::default());
+        let now = Utc::now();
+        let end = now
+            .checked_add_signed(within)
+            .ok_or_else(|| CalendarError::Parsing("Calendar search window is too large".into()))?;
+        let mut events = match self {
+            Self::CalDav { client, calendars } => {
+                let mut events = vec![];
+                for calendar in client
+                    .calendars()
+                    .await?
+                    .into_iter()
+                    .filter(|calendar| {
+                        calendars.is_empty() || calendars.contains(&calendar.name)
+                    })
+                {
+                    events.extend(client.events(&calendar, now, end).await?);
+                }
+                events
+            }
+            Self::Ics(client) => client.events(now, end).await?,
         };
-        let overlapping_events = events
-            .into_iter()
-            .take_while(|e| e.start_at <= next_event.end_at)
-            .collect();
-        Ok(OverlappingEvents::new(overlapping_events))
+        events.sort_by_key(|e| e.start_at);
+        Ok(next_overlapping_events(events))
+    }
+
+    async fn authorize(&mut self) -> Result<Authorize, CalendarError> {
+        match self {
+            Self::CalDav { client, .. } => client.authorize().await,
+            Self::Ics(client) => client.authorize().await,
+        }
+    }
+
+    async fn ask_user(&mut self, authorize: AuthorizeUrl) -> Result<(), CalendarError> {
+        match self {
+            Self::CalDav { client, .. } => client.ask_user(authorize).await,
+            Self::Ics(client) => client.ask_user(authorize).await,
+        }
     }
 }
 
@@ -558,22 +617,23 @@ impl OverlappingEvents {
 
     fn cycle_warning_or_ongoing(&mut self, warning_threshold: Duration) {
         self.current = if let Some(current) = &self.current {
-            if self.events.iter().any(|e| e.uid == current.uid) {
-                let mut iter = self
-                    .events
+            if let Some(position) = self
+                .events
+                .iter()
+                .position(|event| same_event(event, current))
+            {
+                let now = Utc::now();
+                self.events
                     .iter()
                     .cycle()
-                    .skip_while(|e| e.uid != current.uid);
-                iter.next();
-                iter.find(|e| {
-                    let is_ongoing = e.start_at.is_some_and(|d| d < Utc::now())
-                        && e.end_at.is_some_and(|d| d > Utc::now());
-                    let is_warning = e
-                        .start_at
-                        .is_some_and(|d| d - warning_threshold < Utc::now() && Utc::now() < d);
-                    e.uid == current.uid || is_warning || is_ongoing
-                })
-                .cloned()
+                    .skip(position + 1)
+                    .find(|e| {
+                        let is_ongoing = e.start_at < now && e.end_at > now;
+                        let is_warning =
+                            e.start_at - warning_threshold < now && now < e.start_at;
+                        same_event(e, current) || is_warning || is_ongoing
+                    })
+                    .cloned()
             } else {
                 self.events.first().cloned()
             }
@@ -581,6 +641,22 @@ impl OverlappingEvents {
             self.events.first().cloned()
         };
     }
+}
+
+fn next_overlapping_events(events: Vec<Event>) -> OverlappingEvents {
+    let mut events = events.into_iter();
+    let Some(first) = events.next() else {
+        return OverlappingEvents::default();
+    };
+    let first_end = first.end_at;
+    let overlapping = std::iter::once(first)
+        .chain(events.take_while(|event| event.start_at < first_end))
+        .collect();
+    OverlappingEvents::new(overlapping)
+}
+
+fn same_event(left: &Event, right: &Event) -> bool {
+    left.uid == right.uid && left.start_at == right.start_at
 }
 
 async fn open_browser(config: &Config, url: &Url) -> Result<()> {
@@ -597,8 +673,6 @@ pub enum CalendarError {
     Http(#[from] reqwest::Error),
     #[error(transparent)]
     Deserialize(#[from] quick_xml::de::DeError),
-    #[error(transparent)]
-    RecurrenceError(#[from] icalendar::RecurrenceError),
     #[error("Parsing error: {0}")]
     Parsing(String),
     #[error("Auth required")]
@@ -611,6 +685,97 @@ pub enum CalendarError {
     RequestToken(String),
     #[error("Store token error: {0}")]
     StoreToken(#[from] TokenStoreError),
-    #[error("local time falls in a _gap_ in the local time, or if there was an error")]
-    TzConversion,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(
+        uid: &str,
+        start: chrono::DateTime<Utc>,
+        end: chrono::DateTime<Utc>,
+    ) -> Event {
+        Event {
+            uid: uid.into(),
+            summary: None,
+            description: None,
+            location: None,
+            url: None,
+            start_at: start,
+            end_at: end,
+        }
+    }
+
+    #[test]
+    fn legacy_source_defaults_to_caldav() {
+        let source: SourceConfig =
+            toml::from_str(r#"url = "https://caldav.example/calendar/""#).unwrap();
+
+        assert_eq!(source.source_type, SourceType::CalDav);
+    }
+
+    #[test]
+    fn deserializes_ics_source_type() {
+        let source: SourceConfig = toml::from_str(
+            r#"
+            type = "ics"
+            url = "https://calendar.example/private/basic.ics"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(source.source_type, SourceType::Ics);
+    }
+
+    #[test]
+    fn rejects_unknown_source_type() {
+        let result = toml::from_str::<SourceConfig>(
+            r#"
+            type = "webcal"
+            url = "https://calendar.example/calendar"
+            "#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_caldav_calendar_filter_for_ics_source() {
+        let source: SourceConfig = toml::from_str(
+            r#"
+            type = "ics"
+            url = "https://calendar.example/private/basic.ics"
+            calendars = ["ignored"]
+            "#,
+        )
+        .unwrap();
+
+        assert!(Source::new(source).await.is_err());
+    }
+
+    #[test]
+    fn back_to_back_events_do_not_overlap() {
+        let first_start = "2026-07-29T16:00:00Z".parse().unwrap();
+        let boundary = "2026-07-29T17:00:00Z".parse().unwrap();
+        let second_end = "2026-07-29T18:00:00Z".parse().unwrap();
+
+        let events = next_overlapping_events(vec![
+            event("first", first_start, boundary),
+            event("second", boundary, second_end),
+        ]);
+
+        assert_eq!(events.events.len(), 1);
+        assert_eq!(events.events[0].uid, "first");
+    }
+
+    #[test]
+    fn zero_duration_next_event_is_still_selected() {
+        let start = "2026-07-29T16:00:00Z".parse().unwrap();
+
+        let events = next_overlapping_events(vec![event("instant", start, start)]);
+
+        assert_eq!(events.events.len(), 1);
+        assert_eq!(events.current().unwrap().uid, "instant");
+    }
 }

--- a/src/blocks/calendar.rs
+++ b/src/blocks/calendar.rs
@@ -693,16 +693,10 @@ mod tests {
     }
 
     #[test]
-    fn legacy_source_defaults_to_caldav() {
-        let source: SourceConfig =
+    fn deserializes_source_types() {
+        let caldav: SourceConfig =
             toml::from_str(r#"url = "https://caldav.example/calendar/""#).unwrap();
-
-        assert_eq!(source.source_type, SourceType::CalDav);
-    }
-
-    #[test]
-    fn deserializes_ics_source_type() {
-        let source: SourceConfig = toml::from_str(
+        let ics: SourceConfig = toml::from_str(
             r#"
             type = "ics"
             url = "https://calendar.example/private/basic.ics"
@@ -710,19 +704,17 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(source.source_type, SourceType::Ics);
-    }
-
-    #[test]
-    fn rejects_unknown_source_type() {
-        let result = toml::from_str::<SourceConfig>(
-            r#"
+        assert_eq!(caldav.source_type, SourceType::CalDav);
+        assert_eq!(ics.source_type, SourceType::Ics);
+        assert!(
+            toml::from_str::<SourceConfig>(
+                r#"
             type = "webcal"
             url = "https://calendar.example/calendar"
             "#,
+            )
+            .is_err()
         );
-
-        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/blocks/calendar/caldav.rs
+++ b/src/blocks/calendar/caldav.rs
@@ -286,11 +286,7 @@ fn parse_multistatus_events(
     for response in multi_status.responses {
         for prop in response.valid_props() {
             if let PropValue::CalendarData(data) = prop {
-                result.extend(parse_events(
-                    &data,
-                    event_search_start,
-                    event_search_end,
-                )?);
+                result.extend(parse_events(&data, event_search_start, event_search_end)?);
             }
         }
     }

--- a/src/blocks/calendar/caldav.rs
+++ b/src/blocks/calendar/caldav.rs
@@ -1,7 +1,6 @@
 use std::{str::FromStr as _, time::Duration, vec};
 
-use chrono::{DateTime, Datelike as _, Local, TimeZone as _, Timelike as _, Utc};
-use icalendar::{Component as _, EventLike as _, Tz};
+use chrono::{DateTime, Utc};
 use reqwest::{
     self, ClientBuilder, Method, Url,
     header::{CONTENT_TYPE, HeaderMap, HeaderValue},
@@ -10,19 +9,9 @@ use serde::Deserialize;
 
 use super::{
     CalendarError,
-    auth::{Auth, Authorize},
+    auth::{Auth, Authorize, AuthorizeUrl},
+    ical::{Event, parse_events},
 };
-
-#[derive(Clone, Debug)]
-pub struct Event {
-    pub uid: Option<String>,
-    pub summary: Option<String>,
-    pub description: Option<String>,
-    pub location: Option<String>,
-    pub url: Option<String>,
-    pub start_at: Option<DateTime<Utc>>,
-    pub end_at: Option<DateTime<Utc>>,
-}
 
 #[derive(Deserialize, Debug)]
 pub struct Calendar {
@@ -59,7 +48,7 @@ impl Client {
         let request = self
             .client
             .request(Method::from_str("PROPFIND").expect("A valid method"), url)
-            .body(body.clone())
+            .body(body)
             .headers(self.auth.headers().await)
             .header("Depth", depth)
             .build()
@@ -138,18 +127,15 @@ impl Client {
         let multi_status = self
             .report_request(calendar.url.clone(), 1, calendar_events_request(start, end))
             .await?;
-        parse_events(multi_status, start, end)
+        parse_multistatus_events(multi_status, start, end)
     }
 
     pub async fn authorize(&mut self) -> Result<Authorize, CalendarError> {
         self.auth.authorize().await
     }
 
-    pub async fn ask_user(&mut self, authorize: Authorize) -> Result<(), CalendarError> {
-        match authorize {
-            Authorize::Completed => Ok(()),
-            Authorize::AskUser(authorize_url) => self.auth.ask_user(authorize_url).await,
-        }
+    pub async fn ask_user(&mut self, authorize: AuthorizeUrl) -> Result<(), CalendarError> {
+        self.auth.ask_user(authorize).await
     }
 }
 
@@ -168,12 +154,11 @@ struct Response {
 }
 
 impl Response {
-    fn valid_props(self) -> Vec<PropValue> {
+    fn valid_props(self) -> impl Iterator<Item = PropValue> {
         self.propstats
             .into_iter()
             .filter(|p| p.status.contains("200"))
             .flat_map(|p| p.prop.values.into_iter())
-            .collect()
     }
 }
 
@@ -247,7 +232,7 @@ fn parse_href(multi_status: Multistatus, base_url: Url) -> Result<Url, CalendarE
     let props = multi_status
         .responses
         .into_iter()
-        .flat_map(|r| r.valid_props().into_iter())
+        .flat_map(Response::valid_props)
         .next();
     match props.ok_or_else(|| CalendarError::Parsing("Property not found".into()))? {
         PropValue::CurrentUserPrincipal(href) | PropValue::CalendarHomeSet(href) => base_url
@@ -292,7 +277,7 @@ fn parse_calendars(
     Ok(result)
 }
 
-fn parse_events(
+fn parse_multistatus_events(
     multi_status: Multistatus,
     event_search_start: DateTime<Utc>,
     event_search_end: DateTime<Utc>,
@@ -301,88 +286,11 @@ fn parse_events(
     for response in multi_status.responses {
         for prop in response.valid_props() {
             if let PropValue::CalendarData(data) = prop {
-                let calendar =
-                    icalendar::Calendar::from_str(&data).map_err(CalendarError::Parsing)?;
-                for component in calendar.components {
-                    if let icalendar::CalendarComponent::Event(event) = component {
-                        let event_start_at = event.get_start().and_then(|d| match d {
-                            icalendar::DatePerhapsTime::DateTime(dt) => dt.try_into_utc(),
-                            icalendar::DatePerhapsTime::Date(d) => d
-                                .and_hms_opt(0, 0, 0)
-                                .and_then(|d| d.and_local_timezone(Local).earliest())
-                                .map(|d| d.to_utc()),
-                        });
-                        let event_end_at = event.get_end().and_then(|d| match d {
-                            icalendar::DatePerhapsTime::DateTime(dt) => dt.try_into_utc(),
-                            icalendar::DatePerhapsTime::Date(d) => d
-                                .and_hms_opt(23, 59, 59)
-                                .and_then(|d| d.and_local_timezone(Local).earliest())
-                                .map(|d| d.to_utc()),
-                        });
-
-                        if let Some(s) = event_start_at
-                            && let Some(e) = event_end_at
-                        {
-                            let duration = e - s;
-                            result.extend(
-                                event
-                                    .get_recurrence()?
-                                    .after(
-                                        Tz::UTC
-                                            .with_ymd_and_hms(
-                                                event_search_start.year(),
-                                                event_search_start.month(),
-                                                event_search_start.day(),
-                                                event_search_start.hour(),
-                                                event_search_start.minute(),
-                                                event_search_start.second(),
-                                            )
-                                            .earliest()
-                                            .ok_or(CalendarError::TzConversion)?,
-                                    )
-                                    .before(
-                                        Tz::UTC
-                                            .with_ymd_and_hms(
-                                                event_search_end.year(),
-                                                event_search_end.month(),
-                                                event_search_end.day(),
-                                                event_search_end.hour(),
-                                                event_search_end.minute(),
-                                                event_search_end.second(),
-                                            )
-                                            .earliest()
-                                            .ok_or(CalendarError::TzConversion)?,
-                                    )
-                                    .all(u16::MAX)
-                                    .dates
-                                    .into_iter()
-                                    .map(|new_start| {
-                                        let new_start = new_start.to_utc();
-                                        let new_end = new_start + duration;
-                                        Event {
-                                            uid: event.get_uid().map(Into::into),
-                                            summary: event.get_summary().map(Into::into),
-                                            description: event.get_description().map(Into::into),
-                                            location: event.get_location().map(Into::into),
-                                            url: event.get_url().map(Into::into),
-                                            start_at: Some(new_start),
-                                            end_at: Some(new_end),
-                                        }
-                                    }),
-                            );
-                        } else {
-                            result.push(Event {
-                                uid: event.get_uid().map(Into::into),
-                                summary: event.get_summary().map(Into::into),
-                                description: event.get_description().map(Into::into),
-                                location: event.get_location().map(Into::into),
-                                url: event.get_url().map(Into::into),
-                                start_at: event_start_at,
-                                end_at: event_end_at,
-                            });
-                        }
-                    }
-                }
+                result.extend(parse_events(
+                    &data,
+                    event_search_start,
+                    event_search_end,
+                )?);
             }
         }
     }
@@ -428,4 +336,44 @@ pub fn calendar_events_request(start: DateTime<Utc>, end: DateTime<Utc>) -> Stri
         </c:filter>
         </c:calendar-query>"#
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone as _, Utc};
+
+    use super::*;
+
+    #[test]
+    fn parses_calendar_data_from_caldav_response() {
+        let response = concat!(
+            r#"<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">"#,
+            "<d:response>",
+            "<d:href>/event.ics</d:href>",
+            "<d:propstat>",
+            "<d:prop><c:calendar-data>",
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:event\r\n",
+            "DTSTART:20260729T160000Z\r\n",
+            "DTEND:20260729T170000Z\r\n",
+            "SUMMARY:CalDAV event\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+            "</c:calendar-data></d:prop>",
+            "<d:status>HTTP/1.1 200 OK</d:status>",
+            "</d:propstat>",
+            "</d:response>",
+            "</d:multistatus>",
+        );
+        let multistatus = quick_xml::de::from_str(response).unwrap();
+        let start = Utc.with_ymd_and_hms(2026, 7, 29, 15, 0, 0).unwrap();
+        let end = Utc.with_ymd_and_hms(2026, 7, 30, 15, 0, 0).unwrap();
+
+        let events = parse_multistatus_events(multistatus, start, end).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].summary.as_deref(), Some("CalDAV event"));
+    }
 }

--- a/src/blocks/calendar/ical.rs
+++ b/src/blocks/calendar/ical.rs
@@ -270,25 +270,10 @@ fn validate_dtend_form(start: &DatePerhapsTime, end: &DatePerhapsTime) -> Result
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug)]
 struct IcalDuration {
     days: u64,
     clock: Duration,
-}
-
-impl IcalDuration {
-    fn upper_bound(self) -> Result<Duration, String> {
-        // A nominal day can cross a time-zone transition. Twenty-six hours is deliberately
-        // conservative for deciding how far before the display window expansion must begin.
-        let hours = self
-            .days
-            .checked_mul(26)
-            .and_then(|hours| i64::try_from(hours).ok())
-            .ok_or_else(|| "DURATION is too large".to_owned())?;
-        Duration::try_hours(hours)
-            .and_then(|days| days.checked_add(&self.clock))
-            .ok_or_else(|| "DURATION is too large".to_owned())
-    }
 }
 
 fn parse_duration(value: &str) -> Result<IcalDuration, String> {
@@ -485,7 +470,18 @@ impl EventEnd {
     fn search_duration(self) -> Result<Duration, String> {
         match self {
             Self::Exact(duration) => Ok(duration),
-            Self::Nominal { duration, .. } => duration.upper_bound(),
+            Self::Nominal { duration, .. } => {
+                // A nominal day can cross a time-zone transition. Twenty-six hours is deliberately
+                // conservative for deciding how far before the display window expansion must begin.
+                let hours = duration
+                    .days
+                    .checked_mul(26)
+                    .and_then(|hours| i64::try_from(hours).ok())
+                    .ok_or_else(|| "DURATION is too large".to_owned())?;
+                Duration::try_hours(hours)
+                    .and_then(|days| days.checked_add(&duration.clock))
+                    .ok_or_else(|| "DURATION is too large".to_owned())
+            }
         }
     }
 }
@@ -561,6 +557,12 @@ mod tests {
         };
     }
 
+    macro_rules! event {
+        ($($line:literal),* $(,)?) => {
+            calendar!("BEGIN:VEVENT\r\n", $($line,)* "END:VEVENT\r\n")
+        };
+    }
+
     fn utc(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> DateTime<Utc> {
         Utc.with_ymd_and_hms(year, month, day, hour, minute, 0)
             .unwrap()
@@ -580,8 +582,7 @@ mod tests {
 
     #[test]
     fn parses_timed_event_and_metadata() {
-        let data = calendar!(
-            "BEGIN:VEVENT\r\n",
+        let data = event!(
             "UID:meeting\r\n",
             "DTSTART;TZID=America/Los_Angeles:20260729T090000\r\n",
             "DTEND;TZID=America/Los_Angeles:20260729T100000\r\n",
@@ -589,7 +590,6 @@ mod tests {
             "DESCRIPTION:Roadmap review\r\n",
             "LOCATION:Room 1\r\n",
             "URL:https://calendar.example/event\r\n",
-            "END:VEVENT\r\n",
         );
 
         let events = parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 7, 30, 0, 0)).unwrap();
@@ -607,8 +607,7 @@ mod tests {
 
     #[test]
     fn expands_rrule_rdate_and_exdate() {
-        let data = calendar!(
-            "BEGIN:VEVENT\r\n",
+        let data = event!(
             "UID:daily\r\n",
             "DTSTART:20260729T160000Z\r\n",
             "DTEND:20260729T163000Z\r\n",
@@ -616,7 +615,6 @@ mod tests {
             "EXDATE:20260730T160000Z\r\n",
             "RDATE:20260801T160000Z\r\n",
             "SUMMARY:Standup\r\n",
-            "END:VEVENT\r\n",
         );
 
         let events = parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 8, 2, 0, 0)).unwrap();
@@ -692,13 +690,11 @@ mod tests {
 
     #[test]
     fn uses_exclusive_all_day_end() {
-        let data = calendar!(
-            "BEGIN:VEVENT\r\n",
+        let data = event!(
             "UID:all-day\r\n",
             "DTSTART;VALUE=DATE:20260729\r\n",
             "DTEND;VALUE=DATE:20260730\r\n",
             "SUMMARY:All day\r\n",
-            "END:VEVENT\r\n",
         );
 
         let events = parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 7, 31, 0, 0)).unwrap();
@@ -709,13 +705,11 @@ mod tests {
 
     #[test]
     fn supports_duration_and_events_already_in_progress() {
-        let data = calendar!(
-            "BEGIN:VEVENT\r\n",
+        let data = event!(
             "UID:long\r\n",
             "DTSTART:20260728T180000Z\r\n",
             "DURATION:P2D\r\n",
             "SUMMARY:Long event\r\n",
-            "END:VEVENT\r\n",
         );
 
         let events = parse_events(data, utc(2026, 7, 29, 12, 0), utc(2026, 7, 30, 12, 0)).unwrap();
@@ -798,12 +792,10 @@ mod tests {
 
     #[test]
     fn nominal_day_duration_follows_dst_transitions() {
-        let spring = calendar!(
-            "BEGIN:VEVENT\r\n",
+        let spring = event!(
             "UID:spring\r\n",
             "DTSTART;TZID=America/Los_Angeles:20260307T090000\r\n",
             "DURATION:P1D\r\n",
-            "END:VEVENT\r\n",
         );
         let event = parse_events(spring, utc(2026, 3, 7, 0, 0), utc(2026, 3, 10, 0, 0))
             .unwrap()
@@ -811,12 +803,10 @@ mod tests {
             .unwrap();
         assert_eq!(event.end_at - event.start_at, Duration::hours(23));
 
-        let fall = calendar!(
-            "BEGIN:VEVENT\r\n",
+        let fall = event!(
             "UID:fall\r\n",
             "DTSTART;TZID=America/Los_Angeles:20261031T090000\r\n",
             "DURATION:P1D\r\n",
-            "END:VEVENT\r\n",
         );
         let event = parse_events(fall, utc(2026, 10, 31, 0, 0), utc(2026, 11, 3, 0, 0))
             .unwrap()
@@ -827,12 +817,7 @@ mod tests {
 
     #[test]
     fn default_all_day_duration_uses_next_local_midnight() {
-        let data = calendar!(
-            "BEGIN:VEVENT\r\n",
-            "UID:all-day-spring\r\n",
-            "DTSTART;VALUE=DATE:20260308\r\n",
-            "END:VEVENT\r\n",
-        );
+        let data = event!("UID:all-day-spring\r\n", "DTSTART;VALUE=DATE:20260308\r\n",);
         let event = first_event(data);
         let (_, end) = event_bounds(&event).unwrap();
 
@@ -988,13 +973,11 @@ mod tests {
 
     #[test]
     fn count_does_not_bypass_recurrence_work_limit() {
-        let data = calendar!(
-            "BEGIN:VEVENT\r\n",
+        let data = event!(
             "UID:pathological-with-count\r\n",
             "DTSTART:20000101T000000Z\r\n",
             "DURATION:PT1S\r\n",
             "RRULE:FREQ=SECONDLY;COUNT=100000;BYMINUTE=0;BYSECOND=0\r\n",
-            "END:VEVENT\r\n",
         );
         let event = first_event(data);
         let recurrence = event.get_recurrence().unwrap();
@@ -1008,13 +991,11 @@ mod tests {
 
     #[test]
     fn recurrence_work_limit_includes_the_requested_window() {
-        let data = calendar!(
-            "BEGIN:VEVENT\r\n",
+        let data = event!(
             "UID:pathological-in-window\r\n",
             "DTSTART:20260729T000000Z\r\n",
             "DURATION:PT1S\r\n",
             "RRULE:FREQ=SECONDLY;BYMINUTE=0;BYSECOND=0\r\n",
-            "END:VEVENT\r\n",
         );
         let event = first_event(data);
         let recurrence = event.get_recurrence().unwrap();
@@ -1027,12 +1008,10 @@ mod tests {
 
     #[test]
     fn search_window_end_is_exclusive() {
-        let data = calendar!(
-            "BEGIN:VEVENT\r\n",
+        let data = event!(
             "UID:at-end\r\n",
             "DTSTART:20260730T000000Z\r\n",
             "DTEND:20260730T010000Z\r\n",
-            "END:VEVENT\r\n",
         );
 
         let events = parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 7, 30, 0, 0)).unwrap();

--- a/src/blocks/calendar/ical.rs
+++ b/src/blocks/calendar/ical.rs
@@ -1,0 +1,1106 @@
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr as _,
+};
+
+use chrono::{DateTime, Days, Duration, Local, TimeZone as _, Utc};
+use icalendar::{
+    CalendarDateTime, Component as _, DatePerhapsTime, EventLike as _, EventStatus,
+    Tz as RecurrenceTz,
+};
+
+use super::CalendarError;
+
+const MAX_RECURRENCE_RESULTS: u16 = 4096;
+const MAX_RECURRENCE_INTERVALS: i64 = 100_000;
+
+#[derive(Clone, Debug)]
+pub struct Event {
+    pub uid: String,
+    pub summary: Option<String>,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub url: Option<String>,
+    pub start_at: DateTime<Utc>,
+    pub end_at: DateTime<Utc>,
+}
+
+pub fn parse_events(
+    data: &str,
+    event_search_start: DateTime<Utc>,
+    event_search_end: DateTime<Utc>,
+) -> Result<Vec<Event>, CalendarError> {
+    let calendar = icalendar::Calendar::from_str(data).map_err(CalendarError::Parsing)?;
+    let events: Vec<_> = calendar
+        .components
+        .into_iter()
+        .filter_map(|component| match component {
+            icalendar::CalendarComponent::Event(event) => Some(event),
+            _ => None,
+        })
+        .collect();
+
+    // RANGE=THISANDFUTURE changes this and all later instances. The recurrence library does not
+    // implement those semantics, so reject the affected series instead of showing incorrect
+    // future instances.
+    let unsupported_series: HashSet<_> = events
+        .iter()
+        .filter(|event| recurrence_range(event).is_some_and(|range| {
+            range.eq_ignore_ascii_case("THISANDFUTURE")
+        }))
+        .filter_map(event_uid)
+        .map(ToOwned::to_owned)
+        .collect();
+    for uid in &unsupported_series {
+        log::warn!(
+            "Ignoring calendar event series with UID {uid:?}: \
+             RECURRENCE-ID;RANGE=THISANDFUTURE is not supported"
+        );
+    }
+
+    // A modified or cancelled recurrence is represented as another VEVENT with the same UID and
+    // a RECURRENCE-ID. Suppress that instant from the master event; a non-cancelled override is
+    // added below at its replacement DTSTART.
+    let mut overridden_recurrences = HashMap::<String, HashSet<DateTime<Utc>>>::new();
+    let mut invalid_overrides = HashSet::new();
+    for (index, event) in events.iter().enumerate() {
+        let Some(uid) = event_uid(event) else {
+            continue;
+        };
+        if unsupported_series.contains(uid) || !event.properties().contains_key("RECURRENCE-ID") {
+            continue;
+        }
+        let recurrence_id = event
+            .get_recurrence_id()
+            .ok_or_else(|| "RECURRENCE-ID is invalid".to_owned())
+            .and_then(|value| date_to_utc(value, "RECURRENCE-ID").map(|date| date.utc));
+        match recurrence_id {
+            Ok(recurrence_id) => {
+                overridden_recurrences
+                    .entry(uid.to_owned())
+                    .or_default()
+                    .insert(recurrence_id);
+            }
+            Err(error) => {
+                warn_event(uid, &error);
+                invalid_overrides.insert(index);
+            }
+        }
+    }
+
+    let mut result = vec![];
+    for (index, event) in events.into_iter().enumerate() {
+        let Some(uid) = event_uid(&event) else {
+            log::warn!("Ignoring calendar event: UID is missing or empty");
+            continue;
+        };
+        if unsupported_series.contains(uid) || invalid_overrides.contains(&index) {
+            continue;
+        }
+        if event.get_status() == Some(EventStatus::Cancelled) {
+            continue;
+        }
+
+        let (event_start, event_end_spec) = match event_bounds(&event) {
+            Ok(bounds) => bounds,
+            Err(error) => {
+                warn_event(uid, &error);
+                continue;
+            }
+        };
+        let event_end = match event_end_spec.end_at(event_start) {
+            Ok(end) => end,
+            Err(error) => {
+                warn_event(uid, &error);
+                continue;
+            }
+        };
+
+        if event.properties().contains_key("RECURRENCE-ID") {
+            if overlaps_search_window(
+                event_start,
+                event_end,
+                event_search_start,
+                event_search_end,
+            ) {
+                result.push(event_at(&event, event_start, event_end));
+            }
+            continue;
+        }
+
+        let search_duration = match event_end_spec.search_duration() {
+            Ok(duration) => duration,
+            Err(error) => {
+                warn_event(uid, &error);
+                continue;
+            }
+        };
+        let recurrence_search_start = event_search_start
+            .checked_sub_signed(search_duration)
+            .unwrap_or(DateTime::<Utc>::MIN_UTC);
+        let recurrence = match event.get_recurrence() {
+            Ok(recurrence) => recurrence,
+            Err(error) => {
+                warn_event(uid, &format!("invalid recurrence: {error}"));
+                if overlaps_search_window(
+                    event_start,
+                    event_end,
+                    event_search_start,
+                    event_search_end,
+                ) {
+                    result.push(event_at(&event, event_start, event_end));
+                }
+                continue;
+            }
+        };
+        if recurrence_requires_too_much_work(&recurrence, event_search_end) {
+            warn_event(
+                uid,
+                "recurrence expansion would require too many frequency intervals",
+            );
+            if overlaps_search_window(
+                event_start,
+                event_end,
+                event_search_start,
+                event_search_end,
+            ) {
+                result.push(event_at(&event, event_start, event_end));
+            }
+            continue;
+        }
+        let recurrence_result = recurrence
+            .after(recurrence_search_start.with_timezone(&RecurrenceTz::UTC))
+            .before(event_search_end.with_timezone(&RecurrenceTz::UTC))
+            .all(MAX_RECURRENCE_RESULTS);
+        if recurrence_result.limited {
+            warn_event(
+                uid,
+                &format!(
+                    "recurrence expansion reached the {MAX_RECURRENCE_RESULTS}-instance safety limit"
+                ),
+            );
+        }
+
+        let overridden = overridden_recurrences.get(uid);
+        for start in recurrence_result
+            .dates
+            .into_iter()
+            .map(|start| start.to_utc())
+            .filter(|start| !overridden.is_some_and(|dates| dates.contains(start)))
+        {
+            let end = match event_end_spec.end_at(start) {
+                Ok(end) => end,
+                Err(error) => {
+                    warn_event(uid, &error);
+                    continue;
+                }
+            };
+            if overlaps_search_window(start, end, event_search_start, event_search_end) {
+                result.push(event_at(&event, start, end));
+            }
+        }
+    }
+    Ok(result)
+}
+
+fn event_uid(event: &icalendar::Event) -> Option<&str> {
+    event.get_uid().filter(|uid| !uid.is_empty())
+}
+
+fn recurrence_range(event: &icalendar::Event) -> Option<&str> {
+    event
+        .properties()
+        .get("RECURRENCE-ID")?
+        .params()
+        .get("RANGE")
+        .map(|parameter| parameter.value())
+}
+
+fn warn_event(uid: &str, error: &str) {
+    log::warn!("Ignoring calendar event with UID {uid:?}: {error}");
+}
+
+fn event_bounds(event: &icalendar::Event) -> Result<(DateTime<Utc>, EventEnd), String> {
+    let start_value = event
+        .get_start()
+        .ok_or_else(|| "DTSTART is missing or invalid".to_owned())?;
+    let is_all_day = matches!(start_value, DatePerhapsTime::Date(_));
+    let start = date_to_utc(start_value.clone(), "DTSTART")?;
+
+    let has_end = event.properties().contains_key("DTEND");
+    let duration = event.property_value("DURATION");
+    if has_end && duration.is_some() {
+        return Err("DTEND and DURATION must not both be present".into());
+    }
+
+    let end = if has_end {
+        let end_value = event
+            .get_end()
+            .ok_or_else(|| "DTEND is invalid".to_owned())?;
+        validate_dtend_form(&start_value, &end_value)?;
+        let end = date_to_utc(end_value, "DTEND")?.utc;
+        if end <= start.utc {
+            return Err("DTEND must be later than DTSTART".into());
+        }
+        EventEnd::Exact(end - start.utc)
+    } else if let Some(value) = duration {
+        let duration = parse_duration(value)?;
+        if duration.days == 0 && duration.clock == Duration::zero() {
+            return Err("DURATION must be positive".into());
+        }
+        if is_all_day && duration.clock != Duration::zero() {
+            return Err("an all-day event DURATION must contain only days or weeks".into());
+        }
+        EventEnd::Nominal {
+            duration,
+            timezone: start.timezone,
+        }
+    } else if is_all_day {
+        EventEnd::Nominal {
+            duration: IcalDuration {
+                days: 1,
+                clock: Duration::zero(),
+            },
+            timezone: start.timezone,
+        }
+    } else {
+        // RFC 5545 defines an event without DTEND or DURATION as ending at DTSTART.
+        EventEnd::Exact(Duration::zero())
+    };
+    Ok((start.utc, end))
+}
+
+fn validate_dtend_form(start: &DatePerhapsTime, end: &DatePerhapsTime) -> Result<(), String> {
+    match (start, end) {
+        (DatePerhapsTime::Date(_), DatePerhapsTime::Date(_)) => Ok(()),
+        (DatePerhapsTime::DateTime(start), DatePerhapsTime::DateTime(end))
+            if matches!(start, CalendarDateTime::Floating(_))
+                == matches!(end, CalendarDateTime::Floating(_)) =>
+        {
+            Ok(())
+        }
+        (DatePerhapsTime::DateTime(_), DatePerhapsTime::DateTime(_)) => Err(
+            "DTEND must use local floating time if and only if DTSTART uses local floating time"
+                .into(),
+        ),
+        _ => Err("DTEND must have the same value type as DTSTART".into()),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct IcalDuration {
+    days: u64,
+    clock: Duration,
+}
+
+impl IcalDuration {
+    fn upper_bound(self) -> Result<Duration, String> {
+        // A nominal day can cross a time-zone transition. Twenty-six hours is deliberately
+        // conservative for deciding how far before the display window expansion must begin.
+        let hours = self
+            .days
+            .checked_mul(26)
+            .and_then(|hours| i64::try_from(hours).ok())
+            .ok_or_else(|| "DURATION is too large".to_owned())?;
+        Duration::try_hours(hours)
+            .and_then(|days| days.checked_add(&self.clock))
+            .ok_or_else(|| "DURATION is too large".to_owned())
+    }
+}
+
+fn parse_duration(value: &str) -> Result<IcalDuration, String> {
+    let bytes = value.as_bytes();
+    let mut index = usize::from(bytes.first() == Some(&b'+'));
+    if bytes.first() == Some(&b'-') {
+        return Err("DURATION must not be negative".into());
+    }
+    if bytes.get(index) != Some(&b'P') {
+        return Err("DURATION must start with `P` (after an optional `+`)".into());
+    }
+    index += 1;
+    if index == bytes.len() {
+        return Err("DURATION has no components".into());
+    }
+
+    let mut days = 0;
+    let mut clock_seconds = 0_u64;
+
+    if bytes.get(index).is_some_and(u8::is_ascii_digit) {
+        let number = parse_duration_number(bytes, &mut index)?;
+        match bytes.get(index) {
+            Some(b'W') => {
+                index += 1;
+                if index != bytes.len() {
+                    return Err("a week DURATION cannot contain other components".into());
+                }
+                days = number
+                    .checked_mul(7)
+                    .ok_or_else(|| "DURATION is too large".to_owned())?;
+            }
+            Some(b'D') => {
+                index += 1;
+                days = number;
+            }
+            _ => return Err("invalid DURATION date component".into()),
+        }
+    }
+
+    if index < bytes.len() {
+        if bytes[index] != b'T' {
+            return Err("invalid DURATION component".into());
+        }
+        index += 1;
+        if index == bytes.len() {
+            return Err("DURATION `T` must be followed by a time component".into());
+        }
+        let mut previous_rank = 0;
+        while index < bytes.len() {
+            let number = parse_duration_number(bytes, &mut index)?;
+            let (rank, multiplier) = match bytes.get(index) {
+                Some(b'H') => (1, 60 * 60),
+                Some(b'M') => (2, 60),
+                Some(b'S') => (3, 1),
+                _ => return Err("invalid DURATION time component".into()),
+            };
+            if previous_rank != 0 && rank != previous_rank + 1 {
+                return Err(
+                    "DURATION time components are repeated, out of order, or skip a component"
+                        .into(),
+                );
+            }
+            index += 1;
+            previous_rank = rank;
+            clock_seconds = clock_seconds
+                .checked_add(
+                    number
+                        .checked_mul(multiplier)
+                        .ok_or_else(|| "DURATION is too large".to_owned())?,
+                )
+                .ok_or_else(|| "DURATION is too large".to_owned())?;
+        }
+    }
+    let clock_seconds =
+        i64::try_from(clock_seconds).map_err(|_| "DURATION is too large".to_owned())?;
+    Ok(IcalDuration {
+        days,
+        clock: Duration::try_seconds(clock_seconds)
+            .ok_or_else(|| "DURATION is too large".to_owned())?,
+    })
+}
+
+fn parse_duration_number(bytes: &[u8], index: &mut usize) -> Result<u64, String> {
+    let start = *index;
+    while bytes.get(*index).is_some_and(u8::is_ascii_digit) {
+        *index += 1;
+    }
+    if start == *index {
+        return Err("DURATION component is missing a number".into());
+    }
+    std::str::from_utf8(&bytes[start..*index])
+        .expect("ASCII digits are valid UTF-8")
+        .parse()
+        .map_err(|_| "DURATION is too large".into())
+}
+
+#[derive(Clone, Copy, Debug)]
+enum CalendarTimezone {
+    Utc,
+    Local,
+    Named(chrono_tz::Tz),
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ConvertedDate {
+    utc: DateTime<Utc>,
+    timezone: CalendarTimezone,
+}
+
+fn date_to_utc(value: DatePerhapsTime, property: &str) -> Result<ConvertedDate, String> {
+    match value {
+        DatePerhapsTime::DateTime(CalendarDateTime::Floating(value)) => {
+            let value = Local.from_local_datetime(&value).single().ok_or_else(|| {
+                format!("{property} is ambiguous or invalid in the local time zone")
+            })?;
+            Ok(ConvertedDate {
+                utc: value.to_utc(),
+                timezone: CalendarTimezone::Local,
+            })
+        }
+        DatePerhapsTime::DateTime(CalendarDateTime::Utc(value)) => Ok(ConvertedDate {
+            utc: value,
+            timezone: CalendarTimezone::Utc,
+        }),
+        DatePerhapsTime::DateTime(CalendarDateTime::WithTimezone { date_time, tzid }) => {
+            let timezone = tzid.parse::<chrono_tz::Tz>().map_err(|_| {
+                format!(
+                    "{property} uses unknown or unsupported TZID {tzid:?}; \
+                     embedded VTIMEZONE definitions are not supported"
+                )
+            })?;
+            let value = timezone
+                .from_local_datetime(&date_time)
+                .single()
+                .ok_or_else(|| {
+                    format!("{property} is ambiguous or invalid in time zone {tzid:?}")
+                })?;
+            Ok(ConvertedDate {
+                utc: value.to_utc(),
+                timezone: CalendarTimezone::Named(timezone),
+            })
+        }
+        DatePerhapsTime::Date(value) => {
+            let value = value
+                .and_hms_opt(0, 0, 0)
+                .and_then(|value| Local.from_local_datetime(&value).single())
+                .ok_or_else(|| format!("{property} is invalid in the local time zone"))?;
+            Ok(ConvertedDate {
+                utc: value.to_utc(),
+                timezone: CalendarTimezone::Local,
+            })
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum EventEnd {
+    Exact(Duration),
+    Nominal {
+        duration: IcalDuration,
+        timezone: CalendarTimezone,
+    },
+}
+
+impl EventEnd {
+    fn end_at(self, start: DateTime<Utc>) -> Result<DateTime<Utc>, String> {
+        match self {
+            Self::Exact(duration) => start
+                .checked_add_signed(duration)
+                .ok_or_else(|| "event end is outside the supported date range".to_owned()),
+            Self::Nominal { duration, timezone } => {
+                let days = Days::new(duration.days);
+                let after_days = match timezone {
+                    CalendarTimezone::Utc => start.checked_add_days(days),
+                    CalendarTimezone::Local => start
+                        .with_timezone(&Local)
+                        .checked_add_days(days)
+                        .map(|date| date.to_utc()),
+                    CalendarTimezone::Named(timezone) => start
+                        .with_timezone(&timezone)
+                        .checked_add_days(days)
+                        .map(|date| date.to_utc()),
+                }
+                .ok_or_else(|| {
+                    "DURATION ends at an ambiguous, invalid, or out-of-range local time".to_owned()
+                })?;
+                after_days
+                    .checked_add_signed(duration.clock)
+                    .ok_or_else(|| "event end is outside the supported date range".to_owned())
+            }
+        }
+    }
+
+    fn search_duration(self) -> Result<Duration, String> {
+        match self {
+            Self::Exact(duration) => Ok(duration),
+            Self::Nominal { duration, .. } => duration.upper_bound(),
+        }
+    }
+}
+
+fn recurrence_requires_too_much_work(
+    recurrence: &icalendar::RRuleSet,
+    expansion_end: DateTime<Utc>,
+) -> bool {
+    let recurrence_start = recurrence.get_dt_start().to_utc();
+    recurrence.get_rrule().iter().any(|rule| {
+        let target = rule
+            .get_until()
+            .map(|until| until.to_utc().min(expansion_end))
+            .unwrap_or(expansion_end);
+        let elapsed = target.signed_duration_since(recurrence_start).num_seconds();
+        if elapsed <= 0 {
+            return false;
+        }
+        let period_seconds = match rule.get_freq() {
+            icalendar::Frequency::Secondly => 1,
+            icalendar::Frequency::Minutely => 60,
+            icalendar::Frequency::Hourly => 60 * 60,
+            icalendar::Frequency::Daily => 23 * 60 * 60,
+            icalendar::Frequency::Weekly => 6 * 24 * 60 * 60,
+            icalendar::Frequency::Monthly => 27 * 24 * 60 * 60,
+            icalendar::Frequency::Yearly => 365 * 24 * 60 * 60,
+        };
+        let interval = i64::from(rule.get_interval().max(1));
+        elapsed / period_seconds / interval > MAX_RECURRENCE_INTERVALS
+    })
+}
+
+fn overlaps_search_window(
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    search_start: DateTime<Utc>,
+    search_end: DateTime<Utc>,
+) -> bool {
+    end > search_start && start < search_end
+}
+
+fn event_at(
+    event: &icalendar::Event,
+    start_at: DateTime<Utc>,
+    end_at: DateTime<Utc>,
+) -> Event {
+    Event {
+        uid: event
+            .get_uid()
+            .expect("event_at is only called for events with a UID")
+            .into(),
+        summary: event.get_summary().map(Into::into),
+        description: event.get_description().map(Into::into),
+        location: event.get_location().map(Into::into),
+        url: event.get_url().map(Into::into),
+        start_at,
+        end_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone as _, Utc};
+
+    use super::*;
+
+    fn utc(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(year, month, day, hour, minute, 0)
+            .unwrap()
+    }
+
+    fn first_event(data: &str) -> icalendar::Event {
+        icalendar::Calendar::from_str(data)
+            .unwrap()
+            .components
+            .into_iter()
+            .find_map(|component| match component {
+                icalendar::CalendarComponent::Event(event) => Some(event),
+                _ => None,
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn parses_timed_event_and_metadata() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:meeting\r\n",
+            "DTSTART;TZID=America/Los_Angeles:20260729T090000\r\n",
+            "DTEND;TZID=America/Los_Angeles:20260729T100000\r\n",
+            "SUMMARY:Planning\r\n",
+            "DESCRIPTION:Roadmap review\r\n",
+            "LOCATION:Room 1\r\n",
+            "URL:https://calendar.example/event\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let events =
+            parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 7, 30, 0, 0)).unwrap();
+
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(event.uid, "meeting");
+        assert_eq!(event.summary.as_deref(), Some("Planning"));
+        assert_eq!(event.description.as_deref(), Some("Roadmap review"));
+        assert_eq!(event.location.as_deref(), Some("Room 1"));
+        assert_eq!(
+            event.url.as_deref(),
+            Some("https://calendar.example/event")
+        );
+        assert_eq!(event.start_at, utc(2026, 7, 29, 16, 0));
+        assert_eq!(event.end_at, utc(2026, 7, 29, 17, 0));
+    }
+
+    #[test]
+    fn expands_rrule_rdate_and_exdate() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:daily\r\n",
+            "DTSTART:20260729T160000Z\r\n",
+            "DTEND:20260729T163000Z\r\n",
+            "RRULE:FREQ=DAILY;COUNT=3\r\n",
+            "EXDATE:20260730T160000Z\r\n",
+            "RDATE:20260801T160000Z\r\n",
+            "SUMMARY:Standup\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let events =
+            parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 8, 2, 0, 0)).unwrap();
+        let starts: Vec<_> = events.iter().map(|event| event.start_at).collect();
+
+        assert_eq!(
+            starts,
+            [
+                utc(2026, 7, 29, 16, 0),
+                utc(2026, 7, 31, 16, 0),
+                utc(2026, 8, 1, 16, 0),
+            ]
+        );
+    }
+
+    #[test]
+    fn applies_moved_and_cancelled_recurrence_overrides() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:daily\r\n",
+            "DTSTART:20260729T160000Z\r\n",
+            "DTEND:20260729T163000Z\r\n",
+            "RRULE:FREQ=DAILY;COUNT=3\r\n",
+            "SUMMARY:Standup\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:daily\r\n",
+            "RECURRENCE-ID:20260730T160000Z\r\n",
+            "DTSTART:20260730T200000Z\r\n",
+            "DTEND:20260730T203000Z\r\n",
+            "SUMMARY:Moved standup\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:daily\r\n",
+            "RECURRENCE-ID:20260731T160000Z\r\n",
+            "STATUS:CANCELLED\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let mut events =
+            parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 8, 1, 0, 0)).unwrap();
+        events.sort_by_key(|event| event.start_at);
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].start_at, utc(2026, 7, 29, 16, 0));
+        assert_eq!(events[0].summary.as_deref(), Some("Standup"));
+        assert_eq!(events[1].start_at, utc(2026, 7, 30, 20, 0));
+        assert_eq!(events[1].summary.as_deref(), Some("Moved standup"));
+    }
+
+    #[test]
+    fn uses_exclusive_all_day_end() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:all-day\r\n",
+            "DTSTART;VALUE=DATE:20260729\r\n",
+            "DTEND;VALUE=DATE:20260730\r\n",
+            "SUMMARY:All day\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let events = parse_events(
+            data,
+            utc(2026, 7, 29, 0, 0),
+            utc(2026, 7, 31, 0, 0),
+        )
+        .unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].end_at - events[0].start_at,
+            Duration::days(1)
+        );
+    }
+
+    #[test]
+    fn supports_duration_and_events_already_in_progress() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:long\r\n",
+            "DTSTART:20260728T180000Z\r\n",
+            "DURATION:P2D\r\n",
+            "SUMMARY:Long event\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let events =
+            parse_events(data, utc(2026, 7, 29, 12, 0), utc(2026, 7, 30, 12, 0)).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].start_at, utc(2026, 7, 28, 18, 0));
+        assert_eq!(events[0].end_at, utc(2026, 7, 30, 18, 0));
+    }
+
+    #[test]
+    fn rejects_malformed_calendar() {
+        let error = parse_events(
+            "not an iCalendar feed",
+            utc(2026, 7, 29, 0, 0),
+            utc(2026, 7, 30, 0, 0),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, CalendarError::Parsing(_)));
+    }
+
+    #[test]
+    fn isolates_invalid_recurrence_rules() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:broken-recurrence\r\n",
+            "DTSTART:20260730T160000Z\r\n",
+            "DTEND:20260730T170000Z\r\n",
+            "RRULE:FREQ=DAILY;UNTIL=20260729T160000Z\r\n",
+            "SUMMARY:Base occurrence\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:valid-event\r\n",
+            "DTSTART:20260731T160000Z\r\n",
+            "DTEND:20260731T170000Z\r\n",
+            "SUMMARY:Valid event\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let mut events =
+            parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 8, 1, 0, 0)).unwrap();
+        events.sort_by_key(|event| event.start_at);
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].summary.as_deref(), Some("Base occurrence"));
+        assert_eq!(events[1].summary.as_deref(), Some("Valid event"));
+    }
+
+    #[test]
+    fn parses_only_rfc5545_event_durations() {
+        let duration = parse_duration("+P100DT2H3M4S").unwrap();
+        assert_eq!(duration.days, 100);
+        assert_eq!(duration.clock, Duration::seconds(7384));
+
+        let weeks = parse_duration("P100W").unwrap();
+        assert_eq!(weeks.days, 700);
+        assert_eq!(weeks.clock, Duration::zero());
+
+        for valid in ["PT1H", "PT1H2M", "PT1M", "PT1M2S", "PT1S", "P1DT1S"] {
+            assert!(parse_duration(valid).is_ok(), "{valid} was rejected");
+        }
+
+        for invalid in [
+            "-P1D",
+            "P1Y",
+            "P1M",
+            "PT1.5S",
+            "P1DT",
+            "P1D1H",
+            "PT1M1H",
+            "PT1H2S",
+            "P1DT1H2S",
+            "P",
+            "PT",
+            "PT9223372036854775807S",
+        ] {
+            assert!(parse_duration(invalid).is_err(), "{invalid} was accepted");
+        }
+    }
+
+    #[test]
+    fn nominal_day_duration_follows_dst_transitions() {
+        let spring = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:spring\r\n",
+            "DTSTART;TZID=America/Los_Angeles:20260307T090000\r\n",
+            "DURATION:P1D\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+        let event = parse_events(
+            spring,
+            utc(2026, 3, 7, 0, 0),
+            utc(2026, 3, 10, 0, 0),
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+        assert_eq!(event.end_at - event.start_at, Duration::hours(23));
+
+        let fall = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:fall\r\n",
+            "DTSTART;TZID=America/Los_Angeles:20261031T090000\r\n",
+            "DURATION:P1D\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+        let event = parse_events(
+            fall,
+            utc(2026, 10, 31, 0, 0),
+            utc(2026, 11, 3, 0, 0),
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+        assert_eq!(event.end_at - event.start_at, Duration::hours(25));
+    }
+
+    #[test]
+    fn default_all_day_duration_uses_next_local_midnight() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:all-day-spring\r\n",
+            "DTSTART;VALUE=DATE:20260308\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+        let event = first_event(data);
+        let (_, end) = event_bounds(&event).unwrap();
+
+        assert!(matches!(
+            end,
+            EventEnd::Nominal {
+                duration: IcalDuration {
+                    days: 1,
+                    clock
+                },
+                timezone: CalendarTimezone::Local,
+            } if clock == Duration::zero()
+        ));
+    }
+
+    #[test]
+    fn malformed_events_do_not_reject_the_feed() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:bad-duration\r\n",
+            "DTSTART:20260729T160000Z\r\n",
+            "DURATION:P1M\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:negative-duration\r\n",
+            "DTSTART:20260729T160000Z\r\n",
+            "DURATION:-P1D\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:backwards\r\n",
+            "DTSTART:20260729T170000Z\r\n",
+            "DTEND:20260729T160000Z\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:unknown-zone\r\n",
+            "DTSTART;TZID=Custom/Office:20260729T160000\r\n",
+            "DTEND;TZID=Custom/Office:20260729T170000\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:valid\r\n",
+            "DTSTART:20260730T160000Z\r\n",
+            "DTEND:20260730T170000Z\r\n",
+            "SUMMARY:Still parsed\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let events =
+            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].uid, "valid");
+    }
+
+    #[test]
+    fn rejects_invalid_dtend_without_rejecting_the_feed() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:mismatched-value-type\r\n",
+            "DTSTART;VALUE=DATE:20260729\r\n",
+            "DTEND:20260730T170000Z\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:mismatched-local-form\r\n",
+            "DTSTART:20260729T160000\r\n",
+            "DTEND:20260729T170000Z\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:equal-end\r\n",
+            "DTSTART:20260729T160000Z\r\n",
+            "DTEND:20260729T160000Z\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:valid\r\n",
+            "DTSTART:20260730T160000Z\r\n",
+            "DTEND:20260730T170000Z\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let events =
+            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].uid, "valid");
+    }
+
+    #[test]
+    fn skips_events_without_required_uid() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "DTSTART:20260729T160000Z\r\n",
+            "DTEND:20260729T170000Z\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:valid\r\n",
+            "DTSTART:20260730T160000Z\r\n",
+            "DTEND:20260730T170000Z\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let events =
+            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].uid, "valid");
+    }
+
+    #[test]
+    fn rejects_this_and_future_series() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:series\r\n",
+            "DTSTART:20260729T160000Z\r\n",
+            "DTEND:20260729T170000Z\r\n",
+            "RRULE:FREQ=DAILY;COUNT=3\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:series\r\n",
+            "RECURRENCE-ID;RANGE=THISANDFUTURE:20260730T160000Z\r\n",
+            "DTSTART:20260730T180000Z\r\n",
+            "DTEND:20260730T190000Z\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:independent\r\n",
+            "DTSTART:20260730T200000Z\r\n",
+            "DTEND:20260730T210000Z\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let events =
+            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 2, 0, 0)).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].uid, "independent");
+    }
+
+    #[test]
+    fn skips_recurrences_that_would_require_excessive_fast_forwarding() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:pathological\r\n",
+            "DTSTART:20000101T000000Z\r\n",
+            "DURATION:PT1S\r\n",
+            "RRULE:FREQ=SECONDLY\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:valid\r\n",
+            "DTSTART:20260730T160000Z\r\n",
+            "DTEND:20260730T170000Z\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let events =
+            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].uid, "valid");
+    }
+
+    #[test]
+    fn count_does_not_bypass_recurrence_work_limit() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:pathological-with-count\r\n",
+            "DTSTART:20000101T000000Z\r\n",
+            "DURATION:PT1S\r\n",
+            "RRULE:FREQ=SECONDLY;COUNT=100000;BYMINUTE=0;BYSECOND=0\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+        let event = first_event(data);
+        let recurrence = event.get_recurrence().unwrap();
+
+        assert_eq!(recurrence.get_rrule()[0].get_count(), Some(100_000));
+        assert!(recurrence_requires_too_much_work(
+            &recurrence,
+            utc(2026, 7, 29, 0, 0)
+        ));
+    }
+
+    #[test]
+    fn recurrence_work_limit_includes_the_requested_window() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:pathological-in-window\r\n",
+            "DTSTART:20260729T000000Z\r\n",
+            "DURATION:PT1S\r\n",
+            "RRULE:FREQ=SECONDLY;BYMINUTE=0;BYSECOND=0\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+        let event = first_event(data);
+        let recurrence = event.get_recurrence().unwrap();
+
+        assert!(recurrence_requires_too_much_work(
+            &recurrence,
+            utc(2026, 8, 1, 0, 0)
+        ));
+    }
+
+    #[test]
+    fn search_window_end_is_exclusive() {
+        let data = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:at-end\r\n",
+            "DTSTART:20260730T000000Z\r\n",
+            "DTEND:20260730T010000Z\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+
+        let events =
+            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 7, 30, 0, 0)).unwrap();
+
+        assert!(events.is_empty());
+    }
+}

--- a/src/blocks/calendar/ical.rs
+++ b/src/blocks/calendar/ical.rs
@@ -31,53 +31,45 @@ pub fn parse_events(
     event_search_end: DateTime<Utc>,
 ) -> Result<Vec<Event>, CalendarError> {
     let calendar = icalendar::Calendar::from_str(data).map_err(CalendarError::Parsing)?;
-    let events: Vec<_> = calendar
-        .components
-        .into_iter()
-        .filter_map(|component| match component {
-            icalendar::CalendarComponent::Event(event) => Some(event),
-            _ => None,
-        })
-        .collect();
-
-    // RANGE=THISANDFUTURE changes this and all later instances. The recurrence library does not
-    // implement those semantics, so reject the affected series instead of showing incorrect
-    // future instances.
-    let unsupported_series: HashSet<_> = events
-        .iter()
-        .filter(|event| recurrence_range(event).is_some_and(|range| {
-            range.eq_ignore_ascii_case("THISANDFUTURE")
-        }))
-        .filter_map(event_uid)
-        .map(ToOwned::to_owned)
-        .collect();
-    for uid in &unsupported_series {
-        log::warn!(
-            "Ignoring calendar event series with UID {uid:?}: \
-             RECURRENCE-ID;RANGE=THISANDFUTURE is not supported"
-        );
-    }
+    let events = || {
+        calendar
+            .components
+            .iter()
+            .filter_map(|component| component.as_event())
+    };
 
     // A modified or cancelled recurrence is represented as another VEVENT with the same UID and
     // a RECURRENCE-ID. Suppress that instant from the master event; a non-cancelled override is
-    // added below at its replacement DTSTART.
-    let mut overridden_recurrences = HashMap::<String, HashSet<DateTime<Utc>>>::new();
+    // added below at its replacement DTSTART. RANGE=THISANDFUTURE changes every later instance;
+    // the recurrence library does not implement that mode, so reject the affected series.
+    let mut unsupported_series = HashSet::new();
+    let mut overridden_recurrences = HashMap::<&str, HashSet<DateTime<Utc>>>::new();
     let mut invalid_overrides = HashSet::new();
-    for (index, event) in events.iter().enumerate() {
+    for (index, event) in events().enumerate() {
         let Some(uid) = event_uid(event) else {
             continue;
         };
-        if unsupported_series.contains(uid) || !event.properties().contains_key("RECURRENCE-ID") {
+        if recurrence_range(event).is_some_and(|range| range.eq_ignore_ascii_case("THISANDFUTURE"))
+        {
+            if unsupported_series.insert(uid) {
+                log::warn!(
+                    "Ignoring calendar event series with UID {uid:?}: \
+                     RECURRENCE-ID;RANGE=THISANDFUTURE is not supported"
+                );
+            }
+            continue;
+        }
+        if !event.properties().contains_key("RECURRENCE-ID") {
             continue;
         }
         let recurrence_id = event
             .get_recurrence_id()
             .ok_or_else(|| "RECURRENCE-ID is invalid".to_owned())
-            .and_then(|value| date_to_utc(value, "RECURRENCE-ID").map(|date| date.utc));
+            .and_then(|value| date_to_utc(&value, "RECURRENCE-ID").map(|date| date.utc));
         match recurrence_id {
             Ok(recurrence_id) => {
                 overridden_recurrences
-                    .entry(uid.to_owned())
+                    .entry(uid)
                     .or_default()
                     .insert(recurrence_id);
             }
@@ -89,8 +81,8 @@ pub fn parse_events(
     }
 
     let mut result = vec![];
-    for (index, event) in events.into_iter().enumerate() {
-        let Some(uid) = event_uid(&event) else {
+    for (index, event) in events().enumerate() {
+        let Some(uid) = event_uid(event) else {
             log::warn!("Ignoring calendar event: UID is missing or empty");
             continue;
         };
@@ -101,7 +93,7 @@ pub fn parse_events(
             continue;
         }
 
-        let (event_start, event_end_spec) = match event_bounds(&event) {
+        let (event_start, event_end_spec) = match event_bounds(event) {
             Ok(bounds) => bounds,
             Err(error) => {
                 warn_event(uid, &error);
@@ -115,16 +107,23 @@ pub fn parse_events(
                 continue;
             }
         };
+        let mut add_if_visible = |start, end| {
+            if overlaps_search_window(start, end, event_search_start, event_search_end) {
+                result.push(event_at(uid, event, start, end));
+            }
+        };
 
         if event.properties().contains_key("RECURRENCE-ID") {
-            if overlaps_search_window(
-                event_start,
-                event_end,
-                event_search_start,
-                event_search_end,
-            ) {
-                result.push(event_at(&event, event_start, event_end));
-            }
+            add_if_visible(event_start, event_end);
+            continue;
+        }
+
+        let multi_properties = event.multi_properties();
+        if !event.properties().contains_key("RRULE")
+            && !multi_properties.contains_key("RDATE")
+            && !multi_properties.contains_key("EXDATE")
+        {
+            add_if_visible(event_start, event_end);
             continue;
         }
 
@@ -142,14 +141,7 @@ pub fn parse_events(
             Ok(recurrence) => recurrence,
             Err(error) => {
                 warn_event(uid, &format!("invalid recurrence: {error}"));
-                if overlaps_search_window(
-                    event_start,
-                    event_end,
-                    event_search_start,
-                    event_search_end,
-                ) {
-                    result.push(event_at(&event, event_start, event_end));
-                }
+                add_if_visible(event_start, event_end);
                 continue;
             }
         };
@@ -158,14 +150,7 @@ pub fn parse_events(
                 uid,
                 "recurrence expansion would require too many frequency intervals",
             );
-            if overlaps_search_window(
-                event_start,
-                event_end,
-                event_search_start,
-                event_search_end,
-            ) {
-                result.push(event_at(&event, event_start, event_end));
-            }
+            add_if_visible(event_start, event_end);
             continue;
         }
         let recurrence_result = recurrence
@@ -195,9 +180,7 @@ pub fn parse_events(
                     continue;
                 }
             };
-            if overlaps_search_window(start, end, event_search_start, event_search_end) {
-                result.push(event_at(&event, start, end));
-            }
+            add_if_visible(start, end);
         }
     }
     Ok(result)
@@ -225,7 +208,7 @@ fn event_bounds(event: &icalendar::Event) -> Result<(DateTime<Utc>, EventEnd), S
         .get_start()
         .ok_or_else(|| "DTSTART is missing or invalid".to_owned())?;
     let is_all_day = matches!(start_value, DatePerhapsTime::Date(_));
-    let start = date_to_utc(start_value.clone(), "DTSTART")?;
+    let start = date_to_utc(&start_value, "DTSTART")?;
 
     let has_end = event.properties().contains_key("DTEND");
     let duration = event.property_value("DURATION");
@@ -238,7 +221,7 @@ fn event_bounds(event: &icalendar::Event) -> Result<(DateTime<Utc>, EventEnd), S
             .get_end()
             .ok_or_else(|| "DTEND is invalid".to_owned())?;
         validate_dtend_form(&start_value, &end_value)?;
-        let end = date_to_utc(end_value, "DTEND")?.utc;
+        let end = date_to_utc(&end_value, "DTEND")?.utc;
         if end <= start.utc {
             return Err("DTEND must be later than DTSTART".into());
         }
@@ -415,10 +398,10 @@ struct ConvertedDate {
     timezone: CalendarTimezone,
 }
 
-fn date_to_utc(value: DatePerhapsTime, property: &str) -> Result<ConvertedDate, String> {
+fn date_to_utc(value: &DatePerhapsTime, property: &str) -> Result<ConvertedDate, String> {
     match value {
         DatePerhapsTime::DateTime(CalendarDateTime::Floating(value)) => {
-            let value = Local.from_local_datetime(&value).single().ok_or_else(|| {
+            let value = Local.from_local_datetime(value).single().ok_or_else(|| {
                 format!("{property} is ambiguous or invalid in the local time zone")
             })?;
             Ok(ConvertedDate {
@@ -427,7 +410,7 @@ fn date_to_utc(value: DatePerhapsTime, property: &str) -> Result<ConvertedDate, 
             })
         }
         DatePerhapsTime::DateTime(CalendarDateTime::Utc(value)) => Ok(ConvertedDate {
-            utc: value,
+            utc: *value,
             timezone: CalendarTimezone::Utc,
         }),
         DatePerhapsTime::DateTime(CalendarDateTime::WithTimezone { date_time, tzid }) => {
@@ -438,7 +421,7 @@ fn date_to_utc(value: DatePerhapsTime, property: &str) -> Result<ConvertedDate, 
                 )
             })?;
             let value = timezone
-                .from_local_datetime(&date_time)
+                .from_local_datetime(date_time)
                 .single()
                 .ok_or_else(|| {
                     format!("{property} is ambiguous or invalid in time zone {tzid:?}")
@@ -449,7 +432,7 @@ fn date_to_utc(value: DatePerhapsTime, property: &str) -> Result<ConvertedDate, 
             })
         }
         DatePerhapsTime::Date(value) => {
-            let value = value
+            let value = (*value)
                 .and_hms_opt(0, 0, 0)
                 .and_then(|value| Local.from_local_datetime(&value).single())
                 .ok_or_else(|| format!("{property} is invalid in the local time zone"))?;
@@ -545,15 +528,13 @@ fn overlaps_search_window(
 }
 
 fn event_at(
+    uid: &str,
     event: &icalendar::Event,
     start_at: DateTime<Utc>,
     end_at: DateTime<Utc>,
 ) -> Event {
     Event {
-        uid: event
-            .get_uid()
-            .expect("event_at is only called for events with a UID")
-            .into(),
+        uid: uid.into(),
         summary: event.get_summary().map(Into::into),
         description: event.get_description().map(Into::into),
         location: event.get_location().map(Into::into),
@@ -568,6 +549,17 @@ mod tests {
     use chrono::{TimeZone as _, Utc};
 
     use super::*;
+
+    macro_rules! calendar {
+        ($($line:literal),* $(,)?) => {
+            concat!(
+                "BEGIN:VCALENDAR\r\n",
+                "VERSION:2.0\r\n",
+                $($line,)*
+                "END:VCALENDAR\r\n",
+            )
+        };
+    }
 
     fn utc(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> DateTime<Utc> {
         Utc.with_ymd_and_hms(year, month, day, hour, minute, 0)
@@ -588,9 +580,7 @@ mod tests {
 
     #[test]
     fn parses_timed_event_and_metadata() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:meeting\r\n",
             "DTSTART;TZID=America/Los_Angeles:20260729T090000\r\n",
@@ -600,11 +590,9 @@ mod tests {
             "LOCATION:Room 1\r\n",
             "URL:https://calendar.example/event\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
-        let events =
-            parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 7, 30, 0, 0)).unwrap();
+        let events = parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 7, 30, 0, 0)).unwrap();
 
         assert_eq!(events.len(), 1);
         let event = &events[0];
@@ -612,19 +600,14 @@ mod tests {
         assert_eq!(event.summary.as_deref(), Some("Planning"));
         assert_eq!(event.description.as_deref(), Some("Roadmap review"));
         assert_eq!(event.location.as_deref(), Some("Room 1"));
-        assert_eq!(
-            event.url.as_deref(),
-            Some("https://calendar.example/event")
-        );
+        assert_eq!(event.url.as_deref(), Some("https://calendar.example/event"));
         assert_eq!(event.start_at, utc(2026, 7, 29, 16, 0));
         assert_eq!(event.end_at, utc(2026, 7, 29, 17, 0));
     }
 
     #[test]
     fn expands_rrule_rdate_and_exdate() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:daily\r\n",
             "DTSTART:20260729T160000Z\r\n",
@@ -634,11 +617,9 @@ mod tests {
             "RDATE:20260801T160000Z\r\n",
             "SUMMARY:Standup\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
-        let events =
-            parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 8, 2, 0, 0)).unwrap();
+        let events = parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 8, 2, 0, 0)).unwrap();
         let starts: Vec<_> = events.iter().map(|event| event.start_at).collect();
 
         assert_eq!(
@@ -652,10 +633,31 @@ mod tests {
     }
 
     #[test]
+    fn expands_rdate_and_exdate_without_rrule() {
+        let data = calendar!(
+            "BEGIN:VEVENT\r\n",
+            "UID:extra-date\r\n",
+            "DTSTART:20260729T160000Z\r\n",
+            "DTEND:20260729T163000Z\r\n",
+            "RDATE:20260730T160000Z\r\n",
+            "END:VEVENT\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:excluded-date\r\n",
+            "DTSTART:20260729T170000Z\r\n",
+            "DTEND:20260729T173000Z\r\n",
+            "EXDATE:20260729T170000Z\r\n",
+            "END:VEVENT\r\n",
+        );
+
+        let events = parse_events(data, utc(2026, 7, 29, 15, 0), utc(2026, 7, 31, 0, 0)).unwrap();
+        let starts: Vec<_> = events.iter().map(|event| event.start_at).collect();
+
+        assert_eq!(starts, [utc(2026, 7, 29, 16, 0), utc(2026, 7, 30, 16, 0)]);
+    }
+
+    #[test]
     fn applies_moved_and_cancelled_recurrence_overrides() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:daily\r\n",
             "DTSTART:20260729T160000Z\r\n",
@@ -675,7 +677,6 @@ mod tests {
             "RECURRENCE-ID:20260731T160000Z\r\n",
             "STATUS:CANCELLED\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
         let mut events =
@@ -691,48 +692,33 @@ mod tests {
 
     #[test]
     fn uses_exclusive_all_day_end() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:all-day\r\n",
             "DTSTART;VALUE=DATE:20260729\r\n",
             "DTEND;VALUE=DATE:20260730\r\n",
             "SUMMARY:All day\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
-        let events = parse_events(
-            data,
-            utc(2026, 7, 29, 0, 0),
-            utc(2026, 7, 31, 0, 0),
-        )
-        .unwrap();
+        let events = parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 7, 31, 0, 0)).unwrap();
 
         assert_eq!(events.len(), 1);
-        assert_eq!(
-            events[0].end_at - events[0].start_at,
-            Duration::days(1)
-        );
+        assert_eq!(events[0].end_at - events[0].start_at, Duration::days(1));
     }
 
     #[test]
     fn supports_duration_and_events_already_in_progress() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:long\r\n",
             "DTSTART:20260728T180000Z\r\n",
             "DURATION:P2D\r\n",
             "SUMMARY:Long event\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
-        let events =
-            parse_events(data, utc(2026, 7, 29, 12, 0), utc(2026, 7, 30, 12, 0)).unwrap();
+        let events = parse_events(data, utc(2026, 7, 29, 12, 0), utc(2026, 7, 30, 12, 0)).unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].start_at, utc(2026, 7, 28, 18, 0));
@@ -753,9 +739,7 @@ mod tests {
 
     #[test]
     fn isolates_invalid_recurrence_rules() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:broken-recurrence\r\n",
             "DTSTART:20260730T160000Z\r\n",
@@ -769,7 +753,6 @@ mod tests {
             "DTEND:20260731T170000Z\r\n",
             "SUMMARY:Valid event\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
         let mut events =
@@ -815,57 +798,40 @@ mod tests {
 
     #[test]
     fn nominal_day_duration_follows_dst_transitions() {
-        let spring = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let spring = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:spring\r\n",
             "DTSTART;TZID=America/Los_Angeles:20260307T090000\r\n",
             "DURATION:P1D\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
-        let event = parse_events(
-            spring,
-            utc(2026, 3, 7, 0, 0),
-            utc(2026, 3, 10, 0, 0),
-        )
-        .unwrap()
-        .pop()
-        .unwrap();
+        let event = parse_events(spring, utc(2026, 3, 7, 0, 0), utc(2026, 3, 10, 0, 0))
+            .unwrap()
+            .pop()
+            .unwrap();
         assert_eq!(event.end_at - event.start_at, Duration::hours(23));
 
-        let fall = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let fall = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:fall\r\n",
             "DTSTART;TZID=America/Los_Angeles:20261031T090000\r\n",
             "DURATION:P1D\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
-        let event = parse_events(
-            fall,
-            utc(2026, 10, 31, 0, 0),
-            utc(2026, 11, 3, 0, 0),
-        )
-        .unwrap()
-        .pop()
-        .unwrap();
+        let event = parse_events(fall, utc(2026, 10, 31, 0, 0), utc(2026, 11, 3, 0, 0))
+            .unwrap()
+            .pop()
+            .unwrap();
         assert_eq!(event.end_at - event.start_at, Duration::hours(25));
     }
 
     #[test]
     fn default_all_day_duration_uses_next_local_midnight() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:all-day-spring\r\n",
             "DTSTART;VALUE=DATE:20260308\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
         let event = first_event(data);
         let (_, end) = event_bounds(&event).unwrap();
@@ -884,9 +850,7 @@ mod tests {
 
     #[test]
     fn malformed_events_do_not_reject_the_feed() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:bad-duration\r\n",
             "DTSTART:20260729T160000Z\r\n",
@@ -913,11 +877,9 @@ mod tests {
             "DTEND:20260730T170000Z\r\n",
             "SUMMARY:Still parsed\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
-        let events =
-            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
+        let events = parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].uid, "valid");
@@ -925,9 +887,7 @@ mod tests {
 
     #[test]
     fn rejects_invalid_dtend_without_rejecting_the_feed() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:mismatched-value-type\r\n",
             "DTSTART;VALUE=DATE:20260729\r\n",
@@ -948,11 +908,9 @@ mod tests {
             "DTSTART:20260730T160000Z\r\n",
             "DTEND:20260730T170000Z\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
-        let events =
-            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
+        let events = parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].uid, "valid");
@@ -960,9 +918,7 @@ mod tests {
 
     #[test]
     fn skips_events_without_required_uid() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "DTSTART:20260729T160000Z\r\n",
             "DTEND:20260729T170000Z\r\n",
@@ -972,11 +928,9 @@ mod tests {
             "DTSTART:20260730T160000Z\r\n",
             "DTEND:20260730T170000Z\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
-        let events =
-            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
+        let events = parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].uid, "valid");
@@ -984,9 +938,7 @@ mod tests {
 
     #[test]
     fn rejects_this_and_future_series() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:series\r\n",
             "DTSTART:20260729T160000Z\r\n",
@@ -1004,11 +956,9 @@ mod tests {
             "DTSTART:20260730T200000Z\r\n",
             "DTEND:20260730T210000Z\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
-        let events =
-            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 2, 0, 0)).unwrap();
+        let events = parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 2, 0, 0)).unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].uid, "independent");
@@ -1016,9 +966,7 @@ mod tests {
 
     #[test]
     fn skips_recurrences_that_would_require_excessive_fast_forwarding() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:pathological\r\n",
             "DTSTART:20000101T000000Z\r\n",
@@ -1030,11 +978,9 @@ mod tests {
             "DTSTART:20260730T160000Z\r\n",
             "DTEND:20260730T170000Z\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
-        let events =
-            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
+        let events = parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 8, 1, 0, 0)).unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].uid, "valid");
@@ -1042,16 +988,13 @@ mod tests {
 
     #[test]
     fn count_does_not_bypass_recurrence_work_limit() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:pathological-with-count\r\n",
             "DTSTART:20000101T000000Z\r\n",
             "DURATION:PT1S\r\n",
             "RRULE:FREQ=SECONDLY;COUNT=100000;BYMINUTE=0;BYSECOND=0\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
         let event = first_event(data);
         let recurrence = event.get_recurrence().unwrap();
@@ -1065,16 +1008,13 @@ mod tests {
 
     #[test]
     fn recurrence_work_limit_includes_the_requested_window() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:pathological-in-window\r\n",
             "DTSTART:20260729T000000Z\r\n",
             "DURATION:PT1S\r\n",
             "RRULE:FREQ=SECONDLY;BYMINUTE=0;BYSECOND=0\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
         let event = first_event(data);
         let recurrence = event.get_recurrence().unwrap();
@@ -1087,19 +1027,15 @@ mod tests {
 
     #[test]
     fn search_window_end_is_exclusive() {
-        let data = concat!(
-            "BEGIN:VCALENDAR\r\n",
-            "VERSION:2.0\r\n",
+        let data = calendar!(
             "BEGIN:VEVENT\r\n",
             "UID:at-end\r\n",
             "DTSTART:20260730T000000Z\r\n",
             "DTEND:20260730T010000Z\r\n",
             "END:VEVENT\r\n",
-            "END:VCALENDAR\r\n",
         );
 
-        let events =
-            parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 7, 30, 0, 0)).unwrap();
+        let events = parse_events(data, utc(2026, 7, 29, 0, 0), utc(2026, 7, 30, 0, 0)).unwrap();
 
         assert!(events.is_empty());
     }

--- a/src/blocks/calendar/ics.rs
+++ b/src/blocks/calendar/ics.rs
@@ -1,0 +1,252 @@
+use reqwest::{
+    ClientBuilder, Response, Url,
+    header::{ACCEPT, HeaderValue},
+};
+
+use super::{
+    CalendarError,
+    auth::{Auth, Authorize, AuthorizeUrl},
+    ical::{Event, parse_events},
+};
+use crate::{APP_USER_AGENT, REQWEST_TIMEOUT};
+
+const MAX_ICS_SIZE: usize = 32 * 1024 * 1024;
+
+pub struct Client {
+    url: Url,
+    client: reqwest::Client,
+    auth: Auth,
+}
+
+impl Client {
+    pub fn new(url: Url, auth: Auth) -> Self {
+        Self {
+            url,
+            client: ClientBuilder::new()
+                .user_agent(APP_USER_AGENT)
+                .timeout(REQWEST_TIMEOUT)
+                .build()
+                .expect("A valid HTTP client"),
+            auth,
+        }
+    }
+
+    pub async fn events(
+        &mut self,
+        start: chrono::DateTime<chrono::Utc>,
+        end: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<Event>, CalendarError> {
+        let mut retries = 0;
+        loop {
+            let request = self
+                .client
+                .get(self.url.clone())
+                .headers(self.auth.headers().await)
+                .header(ACCEPT, HeaderValue::from_static("text/calendar"))
+                .build()
+                .expect("A valid ICS request");
+            // The URL of an ICS feed can contain a secret token. Reqwest includes request URLs in
+            // some errors, so strip it before the error can reach the block output or logs.
+            let result = self
+                .client
+                .execute(request)
+                .await
+                .map_err(redact_http_error)?;
+            match result.error_for_status() {
+                Err(error) if retries == 0 => {
+                    self.auth.handle_error(error.without_url()).await?;
+                    retries += 1;
+                }
+                Err(error) => return Err(redact_http_error(error)),
+                Ok(result) => {
+                    let body = read_body(result, MAX_ICS_SIZE).await?;
+                    let body = std::str::from_utf8(&body).map_err(|error| {
+                        CalendarError::Parsing(format!(
+                            "iCalendar feed is not valid UTF-8: {error}"
+                        ))
+                    })?;
+                    return parse_events(body, start, end);
+                }
+            }
+        }
+    }
+
+    pub async fn authorize(&mut self) -> Result<Authorize, CalendarError> {
+        self.auth.authorize().await
+    }
+
+    pub async fn ask_user(&mut self, authorize: AuthorizeUrl) -> Result<(), CalendarError> {
+        self.auth.ask_user(authorize).await
+    }
+}
+
+fn redact_http_error(error: reqwest::Error) -> CalendarError {
+    CalendarError::Http(error.without_url())
+}
+
+async fn read_body(mut response: Response, limit: usize) -> Result<Vec<u8>, CalendarError> {
+    let content_length = response.content_length();
+    if content_length.is_some_and(|length| length > limit as u64) {
+        return Err(size_limit_error(limit));
+    }
+
+    let initial_capacity = content_length
+        .and_then(|length| usize::try_from(length).ok())
+        .unwrap_or_default();
+    let mut body = Vec::with_capacity(initial_capacity);
+    while let Some(chunk) = response.chunk().await.map_err(redact_http_error)? {
+        if body
+            .len()
+            .checked_add(chunk.len())
+            .is_none_or(|length| length > limit)
+        {
+            return Err(size_limit_error(limit));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn size_limit_error(limit: usize) -> CalendarError {
+    CalendarError::Parsing(format!(
+        "iCalendar feed exceeds the {limit}-byte size limit"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::{
+        io::{AsyncReadExt as _, AsyncWriteExt as _},
+        net::TcpListener,
+    };
+
+    use super::*;
+
+    async fn serve_response(
+        path: &str,
+        response: String,
+    ) -> (Url, tokio::task::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = stream.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]).into_owned();
+            stream.write_all(response.as_bytes()).await.unwrap();
+            request
+        });
+        (
+            Url::parse(&format!("http://{address}{path}")).unwrap(),
+            handle,
+        )
+    }
+
+    #[tokio::test]
+    async fn fetches_and_parses_ics_over_http() {
+        let body = concat!(
+            "BEGIN:VCALENDAR\r\n",
+            "VERSION:2.0\r\n",
+            "BEGIN:VEVENT\r\n",
+            "UID:event\r\n",
+            "DTSTART:20260729T160000Z\r\n",
+            "DTEND:20260729T170000Z\r\n",
+            "SUMMARY:Test\r\n",
+            "END:VEVENT\r\n",
+            "END:VCALENDAR\r\n",
+        );
+        let (url, request) = serve_response(
+            "/calendar.ics",
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/calendar\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            ),
+        )
+        .await;
+        let mut client = Client::new(url, Auth::Unauthenticated);
+        let start = chrono::DateTime::parse_from_rfc3339("2026-07-29T15:00:00Z")
+            .unwrap()
+            .to_utc();
+        let end = chrono::DateTime::parse_from_rfc3339("2026-07-30T15:00:00Z")
+            .unwrap()
+            .to_utc();
+
+        let events = client.events(start, end).await.unwrap();
+        let request = request.await.unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].summary.as_deref(), Some("Test"));
+        assert!(request.starts_with("GET /calendar.ics HTTP/1.1\r\n"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("\r\naccept: text/calendar\r\n")
+        );
+    }
+
+    #[tokio::test]
+    async fn http_errors_do_not_expose_private_feed_url() {
+        const SECRET: &str = "private-secret-token";
+        let (url, request) = serve_response(
+            &format!("/calendar/ical/{SECRET}/basic.ics"),
+            "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                .into(),
+        )
+        .await;
+        let mut client = Client::new(url, Auth::Unauthenticated);
+        let start = chrono::DateTime::parse_from_rfc3339("2026-07-29T15:00:00Z")
+            .unwrap()
+            .to_utc();
+        let end = chrono::DateTime::parse_from_rfc3339("2026-07-30T15:00:00Z")
+            .unwrap()
+            .to_utc();
+
+        let error = client.events(start, end).await.unwrap_err();
+        request.await.unwrap();
+
+        assert!(matches!(error, CalendarError::Http(_)));
+        assert!(!error.to_string().contains(SECRET));
+    }
+
+    #[tokio::test]
+    async fn body_errors_do_not_expose_private_feed_url() {
+        const SECRET: &str = "private-secret-token";
+        let (url, request) = serve_response(
+            &format!("/calendar/ical/{SECRET}/basic.ics"),
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\ninvalid\r\n"
+                .into(),
+        )
+        .await;
+        let response = reqwest::Client::new().get(url).send().await.unwrap();
+
+        let error = read_body(response, MAX_ICS_SIZE).await.unwrap_err();
+        request.await.unwrap();
+
+        assert!(matches!(error, CalendarError::Http(_)));
+        assert!(!error.to_string().contains(SECRET));
+    }
+
+    #[tokio::test]
+    async fn stops_reading_chunked_body_at_size_limit() {
+        let (url, request) = serve_response(
+            "/calendar.ics",
+            concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "Transfer-Encoding: chunked\r\n",
+                "Connection: close\r\n\r\n",
+                "4\r\n1234\r\n",
+                "5\r\n56789\r\n",
+                "0\r\n\r\n",
+            )
+            .into(),
+        )
+        .await;
+        let response = reqwest::Client::new().get(url).send().await.unwrap();
+
+        let error = read_body(response, 8).await.unwrap_err();
+        request.await.unwrap();
+
+        assert!(matches!(error, CalendarError::Parsing(_)));
+        assert!(error.to_string().contains("8-byte size limit"));
+    }
+}

--- a/src/blocks/calendar/ics.rs
+++ b/src/blocks/calendar/ics.rs
@@ -142,6 +142,13 @@ mod tests {
         )
     }
 
+    fn search_window() -> (chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>) {
+        (
+            "2026-07-29T15:00:00Z".parse().unwrap(),
+            "2026-07-30T15:00:00Z".parse().unwrap(),
+        )
+    }
+
     #[tokio::test]
     async fn fetches_and_parses_ics_over_http() {
         let body = concat!(
@@ -164,12 +171,7 @@ mod tests {
         )
         .await;
         let mut client = Client::new(url, Auth::Unauthenticated);
-        let start = chrono::DateTime::parse_from_rfc3339("2026-07-29T15:00:00Z")
-            .unwrap()
-            .to_utc();
-        let end = chrono::DateTime::parse_from_rfc3339("2026-07-30T15:00:00Z")
-            .unwrap()
-            .to_utc();
+        let (start, end) = search_window();
 
         let events = client.events(start, end).await.unwrap();
         let request = request.await.unwrap();
@@ -194,12 +196,7 @@ mod tests {
         )
         .await;
         let mut client = Client::new(url, Auth::Unauthenticated);
-        let start = chrono::DateTime::parse_from_rfc3339("2026-07-29T15:00:00Z")
-            .unwrap()
-            .to_utc();
-        let end = chrono::DateTime::parse_from_rfc3339("2026-07-30T15:00:00Z")
-            .unwrap()
-            .to_utc();
+        let (start, end) = search_window();
 
         let error = client.events(start, end).await.unwrap_err();
         request.await.unwrap();


### PR DESCRIPTION
## Summary

- Add direct, read-only ICS feed support to the calendar block with `type = "ics"`, keeping CalDAV as the default.
- Share and harden iCalendar parsing for recurrence overrides, RFC 5545 durations and DST behavior, malformed events, and expansion limits.
- Protect secret feed URLs in errors and enforce a streamed 32 MiB response limit.
- Document Google Calendar secret iCal setup without requiring Google Cloud or OAuth.

Tested on current arch with i3 4.25.1
<img width="195" height="34" alt="image" src="https://github.com/user-attachments/assets/0bfddd0a-3e9d-48cf-9b55-3529ee027c61" />
