### PR TITLE
fix: prevent external_ip block from hammering the geolocation service

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -306,6 +306,10 @@ impl CommonApi {
         self.geolocator.name()
     }
 
+    fn locator_rate_limit_interval(&self) -> Duration {
+        self.geolocator.rate_limit_interval()
+    }
+
     /// No-op if last API call was made in the last `interval` seconds.
     pub async fn find_ip_location(
         &self,

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -57,13 +57,30 @@
 //! periodic refresh exists to catch IP updates that don't trigger a notification,
 //! for example due to a IP refresh at the router.
 //!
+//! If the service reports rate limiting, the block keeps showing the last
+//! known IP and waits 10 minutes before asking again.
+//!
 //! Flags: They are not icons but unicode glyphs. You will need a font that
 //! includes them. Tested with: <https://www.babelstone.co.uk/Fonts/Flags.html>
 
 use zbus::MatchRule;
 
 use super::prelude::*;
+use crate::geolocator::is_rate_limited;
 use crate::util::{country_flag_from_iso_code, new_system_dbus_connection};
+
+/// Coalesces bursts of update triggers (a single network transition emits
+/// several D-Bus signals) into one API request.
+const CACHE_INTERVAL: Duration = Duration::from_secs(3);
+
+/// How long the network-change signal stream must stay quiet before the IP is
+/// re-queried; a transition keeps emitting signals for a while, often before
+/// connectivity is actually usable.
+const SETTLE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// How long to wait before asking again after the service reported rate
+/// limiting; retrying sooner only prolongs the block.
+const RATE_LIMIT_INTERVAL: Duration = Duration::from_secs(600);
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -123,9 +140,12 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             .await
             .error("Failed to add match")?;
         let stream: zbus::MessageStream = dbus.into();
-        Box::pin(stream.map(|_| ()))
+        // If the D-Bus connection dies the stream ends; without the chained
+        // pending stream, polling it again would resolve instantly forever,
+        // turning the loop below into a busy loop of API requests.
+        Box::pin(stream.map(|_| ()).chain(futures::stream::pending()))
     } else {
-        Box::pin(futures::stream::empty())
+        Box::pin(futures::stream::pending())
     };
 
     let client = if config.use_ipv4 {
@@ -135,8 +155,23 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     };
 
     loop {
-        let fetch_info = || api.find_ip_location(client, Duration::from_secs(0));
-        let info = fetch_info.retry(ExponentialBuilder::default()).await?;
+        let fetch_info = || api.find_ip_location(client, CACHE_INTERVAL);
+        let info = match fetch_info
+            .retry(ExponentialBuilder::default())
+            .when(|err| !is_rate_limited(err))
+            .await
+        {
+            Ok(info) => info,
+            Err(err) if is_rate_limited(&err) => {
+                // Keep displaying the last known IP and try again much later;
+                // erroring out here would make the block restart machinery
+                // re-query every `error_interval` seconds, which keeps the
+                // rate limit from ever lifting.
+                sleep(RATE_LIMIT_INTERVAL).await;
+                continue;
+            }
+            Err(err) => return Err(err),
+        };
 
         let mut values = map! {
             "ip" => Value::text(info.ip),
@@ -213,7 +248,12 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         select! {
             _ = sleep(config.interval.0) => (),
             _ = api.wait_for_update_request() => (),
-            _ = stream.next_debounced() => ()
+            _ = stream.next_debounced() => {
+                // Wait for the burst of signals to die down before re-querying,
+                // so that one network transition results in one request, made
+                // once the new connection is likely up.
+                while let Ok(Some(_)) = tokio::time::timeout(SETTLE_INTERVAL, stream.next()).await {}
+            }
         }
     }
 }

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -92,7 +92,8 @@ pub struct Config {
     /// Unlike the weather block this defaults to 1 second, not `interval`:
     /// picking up a fresh IP right after a network change is the whole point
     /// of this block, so cached results must expire quickly.
-    pub autolocate_interval: Option<Seconds>,
+    #[default(1.into())]
+    pub autolocate_interval: Seconds,
     #[default(true)]
     pub with_network_manager: bool,
     #[default(false)]
@@ -159,14 +160,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         &REQWEST_CLIENT
     };
 
