### PR TITLE
fix: use net inactive_format for disconnected interfaces

### DIFF
--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -105,15 +105,17 @@ impl NetDevice {
         }))
     }
 
-    /// Note: tun/wireguard/ppp interfaces are not special-cased to be always
-    /// up (as they were since #350): they usually report `Operstate::Unknown`,
-    /// which is covered by the has-an-address clause below, and the
-    /// special-casing made `inactive_format` unreachable for VPN interfaces
-    /// that are actually down (#1917).
+    /// An interface is active only when its operational state allows traffic
+    /// and it has an address. In particular, `Operstate::Up` only describes
+    /// the link state, so an Ethernet interface can remain `Up` after a
+    /// network manager disconnects it and removes its addresses (#1917).
+    ///
+    /// Tun/wireguard/ppp interfaces are not special-cased to be always up (as
+    /// they were since #350): they usually report `Operstate::Unknown`, which
+    /// is covered by the has-an-address clause below.
     pub fn is_up(&self) -> bool {
-        self.iface.operstate == Operstate::Up
-            || (self.iface.operstate == Operstate::Unknown
-                && (self.ip.is_some() || self.ipv6.is_some()))
+        (self.iface.operstate == Operstate::Up || self.iface.operstate == Operstate::Unknown)
+            && (self.ip.is_some() || self.ipv6.is_some())
     }
 
     pub fn ssid(&self) -> Option<String> {
@@ -509,7 +511,7 @@ mod tests {
             iface: Interface {
                 index: 1,
                 operstate,
-                name: "vpn0".into(),
+                name: "net0".into(),
                 stats: None,
             },
             wifi_info: None,
@@ -524,7 +526,9 @@ mod tests {
     fn is_up_by_operstate_and_address() {
         let ip = Some(Ipv4Addr::new(10, 0, 0, 2));
 
-        assert!(device(Operstate::Up, None, None).is_up());
+        // A physical link can remain up after NetworkManager disconnects it,
+        // but without an address it is inactive.
+        assert!(!device(Operstate::Up, None, None).is_up());
         assert!(device(Operstate::Up, ip, None).is_up());
 
         // tun/wireguard/ppp interfaces usually report Unknown; they count as

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -26,7 +26,6 @@ pub struct NetDevice {
     pub ip: Option<Ipv4Addr>,
     pub ipv6: Option<Ipv6Addr>,
     pub icon: &'static str,
-    pub tun_wg_ppp: bool,
     pub nameservers: Vec<IpAddr>,
 }
 
@@ -102,14 +101,17 @@ impl NetDevice {
             ip,
             ipv6,
             icon,
-            tun_wg_ppp: tun | wg | ppp,
             nameservers,
         }))
     }
 
+    /// Note: tun/wireguard/ppp interfaces are not special-cased to be always
+    /// up (as they were since #350): they usually report `Operstate::Unknown`,
+    /// which is covered by the has-an-address clause below, and the
+    /// special-casing made `inactive_format` unreachable for VPN interfaces
+    /// that are actually down (#1917).
     pub fn is_up(&self) -> bool {
-        self.tun_wg_ppp
-            || self.iface.operstate == Operstate::Up
+        self.iface.operstate == Operstate::Up
             || (self.iface.operstate == Operstate::Unknown
                 && (self.ip.is_some() || self.ipv6.is_some()))
     }
@@ -495,5 +497,46 @@ impl From<u8> for Operstate {
             6 => Self::Up,
             _ => Self::Unknown,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn device(operstate: Operstate, ip: Option<Ipv4Addr>, ipv6: Option<Ipv6Addr>) -> NetDevice {
+        NetDevice {
+            iface: Interface {
+                index: 1,
+                operstate,
+                name: "vpn0".into(),
+                stats: None,
+            },
+            wifi_info: None,
+            ip,
+            ipv6,
+            icon: "net_vpn",
+            nameservers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn is_up_by_operstate_and_address() {
+        let ip = Some(Ipv4Addr::new(10, 0, 0, 2));
+
+        assert!(device(Operstate::Up, None, None).is_up());
+        assert!(device(Operstate::Up, ip, None).is_up());
+
+        // tun/wireguard/ppp interfaces usually report Unknown; they count as
+        // up only while they have an address
+        assert!(device(Operstate::Unknown, ip, None).is_up());
+        assert!(device(Operstate::Unknown, None, Some(Ipv6Addr::LOCALHOST)).is_up());
+        assert!(!device(Operstate::Unknown, None, None).is_up());
+
+        // regression test for #1917: a VPN interface that is administratively
+        // down must not be reported as up, so that `inactive_format` is used
+        assert!(!device(Operstate::Down, None, None).is_up());
+        assert!(!device(Operstate::Down, ip, None).is_up());
+        assert!(!device(Operstate::Lowerlayerdown, None, None).is_up());
     }
 }


### PR DESCRIPTION
## Problem

`NetDevice::is_up()` had two independent holes:

- tun/wireguard/ppp interfaces were special-cased as always active, even when their operational state was down
- every interface with `Operstate::Up` was considered active even when it had no address

The second case occurs when an Ethernet cable still has carrier but NetworkManager disconnects the device and removes its addresses. The link remains `Up`, so the net block selected `format`; a required placeholder such as `$ip` was then missing and produced `Failed to render full text` instead of using `inactive_format`.

## Fix

Remove the VPN always-active special case and define an active interface as one that:

1. has an operational state that can carry traffic (`Up` or `Unknown`), and
2. has an IPv4 or IPv6 address.

| operstate | address | active |
|---|---:|---:|
| `Up` | yes | yes |
| `Up` | no | no (connected cable, NetworkManager disconnected) |
| `Unknown` | yes | yes (typical active tun/wireguard device) |
| `Unknown` | no | no |
| any other state | any | no |

This also keeps a down VPN inactive even if it retains a stale or link-local address.

Unit tests cover the complete state/address behavior, including both reproductions from #1917.

Fixes #1917
