### PR TITLE
Fix logic bug in `keyboard_layout` block (xkb_event)

### DIFF
--- a/src/blocks/keyboard_layout/xkb_event.rs
+++ b/src/blocks/keyboard_layout/xkb_event.rs
@@ -20,12 +20,18 @@ pub(super) struct XkbEvent {
 }
 
 fn parse_layout(buf: &[u8], index: usize) -> Result<&str> {
-    let colon_i = buf.iter().position(|c| *c == b':').unwrap_or(buf.len());
-    let layout = buf[..colon_i]
+    let segment = buf
         .split(|&c| c == b'+')
-        .skip(1) // layout names start from index 1
+        .skip(1)
         .nth(index)
         .error("Index out of range")?;
+
+    let colon_i = segment
+        .iter()
+        .position(|c| *c == b':')
+        .unwrap_or(segment.len());
+
+    let layout = &segment[..colon_i];
     std::str::from_utf8(layout).error("non utf8 layout")
 }
 


### PR DESCRIPTION
The [XKB extension protocol](https://xorg.freedesktop.org/archive/current/doc/kbproto/xkbproto.html#Keyboard_State) defines _keyboard state_ to include up to four _keysym groups_, which could emit the following symbol string when fully occupied `pc+us+ara:2+jp:3+fr:4+inet(evdev)+group(alt_shift_toggle)`. 

The current `parse_layout` function looks for the first colon in the entire buffer and truncates everything after it before attempting to split the symbol string. 

```rust
fn parse_layout(buf: &[u8], index: usize) -> Result<&str> {
    let colon_i = buf.iter().position(|c| *c == b':').unwrap_or(buf.len());
    let layout = buf[..colon_i]
        .split(|&c| c == b'+')
        .skip(1) // layout names start from index 1
        .nth(index)
        .error("Index out of range")?;

    std::str::from_utf8(layout).error("non utf8 layout")
}
```

Because the symbol string is truncated early, Group 3 (`jp:3`) and beyond are completely erased. When the user switches to the 3rd Group (index 2), the iterator runs out of elements and throws an `index out of range` error.

To fix this, the logic would be to split the symbol string by `+` and grab the exact segment in the first place. Then, strip the group index afterward.

```rust
fn parse_layout_fixed(buf: &[u8], index: usize) -> Result<&str> {
    let segment = buf
        .split(|&c| c == b'+')
        .skip(1)
        .nth(index)
        .error("Index out of range")?;

    let colon_i = segment
        .iter()
        .position(|c| *c == b':')
        .unwrap_or(segment.len());

    let layout = &segment[..colon_i];

    std::str::from_utf8(layout).error("non utf8 layout")
}
```