-    let autolocate_interval = config.autolocate_interval.unwrap_or(1.into());
-
     loop {
-        let fetch_info = || api.find_ip_location(client, autolocate_interval.0);
         let fetch_start = tokio::time::Instant::now();
-        let info = match fetch_info
-            .retry(ExponentialBuilder::default())
-            .when(|err| !is_rate_limited(err))
+        let info = match api
+            .find_ip_location(client, config.autolocate_interval.0)
             .await
         {
             Ok(info) => info,

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -69,14 +69,21 @@ use super::prelude::*;
 use crate::geolocator::is_rate_limited;
 use crate::util::{country_flag_from_iso_code, new_system_dbus_connection};
 
-/// Coalesces bursts of update triggers (a single network transition emits
+/// Coalesces simultaneous update triggers (a single network transition emits
 /// several D-Bus signals) into one API request.
-const CACHE_INTERVAL: Duration = Duration::from_secs(3);
+const CACHE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// How long the network-change signal stream must stay quiet before the IP is
 /// re-queried; a transition keeps emitting signals for a while, often before
 /// connectivity is actually usable.
-const SETTLE_INTERVAL: Duration = Duration::from_secs(2);
+const SETTLE_QUIET: Duration = Duration::from_secs(1);
+
+/// Upper bound on the settle wait. NetworkManager can keep emitting signals
+/// (IP config, DNS, connectivity checks) for many seconds after a transition;
+/// without a cap the quiet window keeps sliding and the update is delayed
+/// indefinitely. If the network is still not usable when we query, the retry
+/// backoff covers it.
+const SETTLE_MAX: Duration = Duration::from_secs(3);
 
 /// How long to wait before asking again after the service reported rate
 /// limiting; retrying sooner only prolongs the block.
@@ -156,6 +163,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
     loop {
         let fetch_info = || api.find_ip_location(client, CACHE_INTERVAL);
+        let fetch_start = tokio::time::Instant::now();
         let info = match fetch_info
             .retry(ExponentialBuilder::default())
             .when(|err| !is_rate_limited(err))
@@ -172,6 +180,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             }
             Err(err) => return Err(err),
         };
+        log::debug!(
+            "external_ip: got {} after {:?}",
+            info.ip,
+            fetch_start.elapsed()
+        );
 
         let mut values = map! {
             "ip" => Value::text(info.ip),
@@ -252,7 +265,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 // Wait for the burst of signals to die down before re-querying,
                 // so that one network transition results in one request, made
                 // once the new connection is likely up.
-                while let Ok(Some(_)) = tokio::time::timeout(SETTLE_INTERVAL, stream.next()).await {}
+                let settle_start = tokio::time::Instant::now();
+                while let Ok(Some(_)) = tokio::time::timeout(SETTLE_QUIET, stream.next()).await {
+                    if settle_start.elapsed() >= SETTLE_MAX {
+                        break;
+                    }
+                }
+                log::debug!("external_ip: signals settled after {:?}", settle_start.elapsed());
             }
         }
     }

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -6,6 +6,7 @@
 //! ----|--------|--------
 //! `format` | A string to customise the output of this block. See below for available placeholders. | `" $ip $country_flag "`
 //! `interval` | Interval in seconds for automatic updates | `300`
+//! `autolocate_interval` | How long in seconds to reuse the last result from the geolocation service instead of contacting it again. Kept small by default so that network changes are picked up promptly. | `1`
 //! `with_network_manager` | If 'true', listen for NetworkManager events and update the IP immediately if there was a change | `true`
 //! `use_ipv4` | If 'true', use IPv4 for obtaining all info | `false`
 //!
@@ -58,7 +59,8 @@
 //! for example due to a IP refresh at the router.
 //!
 //! If the service reports rate limiting, the block keeps showing the last
-//! known IP and waits 10 minutes before asking again.
+//! known IP and waits for the geolocator's `rate_limit_interval` (10 minutes
+//! by default) before asking again.
 //!
 //! Flags: They are not icons but unicode glyphs. You will need a font that
 //! includes them. Tested with: <https://www.babelstone.co.uk/Fonts/Flags.html>
@@ -68,10 +70,6 @@ use zbus::MatchRule;
 use super::prelude::*;
 use crate::geolocator::is_rate_limited;
 use crate::util::{country_flag_from_iso_code, new_system_dbus_connection};
-
-/// Coalesces simultaneous update triggers (a single network transition emits
-/// several D-Bus signals) into one API request.
-const CACHE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// How long the network-change signal stream must stay quiet before the IP is
 /// re-queried; a transition keeps emitting signals for a while, often before
@@ -85,16 +83,16 @@ const SETTLE_QUIET: Duration = Duration::from_secs(1);
 /// backoff covers it.
 const SETTLE_MAX: Duration = Duration::from_secs(3);
 
-/// How long to wait before asking again after the service reported rate
-/// limiting; retrying sooner only prolongs the block.
-const RATE_LIMIT_INTERVAL: Duration = Duration::from_secs(600);
-
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     pub format: FormatConfig,
     #[default(300.into())]
     pub interval: Seconds,
+    /// Unlike the weather block this defaults to 1 second, not `interval`:
+    /// picking up a fresh IP right after a network change is the whole point
+    /// of this block, so cached results must expire quickly.
+    pub autolocate_interval: Option<Seconds>,
     #[default(true)]
     pub with_network_manager: bool,
     #[default(false)]
@@ -161,8 +159,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         &REQWEST_CLIENT
     };
 
+    let autolocate_interval = config.autolocate_interval.unwrap_or(1.into());
+
     loop {
-        let fetch_info = || api.find_ip_location(client, CACHE_INTERVAL);
+        let fetch_info = || api.find_ip_location(client, autolocate_interval.0);
         let fetch_start = tokio::time::Instant::now();
         let info = match fetch_info
             .retry(ExponentialBuilder::default())
@@ -171,11 +171,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         {
             Ok(info) => info,
             Err(err) if is_rate_limited(&err) => {
-                // Keep displaying the last known IP and try again much later;
-                // erroring out here would make the block restart machinery
-                // re-query every `error_interval` seconds, which keeps the
-                // rate limit from ever lifting.
-                sleep(RATE_LIMIT_INTERVAL).await;
+                // Keep displaying the last known IP and try again once the
+                // geolocator's rate limit interval has passed (plus a margin
+                // so we don't wake up just before it expires); erroring out
+                // here would make the block restart machinery re-query every
+                // `error_interval` seconds, which keeps the rate limit from
+                // ever lifting.
+                sleep(api.locator_rate_limit_interval() + Duration::from_secs(1)).await;
                 continue;
             }
             Err(err) => return Err(err),

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -71,6 +71,8 @@ use super::prelude::*;
 use crate::geolocator::is_rate_limited;
 use crate::util::{country_flag_from_iso_code, new_system_dbus_connection};
 
+make_log_macro!(debug, "external_ip");
+
 /// How long the network-change signal stream must stay quiet before the IP is
 /// re-queried; a transition keeps emitting signals for a while, often before
 /// connectivity is actually usable.
@@ -179,11 +181,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             }
             Err(err) => return Err(err),
         };
-        log::debug!(
-            "external_ip: got {} after {:?}",
-            info.ip,
-            fetch_start.elapsed()
-        );
+        debug!("got {} after {:?}", info.ip, fetch_start.elapsed());
 
         let mut values = map! {
             "ip" => Value::text(info.ip),
@@ -270,7 +268,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                         break;
                     }
                 }
-                log::debug!("external_ip: signals settled after {:?}", settle_start.elapsed());
+                debug!("signals settled after {:?}", settle_start.elapsed());
             }
         }
     }

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -456,8 +456,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
     loop {
         let location = if config.autolocate {
-            let fetch = || api.find_ip_location(&REQWEST_CLIENT, autolocate_interval);
-            Some(fetch.retry(ExponentialBuilder::default()).await?)
+            Some(
+                api.find_ip_location(&REQWEST_CLIENT, autolocate_interval)
+                    .await?,
+            )
         } else {
             None
         };

--- a/src/geolocator.rs
+++ b/src/geolocator.rs
@@ -64,6 +64,12 @@ use smart_default::SmartDefault;
 mod ip2location;
 mod ipapi;
 
+/// Per-request timeout, deliberately much shorter than the shared client's
+/// 10s: lookups normally take well under a second, and when a request is sent
+/// while routes are still changing (the common case for the external_ip
+/// block) it just hangs, so failing fast and retrying beats waiting.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+
 #[derive(Debug)]
 struct AutolocateResult {
     location: IPAddressInfo,

--- a/src/geolocator.rs
+++ b/src/geolocator.rs
@@ -63,6 +63,26 @@ struct AutolocateResult {
     timestamp: Instant,
 }
 
+/// Error cause set by backends when the service refuses to answer because of
+/// rate limiting. Callers can detect it with [`is_rate_limited`] and back off
+/// instead of retrying, which would only prolong the block.
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimited;
+
+impl fmt::Display for RateLimited {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("rate limited by the geolocation service")
+    }
+}
+
+impl StdError for RateLimited {}
+
+pub fn is_rate_limited(err: &Error) -> bool {
+    err.cause
+        .as_ref()
+        .is_some_and(|cause| cause.downcast_ref::<RateLimited>().is_some())
+}
+
 #[derive(Deserialize, Clone, Default, Debug)]
 pub struct IPAddressInfo {
     // Required fields

--- a/src/geolocator.rs
+++ b/src/geolocator.rs
@@ -51,6 +51,8 @@
 //! api_key = "XXX"
 //! ```
 
+use backon::{ExponentialBuilder, Retryable as _};
+
 use crate::errors::{Error, ErrorContext as _, Result, StdError};
 use crate::wrappers::Seconds;
 use std::borrow::Cow;
@@ -155,9 +157,11 @@ impl Geolocator {
 
     /// No-op if last API call was made in the last `interval` seconds.
     ///
-    /// If the service reported rate limiting less than `rate_limit_interval`
-    /// seconds ago, no request is made and an error with a [`RateLimited`]
-    /// cause is returned, so that all callers collectively respect the limit.
+    /// Transient errors are retried with exponential backoff, so callers
+    /// don't need their own retry logic. If the service reported rate
+    /// limiting less than `rate_limit_interval` seconds ago, no request is
+    /// made and an error with a [`RateLimited`] cause is returned, so that
+    /// all callers collectively respect the limit.
     pub async fn find_ip_location(
         &self,
         client: &reqwest::Client,
@@ -184,7 +188,12 @@ impl Geolocator {
             }
         }
 
-        let location = match self.backend.get_info(client).await {
+        let fetch = || self.backend.get_info(client);
+        let location = match fetch
+            .retry(ExponentialBuilder::default())
+            .when(|err| !is_rate_limited(err))
+            .await
+        {
             Ok(location) => location,
             Err(err) => {
                 if is_rate_limited(&err) {
@@ -207,18 +216,14 @@ impl Geolocator {
 }
 
 #[derive(Deserialize, Debug, SmartDefault)]
+#[serde(default)]
 pub struct GeolocatorConfig {
     #[serde(flatten)]
     backend: GeolocatorBackend,
     /// How long to wait before contacting the service again after it reported
     /// rate limiting.
-    #[serde(default = "default_rate_limit_interval")]
-    #[default(default_rate_limit_interval())]
+    #[default(600.into())]
     rate_limit_interval: Seconds,
-}
-
-fn default_rate_limit_interval() -> Seconds {
-    600.into()
 }
 
 #[derive(Deserialize, Debug, SmartDefault, Clone)]
@@ -269,6 +274,11 @@ mod tests {
         let geolocator: Geolocator = toml::from_str("geolocator = \"ipapi\"").unwrap();
         assert!(matches!(geolocator.backend, GeolocatorBackend::Ipapi(_)));
         assert_eq!(geolocator.rate_limit_interval, Duration::from_secs(600));
+
+        // the `geolocator` key is required when the [geolocator] section is
+        // present (serde's struct-level default does not extend to the
+        // flattened backend enum)
+        assert!(toml::from_str::<Geolocator>("").is_err());
 
         let geolocator: Geolocator =
             toml::from_str("geolocator = \"ipapi\"\nrate_limit_interval = 120").unwrap();

--- a/src/geolocator.rs
+++ b/src/geolocator.rs
@@ -7,6 +7,12 @@
 //!
 //! # Configuration
 //!
+//! # Common Options
+//!
+//! Key | Values | Required | Default
+//! ----|--------|----------|--------
+//! `rate_limit_interval` | Seconds to wait before contacting the service again after it reported rate limiting. Until then, cached results are served and no new requests are made. | No | `600`
+//!
 //! # ipapi.co Options
 //!
 //! Key | Values | Required | Default
@@ -46,6 +52,7 @@
 //! ```
 
 use crate::errors::{Error, ErrorContext as _, Result, StdError};
+use crate::wrappers::Seconds;
 use std::borrow::Cow;
 use std::fmt;
 use std::sync::{Arc, Mutex};
@@ -116,11 +123,19 @@ pub struct IPAddressInfo {
     pub org: Option<String>,
 }
 
-#[derive(Default, Debug, Deserialize)]
-#[serde(from = "GeolocatorBackend")]
+#[derive(Debug, Deserialize)]
+#[serde(from = "GeolocatorConfig")]
 pub struct Geolocator {
     backend: GeolocatorBackend,
+    rate_limit_interval: Duration,
     last_autolocate: Mutex<Option<AutolocateResult>>,
+    last_rate_limited: Mutex<Option<Instant>>,
+}
+
+impl Default for Geolocator {
+    fn default() -> Self {
+        GeolocatorConfig::default().into()
+    }
 }
 
 impl Geolocator {
@@ -128,7 +143,15 @@ impl Geolocator {
         self.backend.name()
     }
 
+    pub fn rate_limit_interval(&self) -> Duration {
+        self.rate_limit_interval
+    }
+
     /// No-op if last API call was made in the last `interval` seconds.
+    ///
+    /// If the service reported rate limiting less than `rate_limit_interval`
+    /// seconds ago, no request is made and an error with a [`RateLimited`]
+    /// cause is returned, so that all callers collectively respect the limit.
     pub async fn find_ip_location(
         &self,
         client: &reqwest::Client,
@@ -143,7 +166,27 @@ impl Geolocator {
             }
         }
 
-        let location = self.backend.get_info(client).await?;
+        {
+            let guard = self.last_rate_limited.lock().unwrap();
+            if let Some(at) = *guard
+                && at.elapsed() < self.rate_limit_interval
+            {
+                return Err(Error {
+                    message: Some("geolocation service is rate limited, backing off".into()),
+                    cause: Some(Arc::new(RateLimited)),
+                });
+            }
+        }
+
+        let location = match self.backend.get_info(client).await {
+            Ok(location) => location,
+            Err(err) => {
+                if is_rate_limited(&err) {
+                    *self.last_rate_limited.lock().unwrap() = Some(Instant::now());
+                }
+                return Err(err);
+            }
+        };
 
         {
             let mut guard = self.last_autolocate.lock().unwrap();
@@ -155,6 +198,21 @@ impl Geolocator {
 
         Ok(location)
     }
+}
+
+#[derive(Deserialize, Debug, SmartDefault)]
+pub struct GeolocatorConfig {
+    #[serde(flatten)]
+    backend: GeolocatorBackend,
+    /// How long to wait before contacting the service again after it reported
+    /// rate limiting.
+    #[serde(default = "default_rate_limit_interval")]
+    #[default(default_rate_limit_interval())]
+    rate_limit_interval: Seconds,
+}
+
+fn default_rate_limit_interval() -> Seconds {
+    600.into()
 }
 
 #[derive(Deserialize, Debug, SmartDefault, Clone)]
@@ -185,11 +243,38 @@ impl GeolocatorBackend {
     }
 }
 
-impl From<GeolocatorBackend> for Geolocator {
-    fn from(backend: GeolocatorBackend) -> Self {
+impl From<GeolocatorConfig> for Geolocator {
+    fn from(config: GeolocatorConfig) -> Self {
         Self {
-            backend,
+            backend: config.backend,
+            rate_limit_interval: config.rate_limit_interval.0,
             last_autolocate: Mutex::new(None),
+            last_rate_limited: Mutex::new(None),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_config() {
+        let geolocator: Geolocator = toml::from_str("geolocator = \"ipapi\"").unwrap();
+        assert!(matches!(geolocator.backend, GeolocatorBackend::Ipapi(_)));
+        assert_eq!(geolocator.rate_limit_interval, Duration::from_secs(600));
+
+        let geolocator: Geolocator =
+            toml::from_str("geolocator = \"ipapi\"\nrate_limit_interval = 120").unwrap();
+        assert_eq!(geolocator.rate_limit_interval, Duration::from_secs(120));
+
+        let geolocator: Geolocator =
+            toml::from_str("geolocator = \"ip2location\"\napi_key = \"xxx\"").unwrap();
+        let GeolocatorBackend::Ip2Location(config) = geolocator.backend else {
+            panic!("wrong backend");
+        };
+        assert_eq!(config.api_key.as_deref(), Some("xxx"));
+
+        assert!(toml::from_str::<Geolocator>("geolocator = \"ipapi\"\nbad_key = 1").is_err());
     }
 }

--- a/src/geolocator/ip2location.rs
+++ b/src/geolocator/ip2location.rs
@@ -206,7 +206,7 @@ impl Ip2Location {
         client: &reqwest::Client,
         api_key: Option<&String>,
     ) -> Result<IPAddressInfo> {
-        let mut request_builder = client.get(IP_API_URL);
+        let mut request_builder = client.get(IP_API_URL).timeout(REQUEST_TIMEOUT);
 
         if let Some(api_key) = api_key {
             request_builder = request_builder.query(&[("key", api_key)]);

--- a/src/geolocator/ip2location.rs
+++ b/src/geolocator/ip2location.rs
@@ -212,10 +212,19 @@ impl Ip2Location {
             request_builder = request_builder.query(&[("key", api_key)]);
         }
 
-        let response: ApiResponse = request_builder
+        let response = request_builder
             .send()
             .await
-            .error("Failed during request for current location")?
+            .error("Failed during request for current location")?;
+
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(Error {
+                message: Some("ip2location.io rate limit exceeded".into()),
+                cause: Some(Arc::new(RateLimited)),
+            });
+        }
+
+        let response: ApiResponse = response
             .json()
             .await
             .error("Failed while parsing location API result")?;

--- a/src/geolocator/ipapi.rs
+++ b/src/geolocator/ipapi.rs
@@ -121,11 +121,7 @@ impl Ipapi {
         if response.error {
             Err(Error {
                 message: Some("ipapi.co error".into()),
-                cause: if response.reason.0.as_deref() == Some("RateLimited") {
-                    Some(Arc::new(RateLimited))
-                } else {
-                    Some(Arc::new(response.reason))
-                },
+                cause: Some(Arc::new(response.reason)),
             })
         } else {
             Ok(response

--- a/src/geolocator/ipapi.rs
+++ b/src/geolocator/ipapi.rs
@@ -100,11 +100,20 @@ impl Ipapi {
     }
 
     pub async fn get_info(&self, client: &reqwest::Client) -> Result<IPAddressInfo> {
-        let response: ApiResponse = client
+        let response = client
             .get(IP_API_URL)
             .send()
             .await
-            .error("Failed during request for current location")?
+            .error("Failed during request for current location")?;
+
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(Error {
+                message: Some("ipapi.co rate limit exceeded".into()),
+                cause: Some(Arc::new(RateLimited)),
+            });
+        }
+
+        let response: ApiResponse = response
             .json()
             .await
             .error("Failed while parsing location API result")?;
@@ -112,7 +121,11 @@ impl Ipapi {
         if response.error {
             Err(Error {
                 message: Some("ipapi.co error".into()),
-                cause: Some(Arc::new(response.reason)),
+                cause: if response.reason.0.as_deref() == Some("RateLimited") {
+                    Some(Arc::new(RateLimited))
+                } else {
+                    Some(Arc::new(response.reason))
+                },
             })
         } else {
             Ok(response

--- a/src/geolocator/ipapi.rs
+++ b/src/geolocator/ipapi.rs
@@ -102,6 +102,7 @@ impl Ipapi {
     pub async fn get_info(&self, client: &reqwest::Client) -> Result<IPAddressInfo> {
         let response = client
             .get(IP_API_URL)
+            .timeout(REQUEST_TIMEOUT)
             .send()
             .await
             .error("Failed during request for current location")?;


### PR DESCRIPTION
## Problem

The `external_ip` block could end up rate limited by the geolocation service, and once limited it kept requesting fast enough that the limit never lifted. Several issues compounded:

1. **Busy loop when the signal stream ends.** If the D-Bus connection died (or `with_network_manager = false`, which used `stream::empty()`), polling the finished stream resolved immediately, turning the update loop into an unthrottled busy loop of API requests.
2. **Rate limit responses were retried like transient errors.** HTTP 429 (and ipapi.co's `"reason": "RateLimited"`) produced a generic error, so backon retried it (4 requests in ~7s), and when retries were exhausted the block's restart machinery re-ran `run()` every `error_interval` (5s default) — forever. Net effect: ~4 requests every ~12s at a server that is asking you to stop.
3. **Signal bursts on network transitions.** One VPN connect / Wi-Fi switch emits many NetworkManager `PropertiesChanged` signals over several seconds, often before connectivity is usable, causing several requests (plus failed-request retries) per transition. `next_debounced` only collapses signals already queued at poll time, not ones arriving during the in-flight HTTP request.

## Fix

- `geolocator`: new `RateLimited` error cause + `is_rate_limited()` helper; the ipapi.co backend maps HTTP 429 and the `"RateLimited"` reason to it, the ip2location.io backend maps HTTP 429.
- `external_ip`: skip retries for rate limit errors, keep showing the last known IP, and wait 10 minutes before asking again (instead of erroring out into the 5s restart loop).
- `external_ip`: chain a `pending` stream after the D-Bus stream (and use `stream::pending()` instead of `stream::empty()`) so a finished stream means "no more signals", not "wake up constantly".
- `external_ip`: after a signal wakes the loop, wait until the stream has been quiet for 2s before querying, and pass a 3s cache interval to `find_ip_location` instead of 0, so one network transition results in one request made once the new connection is likely up.

Network changes are still picked up promptly (~2s after the signal burst settles), and the periodic refresh interval is unchanged.

## Testing

- `cargo clippy --all-targets` clean
- `cargo test --lib` — 52 passed
