### PR TITLE
refactor: give blocks a declared output contract

### DIFF
--- a/src/block_plan.rs
+++ b/src/block_plan.rs
@@ -1,0 +1,769 @@
+//! Block output contracts.
+//!
+//! Every standard block prepares a [`BlockPlan`] from its configuration before
+//! running. The plan declares each output variant the block can produce, the
+//! effective format for that output (defaults and inheritance already
+//! resolved), and the icon names each icon-valued placeholder can carry. A
+//! block that renders plain runtime text rather than a format declares that
+//! too, as an [`OutputKind::Text`] output.
+//!
+//! The runtime renders through [`OutputHandle`]s derived from the plan, which
+//! install the effective format and can look up the icon names the plan
+//! declares. Icons are checked in one place, when a widget is published (see
+//! [`Widget::check_contract`][crate::widget::Widget]): every icon value it
+//! carries must be one the output declared, however that value was built.
+//!
+//! The invariant is that everything a block puts on the bar comes from a
+//! declared output: publishing a format or text widget without a handle of
+//! the matching kind fails, a plan that declares nothing is rejected when it
+//! is built, and [`Widget::set_format`][crate::widget::Widget] and
+//! [`Widget::set_text`][crate::widget::Widget] void the contract rather than
+//! quietly keeping it. A widget with no source at all renders nothing and is
+//! exempt.
+//!
+//! Because the plan is prepared before the block runs, a block's icon and
+//! format surface can also be inspected without running it, and what such an
+//! inspection sees cannot drift from what the block actually renders.
+//!
+//! Declaring an icon does not resolve it. Resolution stays lazy: an icon is
+//! looked up in the icon set only when a reachable format actually renders it,
+//! so configurations that omit icons their formats never reference keep
+//! working.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use crate::errors::*;
+use crate::formatting::Format;
+use crate::formatting::value::{Value, ValueInner};
+use crate::widget::Widget;
+
+/// The icon the bar draws on a restartable block error, declared by
+/// [`error_plan`] and rendered by the error widget.
+pub(crate) const RESTART_ICON: &str = "refresh";
+
+/// Marks an error caused by a block breaking its own contract rather than
+/// by the user's configuration. Every contract failure is prefixed with it,
+/// so the two kinds of error can be told apart by their message.
+pub(crate) const CONTRACT_BUG: &str = "block contract bug";
+
+/// The icon names one placeholder of one output variant can carry.
+#[derive(Debug, Clone)]
+pub(crate) enum IconChoices {
+    /// A closed set, fully known once the block's configuration is parsed.
+    /// Includes configuration-derived names (e.g. `toggle`'s `icon_on`).
+    Fixed(Vec<Cow<'static, str>>),
+    /// Any icon name is permitted and resolves through the normal icon set
+    /// and override rules at render time. Reserved for deliberately dynamic
+    /// blocks (`custom`, `custom_dbus`); standard blocks declare closed sets.
+    OpenResolvable,
+}
+
+impl IconChoices {
+    pub(crate) fn fixed<I, S>(names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<Cow<'static, str>>,
+    {
+        Self::Fixed(names.into_iter().map(Into::into).collect())
+    }
+
+    pub(crate) fn one<S: Into<Cow<'static, str>>>(name: S) -> Self {
+        Self::Fixed(vec![name.into()])
+    }
+
+    pub(crate) fn permits(&self, name: &str) -> bool {
+        // An empty icon name renders as empty output (a runtime no-op), so
+        // it is always permitted.
+        name.is_empty()
+            || match self {
+                Self::Fixed(names) => names.iter().any(|n| n == name),
+                Self::OpenResolvable => true,
+            }
+    }
+}
+
+/// What an output renders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OutputKind {
+    /// A format template: placeholders, and icons among them.
+    Format,
+    /// Plain text computed at runtime, with no placeholders and no icons
+    /// (`menu`). The text itself cannot be known before the block runs, but
+    /// declaring the output keeps the block inside the contract: it states
+    /// that this is all the block renders.
+    Text,
+}
+
+/// One output variant of a block: a named state, its effective format, and
+/// the icons each icon-valued placeholder may carry in that state.
+#[derive(Debug, Clone)]
+pub(crate) struct OutputPlan {
+    id: Cow<'static, str>,
+    kind: OutputKind,
+    format: Format,
+    icons: Vec<(&'static str, IconChoices)>,
+}
+
+impl OutputPlan {
+    pub(crate) fn new(id: impl Into<Cow<'static, str>>, format: Format) -> Self {
+        Self {
+            id: id.into(),
+            kind: OutputKind::Format,
+            format,
+            icons: Vec::new(),
+        }
+    }
+
+    /// An output that renders plain runtime text instead of a format.
+    pub(crate) fn text(id: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            id: id.into(),
+            kind: OutputKind::Text,
+            format: Format::new(
+                "".parse().expect("the empty template always parses"),
+                "".parse().expect("the empty template always parses"),
+            ),
+            icons: Vec::new(),
+        }
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub(crate) fn kind(&self) -> OutputKind {
+        self.kind
+    }
+
+    /// The effective format of this output. A [`OutputKind::Text`] output
+    /// renders no template, so its format is empty.
+    pub(crate) fn format(&self) -> &Format {
+        &self.format
+    }
+
+    /// Declare the icon choices for an icon-valued placeholder.
+    /// Duplicate declarations are rejected when the plan is built.
+    pub(crate) fn icon(mut self, placeholder: &'static str, choices: IconChoices) -> Self {
+        self.icons.push((placeholder, choices));
+        self
+    }
+
+    pub(crate) fn choices_for(&self, placeholder: &str) -> Option<&IconChoices> {
+        self.icons
+            .iter()
+            .find(|(p, _)| *p == placeholder)
+            .map(|(_, c)| c)
+    }
+
+    /// The icon-valued placeholders this output declares. The bar itself
+    /// renders through [`OutputHandle`] and looks placeholders up by name, so
+    /// nothing in the hot path needs this — it exists because a plan that can
+    /// only be queried by a name you already know is not inspectable. The
+    /// declaration tests are its consumer today.
+    #[cfg(test)]
+    pub(crate) fn icon_placeholders(&self) -> impl Iterator<Item = (&'static str, &IconChoices)> {
+        self.icons.iter().map(|(p, c)| (*p, c))
+    }
+
+    /// Every static `^icon_name` this output's format can render: both the
+    /// full and short templates, and every alternative branch within them.
+    ///
+    /// These are the other half of the icon surface. `net` and `speedtest`
+    /// spell their arrows and their ping icon straight into the format
+    /// rather than passing icon values, so they declare no icon placeholder
+    /// for them, and an inspector that only walked [`Self::icon_placeholders`]
+    /// would conclude the block draws no icons at all.
+    #[cfg(test)]
+    pub(crate) fn static_icons(&self) -> Vec<&str> {
+        use crate::formatting::template::{FormatTemplate, Token};
+
+        fn walk<'a>(template: &'a FormatTemplate, found: &mut Vec<&'a str>) {
+            for list in template.0.iter() {
+                for token in &list.0 {
+                    match token {
+                        Token::Icon { name } => {
+                            if !found.contains(&name.as_str()) {
+                                found.push(name);
+                            }
+                        }
+                        Token::Recursive(inner) => walk(inner, found),
+                        Token::Text(_) | Token::Placeholder { .. } => (),
+                    }
+                }
+            }
+        }
+        let mut found = Vec::new();
+        walk(&self.format.full, &mut found);
+        walk(&self.format.short, &mut found);
+        found
+    }
+}
+
+/// One [`OutputPlan`] per format the user configured, so a block that can
+/// rotate through several formats declares each of them. `declare` adds the
+/// icon choices, which are the same whichever format is on screen.
+///
+/// Use this when the block's config has a `MaybeMultiFormatConfig`: the
+/// number of outputs is not known until the config is parsed. A block with a
+/// single `format` has one output and builds it inline instead (see
+/// `docker`). This returns a `Vec` rather than a finished plan because a
+/// block can append outputs that are not format variants (see `net`).
+pub(crate) fn format_outputs(
+    formats: Vec<Format>,
+    declare: impl Fn(OutputPlan) -> OutputPlan,
+) -> Vec<OutputPlan> {
+    formats
+        .into_iter()
+        .enumerate()
+        .map(|(index, format)| declare(OutputPlan::new(format_id(index), format)))
+        .collect()
+}
+
+/// The output id of the `index`th configured format.
+pub(crate) fn format_id(index: usize) -> Cow<'static, str> {
+    match index {
+        0 => "format".into(),
+        n => format!("format{}", n + 1).into(),
+    }
+}
+
+/// Rotating over the outputs [`format_outputs`] produced, mirroring the
+/// bar's own next/prev format actions.
+pub(crate) struct FormatRotation {
+    outputs: Vec<OutputHandle>,
+    index: usize,
+}
+
+impl FormatRotation {
+    /// Collects the plan's format outputs. A block may declare further
+    /// outputs for states that are not format variants (net's `inactive`
+    /// and `missing`); those are left alone.
+    pub(crate) fn new(plan: &Arc<BlockPlan>) -> Result<Self> {
+        let outputs: Vec<OutputHandle> = (0..)
+            .map_while(|index| plan.output(&format_id(index)).ok())
+            .collect();
+        if outputs.is_empty() {
+            return Err(Error::new(format!(
+                "{CONTRACT_BUG}: no format outputs to rotate over"
+            )));
+        }
+        Ok(Self { outputs, index: 0 })
+    }
+
+    pub(crate) fn current(&self) -> &OutputHandle {
+        &self.outputs[self.index]
+    }
+
+    pub(crate) fn next(&mut self) {
+        self.index = (self.index + 1) % self.outputs.len();
+    }
+
+    pub(crate) fn prev(&mut self) {
+        self.index = (self.index + self.outputs.len() - 1) % self.outputs.len();
+    }
+}
+
+/// The full prepared contract of one block instance. The validated fields
+/// are immutable from outside this module (read-only iteration only), so
+/// construction-time uniqueness is a permanent invariant.
+/// Deliberately not `Default`: an empty plan is exactly what [`Self::new`]
+/// rejects, and a derived `Default` would hand every block a way around it.
+#[derive(Debug, Clone)]
+pub(crate) struct BlockPlan {
+    outputs: Vec<OutputPlan>,
+}
+
+impl BlockPlan {
+    /// Read-only view of the declared output variants.
+    pub(crate) fn outputs(&self) -> impl Iterator<Item = &OutputPlan> {
+        self.outputs.iter()
+    }
+
+    /// Build a plan, rejecting ambiguous or incomplete metadata
+    /// unconditionally (also in release builds): a plan that declares nothing,
+    /// duplicate output ids, duplicate icon-placeholder declarations within an
+    /// output, and icons on a text output are all contract bugs.
+    pub(crate) fn new(outputs: Vec<OutputPlan>) -> Result<Arc<Self>> {
+        // A block that declares no outputs would render whatever it liked
+        // with nothing to check it against, which is the one hole the
+        // contract exists to close.
+        if outputs.is_empty() {
+            return Err(Error::new(format!(
+                "{CONTRACT_BUG}: the plan declares no outputs"
+            )));
+        }
+        for (i, output) in outputs.iter().enumerate() {
+            if output.kind == OutputKind::Text && !output.icons.is_empty() {
+                return Err(Error::new(format!(
+                    "{CONTRACT_BUG}: text output '{}' declares icons, which it \
+                     cannot render",
+                    output.id
+                )));
+            }
+            if outputs[..i].iter().any(|o| o.id == output.id) {
+                return Err(Error::new(format!(
+                    "{CONTRACT_BUG}: duplicate output id '{}'",
+                    output.id
+                )));
+            }
+            for (j, (placeholder, _)) in output.icons.iter().enumerate() {
+                if output.icons[..j].iter().any(|(p, _)| p == placeholder) {
+                    return Err(Error::new(format!(
+                        "{CONTRACT_BUG}: output '{}' declares '${placeholder}' twice",
+                        output.id
+                    )));
+                }
+            }
+        }
+        Ok(Arc::new(Self { outputs }))
+    }
+
+    /// Handle for the output variant named `id`.
+    pub(crate) fn output(self: &Arc<Self>, id: &str) -> Result<OutputHandle> {
+        let index = self
+            .outputs
+            .iter()
+            .position(|o| o.id == id)
+            .or_error(|| format!("{CONTRACT_BUG}: the plan has no output variant '{id}'"))?;
+        Ok(OutputHandle {
+            plan: self.clone(),
+            index,
+        })
+    }
+}
+
+/// A handle to one declared output variant. Constructing a widget through the
+/// handle installs the plan's effective format, so runtime code cannot select
+/// a format the plan does not know about.
+#[derive(Debug, Clone)]
+pub(crate) struct OutputHandle {
+    plan: Arc<BlockPlan>,
+    index: usize,
+}
+
+impl OutputHandle {
+    pub(crate) fn output(&self) -> &OutputPlan {
+        &self.plan.outputs[self.index]
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        self.output().id()
+    }
+
+    pub(crate) fn format(&self) -> &Format {
+        self.output().format()
+    }
+
+    /// The one icon name this output declares for `placeholder`. Lets runtime
+    /// code take the name from the plan instead of repeating the string.
+    pub(crate) fn single_icon(&self, placeholder: &str) -> Result<Cow<'static, str>> {
+        match self.output().choices_for(placeholder) {
+            Some(IconChoices::Fixed(names)) if names.len() == 1 => Ok(names[0].clone()),
+            _ => Err(Error::new(format!(
+                "{CONTRACT_BUG}: output '{}' does not declare exactly one icon \
+                 for '${placeholder}'",
+                self.id()
+            ))),
+        }
+    }
+
+    /// The single declared icon of `placeholder`, as a value.
+    pub(crate) fn icon_value(&self, placeholder: &str) -> Result<Value> {
+        let name = self.single_icon(placeholder)?;
+        Ok(Value::icon(name))
+    }
+
+    /// A widget rendering this output: effective format installed, icon
+    /// values checked against the declared choices. Publishing it fails if
+    /// this output is a [`OutputKind::Text`] one.
+    pub(crate) fn new_widget(&self) -> Widget {
+        Widget::from_output(self)
+    }
+
+    /// A widget rendering `text` as this output. Publishing it fails unless
+    /// the output was declared as [`OutputKind::Text`].
+    pub(crate) fn new_text_widget(&self, text: String) -> Widget {
+        Widget::text_from_output(self, text)
+    }
+
+    /// Descriptions of every icon value in `values` that this output does not
+    /// declare. Empty when the widget conforms to the contract.
+    pub(crate) fn icon_violations(&self, values: &crate::formatting::Values) -> Vec<String> {
+        let output = self.output();
+        let mut violations = Vec::new();
+        for (key, value) in values {
+            if let ValueInner::Icon(name, _) = &value.inner {
+                let ok = output
+                    .choices_for(key)
+                    .is_some_and(|choices| choices.permits(name));
+                if !ok {
+                    violations.push(format!(
+                        "{CONTRACT_BUG}: icon '{name}' set for placeholder '${key}' \
+                         is not declared by output '{}'",
+                        output.id
+                    ));
+                }
+            }
+        }
+        violations
+    }
+}
+
+/// The error outputs every block shares: the effective (global or per-block)
+/// error formats with the standard error placeholders, including the
+/// conditional `refresh` icon shown for restartable errors. The bar renders
+/// every block error through these handles.
+#[derive(Debug)]
+pub(crate) struct ErrorOutputs {
+    pub error: OutputHandle,
+    pub fullscreen: OutputHandle,
+}
+
+pub(crate) fn error_outputs(
+    error_format: Format,
+    error_fullscreen_format: Format,
+    restartable_possible: bool,
+) -> ErrorOutputs {
+    let plan = error_plan(error_format, error_fullscreen_format, restartable_possible)
+        .expect("the error plan has statically unique ids");
+    ErrorOutputs {
+        error: OutputHandle {
+            plan: plan.clone(),
+            index: 0,
+        },
+        fullscreen: OutputHandle { plan, index: 1 },
+    }
+}
+
+/// The plan behind [`error_outputs`]: output 0 is "error", output 1 is
+/// "error_fullscreen". The conditional `refresh` restart icon is only
+/// declared when the block can actually become restartable: without a
+/// `max_retries` limit the bar retries forever and never renders the
+/// restart button.
+pub(crate) fn error_plan(
+    error_format: Format,
+    error_fullscreen_format: Format,
+    restartable_possible: bool,
+) -> Result<Arc<BlockPlan>> {
+    let output = |id, format| {
+        let output = OutputPlan::new(id, format);
+        if restartable_possible {
+            output.icon("restart_block_icon", IconChoices::one(RESTART_ICON))
+        } else {
+            output
+        }
+    };
+    BlockPlan::new(vec![
+        output("error", error_format),
+        output("error_fullscreen", error_fullscreen_format),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formatting::config::Config as FormatConfig;
+
+    fn format(s: &str) -> Format {
+        FormatConfig::default().with_default(s).unwrap()
+    }
+
+    fn plan() -> Arc<BlockPlan> {
+        BlockPlan::new(vec![
+            OutputPlan::new("connected", format(" VPN: $icon "))
+                .icon("icon", IconChoices::one("net_vpn")),
+            OutputPlan::new("disconnected", format(" VPN: $icon "))
+                .icon("icon", IconChoices::fixed(["net_wired", "net_down"])),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn output_lookup() {
+        let plan = plan();
+        assert_eq!(plan.output("connected").unwrap().id(), "connected");
+        assert!(plan.output("bogus").is_err());
+    }
+
+    #[test]
+    fn fixed_choices_permit_only_declared_names() {
+        let plan = plan();
+        let disconnected = plan.output("disconnected").unwrap();
+        let choices = disconnected.output().choices_for("icon").unwrap();
+        assert!(choices.permits("net_wired"));
+        assert!(choices.permits("net_down"));
+        assert!(!choices.permits("net_vpn"));
+    }
+
+    #[test]
+    fn open_choices_permit_everything() {
+        assert!(IconChoices::OpenResolvable.permits("anything_at_all"));
+    }
+
+    #[test]
+    fn declared_icon_passes_validation() {
+        let plan = plan();
+        let handle = plan.output("connected").unwrap();
+        let values = map!("icon" => crate::formatting::value::Value::icon("net_vpn"));
+        assert!(handle.icon_violations(&values).is_empty());
+    }
+
+    #[test]
+    fn an_icon_built_outside_the_plan_is_still_caught() {
+        // The published Value::icon constructor is unchecked by design;
+        // the contract is enforced when the widget is published, so a
+        // block that bypasses its handle does not get away with it.
+        let plan = plan();
+        let handle = plan.output("connected").unwrap();
+        let mut widget = handle.new_widget();
+        widget.set_values(map!("icon" => crate::formatting::value::Value::icon("net_wired")));
+        assert!(widget.check_contract().is_err());
+    }
+
+    #[test]
+    fn undeclared_icon_is_a_violation() {
+        let plan = plan();
+        let handle = plan.output("connected").unwrap();
+        let values = map!("icon" => crate::formatting::value::Value::icon("net_wired"));
+        let violations = handle.icon_violations(&values);
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].contains("net_wired"));
+        assert!(violations[0].contains("'connected'"));
+    }
+
+    #[test]
+    fn undeclared_placeholder_is_a_violation() {
+        let plan = plan();
+        let handle = plan.output("connected").unwrap();
+        let values = map!("other" => crate::formatting::value::Value::icon("net_vpn"));
+        assert_eq!(handle.icon_violations(&values).len(), 1);
+    }
+
+    #[test]
+    fn non_icon_values_are_ignored() {
+        let plan = plan();
+        let handle = plan.output("connected").unwrap();
+        let values = map!("country" => crate::formatting::value::Value::text("ES".into()));
+        assert!(handle.icon_violations(&values).is_empty());
+    }
+
+    #[test]
+    fn error_outputs_declare_the_refresh_icon() {
+        let outputs = error_outputs(
+            format(" {$restart_block_icon |}{$short_error_message|X} "),
+            format(" $full_error_message "),
+            true,
+        );
+        assert_eq!(outputs.error.id(), "error");
+        assert_eq!(outputs.fullscreen.id(), "error_fullscreen");
+        assert_eq!(
+            outputs.error.single_icon("restart_block_icon").unwrap(),
+            "refresh"
+        );
+        let values = map!(
+            "restart_block_icon" => crate::formatting::value::Value::icon("refresh"),
+            "full_error_message" => crate::formatting::value::Value::text("boom".into()),
+        );
+        assert!(outputs.error.icon_violations(&values).is_empty());
+        assert!(outputs.fullscreen.icon_violations(&values).is_empty());
+    }
+
+    #[test]
+    fn duplicate_output_ids_are_rejected_unconditionally() {
+        let result = BlockPlan::new(vec![
+            OutputPlan::new("main", format(" a ")),
+            OutputPlan::new("main", format(" b ")),
+        ]);
+        assert!(result.unwrap_err().to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn duplicate_icon_declarations_are_rejected_unconditionally() {
+        let result = BlockPlan::new(vec![
+            OutputPlan::new("main", format(" $icon "))
+                .icon("icon", IconChoices::one("a"))
+                .icon("icon", IconChoices::one("b")),
+        ]);
+        assert!(result.unwrap_err().to_string().contains("twice"));
+    }
+
+    #[test]
+    fn raw_format_replacement_invalidates_the_contract() {
+        let plan = plan();
+        let handle = plan.output("connected").unwrap();
+        let mut widget = handle.new_widget();
+        assert!(widget.check_contract().is_ok());
+        // A raw set_format bypasses the plan: the contract is void and
+        // publishing the widget must fail.
+        widget.set_format(format(" ^icon_arbitrary "));
+        assert!(widget.contract().is_none());
+        assert!(widget.check_contract().is_err());
+    }
+
+    #[test]
+    fn widget_from_handle_carries_contract() {
+        let plan = plan();
+        let handle = plan.output("connected").unwrap();
+        let widget = handle.new_widget();
+        assert_eq!(widget.contract().unwrap().id(), "connected");
+    }
+
+    #[test]
+    fn a_plan_that_declares_nothing_is_rejected() {
+        // `BlockPlan::new` is the only way to build a plan. A `Default` impl
+        // (derived or written) would be a second, unchecked constructor
+        // producing exactly the empty plan this rejects, so assert at compile
+        // time that there is none: the two implementations below overlap if,
+        // and only if, `BlockPlan: Default`.
+        trait OnlyBuiltByNew {}
+        impl<T: Default> OnlyBuiltByNew for T {}
+        impl OnlyBuiltByNew for BlockPlan {}
+        fn only_built_by_new<T: OnlyBuiltByNew>() {}
+        only_built_by_new::<BlockPlan>();
+
+        // Otherwise a block could satisfy the framework with an empty plan
+        // and then render whatever it liked.
+        let err = BlockPlan::new(Vec::new()).unwrap_err().to_string();
+        assert!(err.contains(CONTRACT_BUG), "{err}");
+        assert!(err.contains("no outputs"), "{err}");
+    }
+
+    #[test]
+    fn a_text_output_cannot_declare_icons() {
+        let err = BlockPlan::new(vec![
+            OutputPlan::text("main").icon("icon", IconChoices::one("a")),
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains(CONTRACT_BUG), "{err}");
+    }
+
+    #[test]
+    fn text_output_widgets_carry_the_contract() {
+        let plan = BlockPlan::new(vec![OutputPlan::text("main")]).unwrap();
+        let handle = plan.output("main").unwrap();
+        assert_eq!(handle.output().kind(), OutputKind::Text);
+        let widget = handle.new_text_widget("whatever the block computed".into());
+        assert_eq!(widget.contract().unwrap().id(), "main");
+        widget.check_contract().unwrap();
+    }
+
+    #[test]
+    fn raw_text_replacement_invalidates_the_contract() {
+        let plan = BlockPlan::new(vec![OutputPlan::text("main")]).unwrap();
+        let handle = plan.output("main").unwrap();
+        let mut widget = handle.new_text_widget("declared".into());
+        // The same rule as `set_format`: text set outside the handle is not
+        // what the output promised.
+        widget.set_text("smuggled in".into());
+        assert!(widget.contract().is_none());
+        let err = widget.check_contract().unwrap_err().to_string();
+        assert!(err.contains(CONTRACT_BUG), "{err}");
+    }
+
+    #[test]
+    fn a_widget_must_render_the_kind_its_output_declared() {
+        // Text handle, format widget.
+        let text_plan = BlockPlan::new(vec![OutputPlan::text("main")]).unwrap();
+        let err = text_plan
+            .output("main")
+            .unwrap()
+            .new_widget()
+            .check_contract()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains(CONTRACT_BUG), "{err}");
+
+        // Format handle, text widget.
+        let plan = plan();
+        let err = plan
+            .output("connected")
+            .unwrap()
+            .new_text_widget("plain".into())
+            .check_contract()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains(CONTRACT_BUG), "{err}");
+    }
+
+    #[test]
+    fn static_format_icons_are_enumerable() {
+        // `^icon_*` tokens are the other half of the icon surface: they never
+        // appear as declared placeholders, so a plan that could not report
+        // them would understate what the block draws.
+        let plan = BlockPlan::new(vec![OutputPlan::new(
+            "main",
+            FormatConfig::default()
+                .with_defaults(
+                    " ^icon_ping $ping {^icon_net_down $down|^icon_net_up} ",
+                    " ^icon_ping ",
+                )
+                .unwrap(),
+        )])
+        .unwrap();
+        let handle = plan.output("main").unwrap();
+        // Both templates, both branches of the alternative, no duplicates.
+        assert_eq!(
+            handle.output().static_icons(),
+            ["ping", "net_down", "net_up"]
+        );
+    }
+
+    #[test]
+    fn a_text_output_renders_no_static_icons() {
+        let plan = BlockPlan::new(vec![OutputPlan::text("main")]).unwrap();
+        assert!(
+            plan.output("main")
+                .unwrap()
+                .output()
+                .static_icons()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn a_contract_cannot_be_attached_to_a_format_the_output_never_declared() {
+        // There is no setter for the contract alone: the only ways to get one
+        // are the handle's constructors and `set_output`, all of which install
+        // the output's own format at the same time. Anything else voids it.
+        let plan = plan();
+        let handle = plan.output("connected").unwrap();
+
+        let mut widget = handle.new_widget();
+        widget.set_format(format(" a totally different format "));
+        assert!(widget.check_contract().is_err());
+
+        widget.set_output(&handle);
+        widget.check_contract().unwrap();
+    }
+
+    #[test]
+    fn an_empty_widget_needs_no_output() {
+        // A widget with no source renders nothing, so there is nothing to
+        // hold it to: the bar uses this to collapse a block.
+        Widget::new().check_contract().unwrap();
+    }
+
+    #[test]
+    fn drift_between_declaration_and_runtime_is_marked_as_a_contract_bug() {
+        let plan = plan();
+        // A missing output id and a placeholder that is not declared with
+        // exactly one icon are both programmer errors, not user ones.
+        for err in [
+            plan.output("never_declared").unwrap_err().to_string(),
+            plan.output("disconnected")
+                .unwrap()
+                .single_icon("icon")
+                .unwrap_err()
+                .to_string(),
+            plan.output("connected")
+                .unwrap()
+                .single_icon("never_declared")
+                .unwrap_err()
+                .to_string(),
+        ] {
+            assert!(err.contains(CONTRACT_BUG), "{err}");
+        }
+    }
+}

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -90,8 +90,23 @@ macro_rules! define_blocks {
                         $(#[cfg(feature = $feat)])?
                         #[allow(deprecated)]
                         Self::$block(config) => futures.push(async move {
+                            // The block's declared output contract, resolved
+                            // once and passed into run. Every block module
+                            // must define `prepare(config) ->
+                            // Result<Arc<BlockPlan>>`; a block without one
+                            // fails to compile here.
+                            let plan = match $block::prepare(&config) {
+                                Ok(plan) => plan,
+                                Err(err) => {
+                                    let _ = api.set_error(Error {
+                                        message: Some("Failed to prepare block".into()),
+                                        cause: Some(Arc::new(err)),
+                                    });
+                                    return;
+                                }
+                            };
                             let mut error_count: u8 = 0;
-                            while let Err(mut err) = $block::run(&config, &api).await {
+                            while let Err(mut err) = $block::run(&config, &api, &plan).await {
                                 let Ok(mut actions) = api.get_actions() else { return };
                                 if api.set_default_actions(&[
                                     (MouseButton::Left, Some(RESTART_BLOCK_BTN), "error_count_reset"),
@@ -242,6 +257,7 @@ pub struct CommonApi {
 impl CommonApi {
     /// Sends the widget to be displayed.
     pub fn set_widget(&self, widget: Widget) -> Result<()> {
+        widget.check_contract()?;
         self.request_sender
             .send(Request {
                 block_id: self.id,

--- a/src/blocks/amd_gpu.rs
+++ b/src/blocks/amd_gpu.rs
@@ -33,7 +33,7 @@
 //! ```
 //!
 //! # Icons Used
-//! - `gpu`
+//! - `gpu` (`$icon`)
 
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -42,6 +42,8 @@ use tokio::fs::read_dir;
 
 use super::prelude::*;
 use crate::util::read_file;
+
+const ICON: &str = "gpu";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(default)]
@@ -53,14 +55,22 @@ pub struct Config {
     pub interval: Seconds,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    // Every output renders the same value set, built unconditionally on
+    // every update.
+    let declare = |output: OutputPlan| output.icon("icon", IconChoices::one(ICON));
+    let formats = config.formats.with_default(" $icon $utilization ")?;
+    BlockPlan::new(format_outputs(formats, declare))
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "next_format"),
         (MouseButton::Right, None, "prev_format"),
     ])?;
 
-    let mut formats = config.formats.with_default(" $icon $utilization ")?;
+    let mut formats = FormatRotation::new(plan)?;
 
     let device = match &config.device {
         Some(name) => Device::new(name).await?,
@@ -71,12 +81,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     };
 
     loop {
-        let mut widget = Widget::new().with_format(formats.get_format());
+        let output = formats.current();
+        let mut widget = output.new_widget();
 
         let info = device.read_info().await?;
 
         widget.set_values(map! {
-            "icon" => Value::icon("gpu"),
+            "icon" => Value::icon(ICON),
             "utilization" => Value::percents(info.utilization_percents),
             "vram_total" => Value::bytes(info.vram_total_bytes),
             "vram_used" => Value::bytes(info.vram_used_bytes),
@@ -98,11 +109,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
                     "next_format" | "toggle_format" => {
-                        formats.next_format();
+                        formats.next();
                         break;
                     }
                     "prev_format" => {
-                        formats.prev_format();
+                        formats.prev();
                         break;
                     }
                     _ => (),
@@ -192,5 +203,27 @@ mod tests {
     async fn test_non_existing_gpu_device() {
         let device = Device::new("/nope").await;
         assert!(device.is_err());
+    }
+
+    #[test]
+    fn plan_declares_single_format_with_gpu_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let format = plan.output("format").unwrap();
+        assert_eq!(format.single_icon("icon").unwrap(), "gpu");
+        assert!(format.format().contains_key("utilization"));
+        assert!(plan.output("format2").is_err());
+    }
+
+    #[test]
+    fn every_configured_format_is_declared() {
+        let config: Config =
+            toml::from_str(r#"format = [" $icon $utilization ", " $icon $vram_used_percents "]"#)
+                .unwrap();
+        let plan = prepare(&config).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "format2"]);
+        let second = plan.output("format2").unwrap();
+        assert!(second.format().contains_key("vram_used_percents"));
+        assert_eq!(second.single_icon("icon").unwrap(), "gpu");
     }
 }

--- a/src/blocks/backlight.rs
+++ b/src/blocks/backlight.rs
@@ -76,7 +76,7 @@
 //! also need to restart for this rule to take effect.
 //!
 //! # Icons Used
-//! - `backlight` (as a progression)
+//! - `backlight` (`$icon`, as a progression)
 
 use std::sync::Arc;
 
@@ -104,7 +104,21 @@ pub struct Config {
     pub ddcci_max_tries_write_read: Option<u8>,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new("main", config.format.with_default(" $icon $brightness ")?)
+            .icon("icon", IconChoices::one("backlight")),
+        // The "missing" output sets no values at all.
+        OutputPlan::new(
+            "missing",
+            config
+                .missing_format
+                .with_default(" no backlight devices ")?,
+        ),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "cycle"),
@@ -112,10 +126,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         (MouseButton::WheelDown, None, "brightness_down"),
     ])?;
 
-    let format = config.format.with_default(" $icon $brightness ")?;
-    let missing_format = config
-        .missing_format
-        .with_default(" no backlight devices ")?;
+    let output_main = plan.output("main")?;
+    let output_missing = plan.output("missing")?;
 
     let default_cycle = &[config.minimum, config.maximum];
     let mut cycle = config
@@ -168,9 +180,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     loop {
         match block_error {
             Some(CalibrightError::NoDevices) => {
-                let widget = Widget::new()
-                    .with_format(missing_format.clone())
-                    .with_state(State::Critical);
+                let widget = output_missing.new_widget().with_state(State::Critical);
                 api.set_widget(widget)?;
             }
             Some(e) => {
@@ -180,7 +190,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 })?;
             }
             None => {
-                let mut widget = Widget::new().with_format(format.clone());
+                let mut widget = output_main.new_widget();
                 let mut icon_value = brightness;
                 if config.invert_icons {
                     icon_value = 1.0 - icon_value;
@@ -237,5 +247,31 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_and_missing() {
+        let plan = prepare(&Config::default()).unwrap();
+        let main = plan.output("main").unwrap();
+        assert_eq!(main.single_icon("icon").unwrap(), "backlight");
+        assert!(main.format().contains_key("brightness"));
+        let missing = plan.output("missing").unwrap();
+        assert_eq!(missing.output().icon_placeholders().count(), 0);
+    }
+
+    #[test]
+    fn custom_missing_format_is_used() {
+        let config = Config {
+            missing_format: " $brightness ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let missing = plan.output("missing").unwrap();
+        assert!(missing.format().contains_key("brightness"));
     }
 }

--- a/src/blocks/battery.rs
+++ b/src/blocks/battery.rs
@@ -61,15 +61,19 @@
 //! ```
 //!
 //! # Icons Used
-//! - `bat` (as a progression)
-//! - `bat_charging` (as a progression)
-//! - `bat_not_available`
+//! - `bat` (`$icon`, in `format` `full_format` `empty_format` `not_charging_format`, as a progression)
+//! - `bat_charging` (`$icon`, in `charging_format`, as a progression)
+//! - `bat_not_available` (`$icon`, in `missing_format`)
 
 use regex::Regex;
 use std::convert::Infallible;
 use std::str::FromStr;
 
 use super::prelude::*;
+
+const ICON: &str = "bat";
+const CHARGING_ICON: &str = "bat_charging";
+const MISSING_ICON: &str = "bat_not_available";
 
 mod apc_ups;
 mod sysfs;
@@ -114,13 +118,36 @@ pub enum BatteryDriver {
     Upower,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
     let format = config.format.with_default(" $icon $percentage ")?;
-    let format_full = config.full_format.with_default(" $icon ")?;
-    let charging_format = config.charging_format.with_default_format(&format);
-    let format_empty = config.empty_format.with_default(" $icon ")?;
-    let format_not_charging = config.not_charging_format.with_default(" $icon ")?;
-    let missing_format = config.missing_format.with_default(" $icon ")?;
+    BlockPlan::new(vec![
+        OutputPlan::new("discharging", format.clone()).icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new(
+            "charging",
+            config.charging_format.with_default_format(&format),
+        )
+        .icon("icon", IconChoices::one(CHARGING_ICON)),
+        OutputPlan::new("full", config.full_format.with_default(" $icon ")?)
+            .icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new("empty", config.empty_format.with_default(" $icon ")?)
+            .icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new(
+            "not_charging",
+            config.not_charging_format.with_default(" $icon ")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new("missing", config.missing_format.with_default(" $icon ")?)
+            .icon("icon", IconChoices::one(MISSING_ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_discharging = plan.output("discharging")?;
+    let output_charging = plan.output("charging")?;
+    let output_full = plan.output("full")?;
+    let output_empty = plan.output("empty")?;
+    let output_not_charging = plan.output("not_charging")?;
+    let output_missing = plan.output("missing")?;
 
     let dev_name = DeviceName::new(config.device.clone())?;
     let mut device: Box<dyn BatteryDevice + Send + Sync> = match config.driver {
@@ -150,15 +177,14 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
         match info {
             Some(info) => {
-                let mut widget = Widget::new();
-
-                widget.set_format(match info.status {
-                    BatteryStatus::Empty => format_empty.clone(),
-                    BatteryStatus::Full => format_full.clone(),
-                    BatteryStatus::Charging => charging_format.clone(),
-                    BatteryStatus::NotCharging => format_not_charging.clone(),
-                    _ => format.clone(),
-                });
+                let output = match info.status {
+                    BatteryStatus::Empty => &output_empty,
+                    BatteryStatus::Full => &output_full,
+                    BatteryStatus::Charging => &output_charging,
+                    BatteryStatus::NotCharging => &output_not_charging,
+                    _ => &output_discharging,
+                };
+                let mut widget = output.new_widget();
 
                 let mut values = map!(
                     "percentage" => Value::percents(info.capacity)
@@ -182,15 +208,15 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 });
 
                 let (icon_name, icon_value, state) = match (info.status, info.capacity) {
-                    (BatteryStatus::Empty, _) => ("bat", 0.0, State::Critical),
+                    (BatteryStatus::Empty, _) => (ICON, 0.0, State::Critical),
                     (BatteryStatus::Full | BatteryStatus::NotCharging, _) => {
-                        ("bat", 1.0, State::Idle)
+                        (ICON, 1.0, State::Idle)
                     }
                     (status, capacity) => (
                         if status == BatteryStatus::Charging {
-                            "bat_charging"
+                            CHARGING_ICON
                         } else {
-                            "bat"
+                            ICON
                         },
                         capacity / 100.0,
                         if status == BatteryStatus::Charging {
@@ -219,10 +245,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 api.set_widget(widget)?;
             }
             None => {
-                let mut widget = Widget::new()
-                    .with_format(missing_format.clone())
-                    .with_state(State::Critical);
-                widget.set_values(map!("icon" => Value::icon("bat_not_available")));
+                let mut widget = output_missing.new_widget().with_state(State::Critical);
+                widget.set_values(map!("icon" => Value::icon(MISSING_ICON)));
                 api.set_widget(widget)?;
             }
         }
@@ -305,5 +329,71 @@ impl FromStr for BatteryStatus {
             "Not charging" => Self::NotCharging,
             _ => Self::Unknown,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn charging_format_inherits_configured_format() {
+        // With no explicit charging_format, charging must render whatever
+        // `format` resolved to — including a format with no $icon.
+        let config = Config {
+            format: " $percentage ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        assert!(
+            !plan
+                .output("charging")
+                .unwrap()
+                .format()
+                .contains_key("icon")
+        );
+
+        let plan = prepare(&Config::default()).unwrap();
+        assert!(
+            plan.output("charging")
+                .unwrap()
+                .format()
+                .contains_key("icon")
+        );
+    }
+
+    #[test]
+    fn explicit_charging_format_wins_over_inheritance() {
+        let config = Config {
+            format: " $percentage ".parse().unwrap(),
+            charging_format: " $icon ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        assert!(
+            plan.output("charging")
+                .unwrap()
+                .format()
+                .contains_key("icon")
+        );
+    }
+
+    #[test]
+    fn icons_are_state_specific() {
+        let plan = prepare(&Config::default()).unwrap();
+        for (id, icon) in [
+            ("discharging", "bat"),
+            ("charging", "bat_charging"),
+            ("full", "bat"),
+            ("empty", "bat"),
+            ("not_charging", "bat"),
+            ("missing", "bat_not_available"),
+        ] {
+            assert_eq!(
+                plan.output(id).unwrap().single_icon("icon").unwrap(),
+                icon,
+                "{id}"
+            );
+        }
     }
 }

--- a/src/blocks/bluetooth.rs
+++ b/src/blocks/bluetooth.rs
@@ -51,16 +51,19 @@
 //! ```
 //!
 //! # Icons Used
-//! - `headphones` for bluetooth devices identifying as "audio-card", "audio-headset" or "audio-headphones"
-//! - `joystick` for bluetooth devices identifying as "input-gaming"
-//! - `keyboard` for bluetooth devices identifying as "input-keyboard"
-//! - `mouse` for bluetooth devices identifying as "input-mouse"
-//! - `bluetooth` for all other devices
+//! - `headphones` (`$icon`) for bluetooth devices identifying as "audio-card", "audio-headset" or "audio-headphones"
+//! - `joystick` (`$icon`) for bluetooth devices identifying as "input-gaming"
+//! - `keyboard` (`$icon`) for bluetooth devices identifying as "input-keyboard"
+//! - `mouse` (`$icon`) for bluetooth devices identifying as "input-mouse"
+//! - `bluetooth` (`$icon`) for all other devices, and when the device is unavailable
+//! - `bat` (`$battery_icon`, as a progression) for devices reporting a battery level
 
 use zbus::fdo::{DBusProxy, ObjectManagerProxy, PropertiesProxy};
 
 use super::prelude::*;
 use crate::wrappers::RangeMap;
+
+const GENERIC_ICON: &str = "bluetooth";
 
 make_log_macro!(debug, "bluetooth");
 
@@ -78,14 +81,44 @@ pub struct Config {
     pub battery_state: Option<RangeMap<u8, State>>,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let mut actions = api.get_actions()?;
-    api.set_default_actions(&[(MouseButton::Right, None, "toggle")])?;
+/// Every icon name [`device_icon`] can return. The device type is externally
+/// selected but finite, so the block plan declares the full set.
+const DEVICE_ICONS: [&str; 5] = ["headphones", "joystick", "keyboard", "mouse", GENERIC_ICON];
 
+fn device_icon(bluez_icon: Option<&str>) -> &'static str {
+    match bluez_icon {
+        Some("audio-card" | "audio-headset" | "audio-headphones") => "headphones",
+        Some("input-gaming") => "joystick",
+        Some("input-keyboard") => "keyboard",
+        Some("input-mouse") => "mouse",
+        _ => GENERIC_ICON,
+    }
+}
+
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
     let format = config.format.with_default(" $icon $name{ $percentage|} ")?;
     let disconnected_format = config
         .disconnected_format
         .with_default(" $icon{ $name|} ")?;
+    BlockPlan::new(vec![
+        OutputPlan::new("connected", format)
+            .icon("icon", IconChoices::fixed(DEVICE_ICONS))
+            .icon("battery_icon", IconChoices::one("bat")),
+        OutputPlan::new("disconnected", disconnected_format.clone())
+            .icon("icon", IconChoices::fixed(DEVICE_ICONS))
+            .icon("battery_icon", IconChoices::one("bat")),
+        OutputPlan::new("unavailable", disconnected_format)
+            .icon("icon", IconChoices::one(GENERIC_ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let mut actions = api.get_actions()?;
+    api.set_default_actions(&[(MouseButton::Right, None, "toggle")])?;
+
+    let output_connected = plan.output("connected")?;
+    let output_disconnected = plan.output("disconnected")?;
+    let output_unavailable = plan.output("unavailable")?;
 
     let mut monitor = DeviceMonitor::new(config.mac.clone(), config.adapter_mac.clone()).await?;
 
@@ -105,7 +138,12 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             Some(device) => {
                 debug!("Device available, info: {device:?}");
 
-                let mut widget = Widget::new();
+                let output = if device.connected {
+                    &output_connected
+                } else {
+                    &output_disconnected
+                };
+                let mut widget = output.new_widget();
 
                 let values = map! {
                     "icon" => Value::icon(device.icon),
@@ -117,13 +155,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 };
 
                 if device.connected {
-                    widget.set_format(format.clone());
                     widget.state = battery_states
                         .get(&device.battery_percentage.unwrap_or(100))
                         .copied()
                         .unwrap_or(State::Good);
                 } else {
-                    widget.set_format(disconnected_format.clone());
                     widget.state = State::Idle;
                 }
 
@@ -133,8 +169,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             // Unavailable
             None => {
                 debug!("Showing device as unavailable");
-                let mut widget = Widget::new().with_format(disconnected_format.clone());
-                widget.set_values(map!("icon" => Value::icon("bluetooth")));
+                let mut widget = output_unavailable.new_widget();
+                widget.set_values(map!("icon" => Value::icon(GENERIC_ICON)));
                 api.set_widget(widget)?;
             }
         }
@@ -304,13 +340,7 @@ impl DeviceMonitor {
         };
 
         //icon can be null, so ignore errors when fetching it
-        let icon: &str = match device.device.icon().await.ok().as_deref() {
-            Some("audio-card" | "audio-headset" | "audio-headphones") => "headphones",
-            Some("input-gaming") => "joystick",
-            Some("input-keyboard") => "keyboard",
-            Some("input-mouse") => "mouse",
-            _ => "bluetooth",
-        };
+        let icon: &str = device_icon(device.device.icon().await.ok().as_deref());
 
         Some(DeviceInfo {
             connected,
@@ -433,4 +463,79 @@ trait Device1 {
 trait Battery1 {
     #[zbus(property)]
     fn percentage(&self) -> zbus::Result<u8>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> Config {
+        Config {
+            mac: "00:00:00:00:00:00".into(),
+            adapter_mac: None,
+            format: Default::default(),
+            disconnected_format: Default::default(),
+            battery_state: None,
+        }
+    }
+
+    #[test]
+    fn plan_declares_every_state_with_its_icons() {
+        let plan = prepare(&config()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["connected", "disconnected", "unavailable"]);
+
+        // The device values (icon, battery_icon) are set regardless of the
+        // connection state, so both connected and disconnected declare them.
+        for id in ["connected", "disconnected"] {
+            let output = plan.output(id).unwrap();
+            let choices = output.output().choices_for("icon").unwrap();
+            for name in DEVICE_ICONS {
+                assert!(choices.permits(name), "{id} must permit {name}");
+            }
+            assert_eq!(output.single_icon("battery_icon").unwrap(), "bat");
+        }
+
+        let unavailable = plan.output("unavailable").unwrap();
+        assert_eq!(unavailable.single_icon("icon").unwrap(), "bluetooth");
+        assert!(
+            unavailable.output().choices_for("battery_icon").is_none(),
+            "battery values are never set when the device is unavailable"
+        );
+    }
+
+    #[test]
+    fn every_device_icon_is_declared() {
+        // Tie the runtime chooser to the declared set.
+        for input in [
+            Some("audio-card"),
+            Some("audio-headset"),
+            Some("audio-headphones"),
+            Some("input-gaming"),
+            Some("input-keyboard"),
+            Some("input-mouse"),
+            Some("something-else"),
+            None,
+        ] {
+            assert!(DEVICE_ICONS.contains(&device_icon(input)));
+        }
+    }
+
+    #[test]
+    fn unavailable_shares_the_disconnected_format() {
+        let config = Config {
+            disconnected_format: " off ".parse().unwrap(),
+            ..config()
+        };
+        let plan = prepare(&config).unwrap();
+        for id in ["disconnected", "unavailable"] {
+            assert!(!plan.output(id).unwrap().format().contains_key("icon"));
+        }
+        assert!(
+            plan.output("connected")
+                .unwrap()
+                .format()
+                .contains_key("icon")
+        );
+    }
 }

--- a/src/blocks/calendar.rs
+++ b/src/blocks/calendar.rs
@@ -165,7 +165,7 @@
 //! - `$end`: End time of the event
 //!
 //! # Icons Used
-//! - `calendar`
+//! - `calendar` (`$icon`)
 
 use chrono::{Duration, Local, Utc};
 use oauth2::{AuthUrl, ClientId, ClientSecret, Scope, TokenUrl};
@@ -186,6 +186,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use caldav::Client;
+
+const ICON: &str = "calendar";
 
 #[derive(Deserialize, Debug, SmartDefault, Clone)]
 #[serde(deny_unknown_fields, default)]
@@ -265,7 +267,7 @@ enum WidgetStatus {
     FetchSources,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
     let next_event_format = config
         .next_event_format
         .with_default(" $icon $start.datetime(f:'%a %H:%M') $summary ")?;
@@ -276,6 +278,19 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let redirect_format = config
         .redirect_format
         .with_default(" $icon Check your web browser ")?;
+    BlockPlan::new(vec![
+        OutputPlan::new("no_events", no_events_format).icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new("next_event", next_event_format).icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new("ongoing_event", ongoing_event_format).icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new("redirect", redirect_format).icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_no_events = plan.output("no_events")?;
+    let output_next_event = plan.output("next_event")?;
+    let output_ongoing_event = plan.output("ongoing_event")?;
+    let output_redirect = plan.output("redirect")?;
 
     api.set_default_actions(&[(MouseButton::Left, None, "open_link")])?;
 
@@ -311,10 +326,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut next_events = OverlappingEvents::default();
 
     loop {
-        let mut widget = Widget::new().with_format(no_events_format.clone());
-        widget.set_values(map! {
-            "icon" => Value::icon("calendar"),
-        });
+        let mut output = &output_no_events;
+        let mut values = map! {
+            "icon" => Value::icon(ICON),
+        };
 
         if matches!(widget_status, WidgetStatus::FetchSources) {
             for retries in 0..=1 {
@@ -332,8 +347,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                                 .error("Authorization failed")?;
                             match &authorization {
                                 Authorize::AskUser(AuthorizeUrl { url, .. }) if retries == 0 => {
-                                    widget.set_format(redirect_format.clone());
-                                    api.set_widget(widget.clone())?;
+                                    output = &output_redirect;
+                                    let mut widget = output.new_widget();
+                                    widget.set_values(values.clone());
+                                    api.set_widget(widget)?;
                                     open_browser(config, url).await?;
                                     source
                                         .client
@@ -359,30 +376,36 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             }
         }
 
+        let mut warning = false;
         if let Some(event) = next_events.current().cloned()
             && let Some(start_date) = event.start_at
             && let Some(end_date) = event.end_at
         {
             let warn_datetime = start_date - warning_threshold;
             if warn_datetime < Utc::now() && Utc::now() < start_date {
-                widget.state = State::Warning;
+                warning = true;
             }
-            if start_date < Utc::now() && Utc::now() < end_date {
-                widget.set_format(ongoing_event_format.clone());
+            output = if start_date < Utc::now() && Utc::now() < end_date {
+                &output_ongoing_event
             } else {
-                widget.set_format(next_event_format.clone());
-            }
-            widget.set_values(map! {
-                  "icon" => Value::icon("calendar"),
-                   [if let Some(summary) = event.summary] "summary" => Value::text(summary),
-                   [if let Some(description) = event.description] "description" => Value::text(description),
-                   [if let Some(location) = event.location] "location" => Value::text(location),
-                   [if let Some(url) = event.url] "url" => Value::text(url),
-                   "start" => Value::datetime(start_date, None),
-                   "end" => Value::datetime(end_date, None),
-                });
+                &output_next_event
+            };
+            values = map! {
+              "icon" => Value::icon(ICON),
+               [if let Some(summary) = event.summary] "summary" => Value::text(summary),
+               [if let Some(description) = event.description] "description" => Value::text(description),
+               [if let Some(location) = event.location] "location" => Value::text(location),
+               [if let Some(url) = event.url] "url" => Value::text(url),
+               "start" => Value::datetime(start_date, None),
+               "end" => Value::datetime(end_date, None),
+            };
         }
 
+        let mut widget = output.new_widget();
+        if warning {
+            widget.state = State::Warning;
+        }
+        widget.set_values(values);
         api.set_widget(widget)?;
         loop {
             select! {
@@ -613,4 +636,45 @@ pub enum CalendarError {
     StoreToken(#[from] TokenStoreError),
     #[error("local time falls in a _gap_ in the local time, or if there was an error")]
     TzConversion,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_every_state_with_the_calendar_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(
+            ids,
+            ["no_events", "next_event", "ongoing_event", "redirect"]
+        );
+        for id in ids {
+            let output = plan.output(id).unwrap();
+            assert_eq!(output.single_icon("icon").unwrap(), "calendar");
+        }
+    }
+
+    #[test]
+    fn each_state_resolves_its_own_format() {
+        let config = Config {
+            next_event_format: " $icon $summary ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        assert!(
+            plan.output("next_event")
+                .unwrap()
+                .format()
+                .contains_key("summary")
+        );
+        assert!(
+            !plan
+                .output("no_events")
+                .unwrap()
+                .format()
+                .contains_key("summary")
+        );
+    }
 }

--- a/src/blocks/cpu.rs
+++ b/src/blocks/cpu.rs
@@ -41,9 +41,9 @@
 //! ```
 //!
 //! # Icons Used
-//! - `cpu` (as a progression)
-//! - `cpu_boost_on`
-//! - `cpu_boost_off`
+//! - `cpu` (`$icon`, as a progression)
+//! - `cpu_boost_on` (`$boost`)
+//! - `cpu_boost_off` (`$boost`)
 
 use std::str::FromStr as _;
 
@@ -71,14 +71,39 @@ pub struct Config {
     pub critical_cpu: f64,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+/// Every icon name [`boost_icon`] can return. The boost status is externally
+/// selected but finite, so the block plan declares the full set.
+const BOOST_ICON_NAMES: [&str; 2] = ["cpu_boost_on", "cpu_boost_off"];
+
+fn boost_icon(on: bool) -> &'static str {
+    match on {
+        true => "cpu_boost_on",
+        false => "cpu_boost_off",
+    }
+}
+
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    // `icon`, `barchart` and `utilization` are computed on every update.
+    // `frequency`/`max_frequency` (CPU support), `boost` (sysfs support) and
+    // the per-core `utilizationN`/`frequencyN` values are conditional or
+    // dynamically named, so they stay undeclared.
+    let declare = |output: OutputPlan| {
+        output
+            .icon("icon", IconChoices::one("cpu"))
+            .icon("boost", IconChoices::fixed(BOOST_ICON_NAMES))
+    };
+    let formats = config.formats.with_default(" $icon $utilization ")?;
+    BlockPlan::new(format_outputs(formats, declare))
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "next_format"),
         (MouseButton::Right, None, "prev_format"),
     ])?;
 
-    let mut formats = config.formats.with_default(" $icon $utilization ")?;
+    let mut formats = FormatRotation::new(plan)?;
 
     // Store previous /proc/stat state
     let mut cputime = read_proc_stat().await?;
@@ -113,10 +138,9 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         }
 
         // Read boost state on intel CPUs
-        let boost = boost_status().await.map(|status| match status {
-            true => "cpu_boost_on",
-            false => "cpu_boost_off",
-        });
+        let boost = boost_status().await.map(boost_icon);
+
+        let output = formats.current();
 
         let mut values = map!(
             "icon" => Value::icon_progression("cpu", utilization_avg),
@@ -125,7 +149,9 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             [if !freqs.is_empty()] "frequency" => Value::hertz(freqs.iter().sum::<f64>() / (freqs.len() as f64)),
             [if !freqs.is_empty()] "max_frequency" => Value::hertz(freqs.iter().copied().max_by(f64::total_cmp).unwrap()),
         );
-        boost.map(|b| values.insert("boost".into(), Value::icon(b)));
+        if let Some(boost) = boost {
+            values.insert("boost".into(), Value::icon(boost));
+        }
         for (i, freq) in freqs.iter().enumerate() {
             values.insert(format!("frequency{}", i + 1).into(), Value::hertz(*freq));
         }
@@ -136,7 +162,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             );
         }
 
-        let mut widget = Widget::new().with_format(formats.get_format());
+        let mut widget = output.new_widget();
         widget.set_values(values);
         widget.state = match utilization_avg * 100. {
             x if x > config.critical_cpu => State::Critical,
@@ -152,11 +178,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
                     "next_format" | "toggle_format" => {
-                        formats.next_format();
+                        formats.next();
                         break;
                     }
                     "prev_format" => {
-                        formats.prev_format();
+                        formats.prev();
                         break;
                     }
                     _ => (),
@@ -265,5 +291,69 @@ async fn boost_status() -> Option<bool> {
         Some(no_turbo.starts_with('0'))
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_icon_and_boost_choices() {
+        let plan = prepare(&Config::default()).unwrap();
+        let format = plan.output("format").unwrap();
+        assert_eq!(format.single_icon("icon").unwrap(), "cpu");
+        let boost = format.output().choices_for("boost").unwrap();
+        assert!(boost.permits("cpu_boost_on"));
+        assert!(boost.permits("cpu_boost_off"));
+        assert!(!boost.permits("cpu"));
+        // One format configured, so there is nothing to rotate to.
+        assert!(plan.output("format2").is_err());
+    }
+
+    #[test]
+    fn every_configured_format_becomes_an_output() {
+        let config: Config =
+            toml::from_str(r#"format = [" $icon ", " $icon $frequency "]"#).unwrap();
+        let plan = prepare(&config).unwrap();
+        let second = plan.output("format2").unwrap();
+        assert!(second.format().contains_key("frequency"));
+        // Every format the user can rotate to carries the same contract.
+        assert_eq!(second.single_icon("icon").unwrap(), "cpu");
+        assert!(
+            second
+                .output()
+                .choices_for("boost")
+                .unwrap()
+                .permits("cpu_boost_off")
+        );
+    }
+
+    #[test]
+    fn every_boost_icon_is_declared() {
+        for on in [true, false] {
+            assert!(BOOST_ICON_NAMES.contains(&boost_icon(on)));
+        }
+        assert_eq!(BOOST_ICON_NAMES.len(), 2);
+    }
+
+    #[test]
+    fn legacy_format_alt_still_declares_both_formats() {
+        // Upstream kept `format` + `format_alt` working alongside the new
+        // list form, so both spellings must yield two outputs.
+        let split: Config =
+            toml::from_str("format = \" $icon \"\nformat_alt = \" $icon $frequency \"").unwrap();
+        let list: Config = toml::from_str(r#"format = [" $icon ", " $icon $frequency "]"#).unwrap();
+        for config in [split, list] {
+            let plan = prepare(&config).unwrap();
+            let ids: Vec<_> = plan.outputs().map(|o| o.id().to_string()).collect();
+            assert_eq!(ids, ["format", "format2"]);
+            assert!(
+                plan.output("format2")
+                    .unwrap()
+                    .format()
+                    .contains_key("frequency")
+            );
+        }
     }
 }

--- a/src/blocks/custom.rs
+++ b/src/blocks/custom.rs
@@ -95,8 +95,6 @@
 //! # TODO:
 //! - Use `shellexpand`
 
-use crate::formatting::Format;
-
 use super::prelude::*;
 use inotify::{Inotify, WatchMask};
 use std::process::Stdio;
@@ -118,14 +116,31 @@ pub struct Config {
     pub watch_files: Vec<ShellString>,
 }
 
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let mut output = OutputPlan::new(
+        "main",
+        config.format.with_defaults(
+            "{ $icon|} $text.pango-str() ",
+            "{ $icon|} $short_text.pango-str() |",
+        )?,
+    );
+    // Only JSON output can carry an icon name; a plain-text command never
+    // sets one. When it can, any name is permitted and resolves through the
+    // normal icon set and override rules.
+    if config.json {
+        output = output.icon("icon", IconChoices::OpenResolvable);
+    }
+    BlockPlan::new(vec![output])
+}
+
 async fn update_bar(
     stdout: &str,
     hide_when_empty: bool,
     json: bool,
     api: &CommonApi,
-    format: Format,
+    output: &OutputHandle,
 ) -> Result<()> {
-    let mut widget = Widget::new().with_format(format);
+    let mut widget = output.new_widget();
 
     let text_empty;
 
@@ -154,13 +169,10 @@ async fn update_bar(
     }
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     api.set_default_actions(&[(MouseButton::Left, None, "cycle")])?;
 
-    let format = config.format.with_defaults(
-        "{ $icon|} $text.pango-str() ",
-        "{ $icon|} $short_text.pango-str() |",
-    )?;
+    let output_main = plan.output("main")?;
 
     let mut timer = config.interval.timer();
 
@@ -232,7 +244,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 config.hide_when_empty,
                 config.json,
                 api,
-                format.clone(),
+                &output_main,
             )
             .await?;
         }
@@ -265,7 +277,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 config.hide_when_empty,
                 config.json,
                 api,
-                format.clone(),
+                &output_main,
             )
             .await?;
 
@@ -294,4 +306,27 @@ struct Input {
     state: State,
     text: String,
     short_text: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn icon_choices_are_open_only_with_json() {
+        // A plain-text command can never set an icon.
+        let plan = prepare(&Config::default()).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.output().choices_for("icon").is_none());
+
+        let config = Config {
+            json: true,
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        let choices = output.output().choices_for("icon").unwrap();
+        assert!(matches!(choices, IconChoices::OpenResolvable));
+        assert!(choices.permits("any_name_the_command_emits"));
+    }
 }

--- a/src/blocks/custom_dbus.rs
+++ b/src/blocks/custom_dbus.rs
@@ -121,11 +121,24 @@ impl Block {
     }
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let widget = Widget::new().with_format(config.format.with_defaults(
-        "{ $icon|}{ $text.pango-str()|} ",
-        "{ $icon|} $short_text.pango-str() | ",
-    )?);
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    // The icon name arrives over D-Bus at runtime, so any name is permitted;
+    // it resolves through the normal icon set and override rules.
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "main",
+            config.format.with_defaults(
+                "{ $icon|}{ $text.pango-str()|} ",
+                "{ $icon|} $short_text.pango-str() | ",
+            )?,
+        )
+        .icon("icon", IconChoices::OpenResolvable),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output = plan.output("main")?;
+    let widget = output.new_widget();
 
     let dbus_conn = DBUS_CONNECTION
         .get_or_init(dbus_conn)
@@ -160,4 +173,47 @@ async fn dbus_conn() -> Result<zbus::Connection> {
         .await
         .error("Failed to request DBus name")?;
     Ok(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(toml: &str) -> Config {
+        toml::from_str(toml).unwrap()
+    }
+
+    #[test]
+    fn plan_declares_an_open_icon_because_the_name_arrives_over_dbus() {
+        let plan = prepare(&config(r#"path = "/my_path""#)).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["main"]);
+
+        let output = plan.output("main").unwrap();
+        let choices = output.output().choices_for("icon").unwrap();
+        assert!(matches!(choices, IconChoices::OpenResolvable));
+        assert!(choices.permits("any_name_set_over_dbus"));
+        // Whatever name arrives over D-Bus passes the publish-time check,
+        // which is where the contract is enforced.
+        let mut widget = output.new_widget();
+        widget.set_values(map!("icon" => Value::icon("whatever_was_sent")));
+        widget.check_contract().unwrap();
+    }
+
+    #[test]
+    fn custom_format_is_respected() {
+        // The default short format also carries `$icon`, so both halves have
+        // to be overridden for the icon to be gone from the output.
+        let plan = prepare(&config(
+            r#"
+            path = "/my_path"
+            format = { full = " $text.pango-str() ", short = " $short_text.pango-str() " }
+            "#,
+        ))
+        .unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.format().contains_key("text"));
+        assert!(output.format().contains_key("short_text"));
+        assert!(!output.format().contains_key("icon"));
+    }
 }

--- a/src/blocks/disk_iostats.rs
+++ b/src/blocks/disk_iostats.rs
@@ -36,7 +36,7 @@
 //!
 //! # Icons Used
 //!
-//! - `disk_drive`
+//! - `disk_drive` (`$icon`)
 
 use super::prelude::*;
 use crate::util::read_file;
@@ -46,6 +46,8 @@ use std::path::Path;
 use std::time::Instant;
 use tokio::fs::read_dir;
 use tokio::fs::read_link;
+
+const ICON: &str = "disk_drive";
 
 /// Path for block devices
 const BLOCK_DEVICES_PATH: &str = "/sys/class/block";
@@ -60,11 +62,23 @@ pub struct Config {
     pub missing_format: FormatConfig,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config
-        .format
-        .with_default(" $icon $speed_read.eng(prefix:K) $speed_write.eng(prefix:K) ")?;
-    let missing_format = config.missing_format.with_default(" × ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "main",
+            config
+                .format
+                .with_default(" $icon $speed_read.eng(prefix:K) $speed_write.eng(prefix:K) ")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+        // The "missing" output sets no values at all.
+        OutputPlan::new("missing", config.missing_format.with_default(" × ")?),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
+    let output_missing = plan.output("missing")?;
 
     let mut timer = config.interval.timer();
     let mut old_stats = None;
@@ -77,12 +91,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         }
         match device {
             None => {
-                api.set_widget(Widget::new().with_format(missing_format.clone()))?;
+                api.set_widget(output_missing.new_widget())?;
             }
             Some(mut device) => {
-                let mut widget = Widget::new();
-
-                widget.set_format(format.clone());
+                let mut widget = output_main.new_widget();
 
                 if let Ok(link) = read_link(Path::new("/dev/").join(&device)).await
                     && let Some(name) = link.file_name()
@@ -108,7 +120,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 old_stats = Some(new_stats);
 
                 widget.set_values(map! {
-                    "icon" => Value::icon("disk_drive"),
+                    "icon" => Value::icon(ICON),
                     "speed_read" => Value::bytes(speed_read),
                     "speed_write" => Value::bytes(speed_write),
                     "device" => Value::text(device),
@@ -216,5 +228,32 @@ async fn read_sector_size(device: &str) -> Result<u64> {
         Err(Error::new(
             "Failed to find device for partition HW sector size",
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_and_missing() {
+        let plan = prepare(&Config::default()).unwrap();
+        let main = plan.output("main").unwrap();
+        assert_eq!(main.single_icon("icon").unwrap(), "disk_drive");
+        assert!(main.format().contains_key("speed_read"));
+        assert!(main.format().contains_key("speed_write"));
+        let missing = plan.output("missing").unwrap();
+        assert_eq!(missing.output().icon_placeholders().count(), 0);
+    }
+
+    #[test]
+    fn custom_missing_format_is_used() {
+        let config = Config {
+            missing_format: " $device gone ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let missing = plan.output("missing").unwrap();
+        assert!(missing.format().contains_key("device"));
     }
 }

--- a/src/blocks/disk_space.rs
+++ b/src/blocks/disk_space.rs
@@ -61,7 +61,7 @@
 //! ```
 //!
 //! # Icons Used
-//! - `disk_drive`
+//! - `disk_drive` (`$icon`)
 
 // make_log_macro!(debug, "disk_space");
 
@@ -71,6 +71,8 @@ use super::prelude::*;
 use crate::formatting::prefix::Prefix;
 use nix::sys::statvfs::statvfs;
 use tokio::process::Command;
+
+const ICON: &str = "disk_drive";
 
 #[derive(Copy, Clone, Debug, Deserialize, SmartDefault)]
 #[serde(rename_all = "lowercase")]
@@ -107,14 +109,22 @@ pub struct Config {
     pub alert: f64,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    // Every output renders the same value set, built unconditionally on
+    // every update.
+    let declare = |output: OutputPlan| output.icon("icon", IconChoices::one(ICON));
+    let formats = config.formats.with_default(" $icon $available ")?;
+    BlockPlan::new(format_outputs(formats, declare))
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "next_format"),
         (MouseButton::Right, None, "prev_format"),
     ])?;
 
-    let mut formats = config.formats.with_default(" $icon $available ")?;
+    let mut formats = FormatRotation::new(plan)?;
 
     let unit = match config.alert_unit.as_deref() {
         // Decimal
@@ -139,7 +149,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut timer = config.interval.timer();
 
     loop {
-        let mut widget = Widget::new().with_format(formats.get_format());
+        let output = formats.current();
+        let mut widget = output.new_widget();
 
         let (total, used, available, free) = match config.backend {
             Backend::Vfs => get_vfs(&*path)?,
@@ -154,7 +165,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
         let percentage = result / (total as f64) * 100.;
         widget.set_values(map! {
-            "icon" => Value::icon("disk_drive"),
+            "icon" => Value::icon(ICON),
             "path" => Value::text(path.to_string()),
             "percentage" => Value::percents(percentage),
             "total" => Value::bytes(total as f64),
@@ -199,11 +210,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
                     "next_format" | "toggle_format" => {
-                        formats.next_format();
+                        formats.next();
                         break;
                     }
                     "prev_format" => {
-                        formats.prev_format();
+                        formats.prev();
                         break;
                     }
                     _ => (),
@@ -296,5 +307,32 @@ async fn get_btrfs(path: &str) -> Result<(u64, u64, u64, u64)> {
             *final_free.get().ok_or(Error::new(OUTPUT_CHANGED))?,
             *final_free.get().ok_or(Error::new(OUTPUT_CHANGED))?,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_single_format_with_disk_drive_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let format = plan.output("format").unwrap();
+        assert_eq!(format.single_icon("icon").unwrap(), "disk_drive");
+        assert!(format.format().contains_key("available"));
+        assert!(plan.output("format2").is_err());
+    }
+
+    #[test]
+    fn every_configured_format_is_declared() {
+        let config: Config =
+            toml::from_str(r#"format = [" $icon $available ", " $icon $available / $total "]"#)
+                .unwrap();
+        let plan = prepare(&config).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "format2"]);
+        let second = plan.output("format2").unwrap();
+        assert!(second.format().contains_key("total"));
+        assert_eq!(second.single_icon("icon").unwrap(), "disk_drive");
     }
 }

--- a/src/blocks/docker.rs
+++ b/src/blocks/docker.rs
@@ -28,9 +28,11 @@
 //!
 //! # Icons Used
 //!
-//! - `docker`
+//! - `docker` (`$icon`)
 
 use super::prelude::*;
+
+const ICON: &str = "docker";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -42,8 +44,18 @@ pub struct Config {
     pub socket_path: ShellString,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config.format.with_default(" $icon $running.eng(w:1) ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "main",
+            config.format.with_default(" $icon $running.eng(w:1) ")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
     let socket_path = config.socket_path.expand()?;
 
     let client = reqwest::Client::builder()
@@ -61,9 +73,9 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             .await
             .error("Failed to deserialize JSON")?;
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
         widget.set_values(map! {
-            "icon" => Value::icon("docker"),
+            "icon" => Value::icon(ICON),
             "total" =>   Value::number(status.total),
             "running" => Value::number(status.running),
             "paused" =>  Value::number(status.paused),
@@ -91,4 +103,30 @@ struct Status {
     paused: i64,
     #[serde(rename = "Images")]
     images: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_output_with_docker_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(declared, ["main"]);
+        let output = plan.output("main").unwrap();
+        assert_eq!(output.single_icon("icon").unwrap(), "docker");
+    }
+
+    #[test]
+    fn custom_format_is_respected() {
+        let config = Config {
+            format: " $running ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.format().contains_key("running"));
+        assert!(!output.format().contains_key("icon"));
+    }
 }

--- a/src/blocks/external_ip.rs
+++ b/src/blocks/external_ip.rs
@@ -102,8 +102,20 @@ pub struct Config {
     pub use_ipv4: bool,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config.format.with_default(" $ip $country_flag ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    // Only the required `IPAddressInfo` fields are set on every render.
+    // Everything else (version, region, country_*, in_eu, ...) is optional
+    // in the geolocator response and inserted conditionally, so it stays
+    // undeclared.
+    BlockPlan::new(vec![OutputPlan::new(
+        "main",
+        config.format.with_default(" $ip $country_flag ")?,
+    )])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
+    let format = output_main.format();
 
     type UpdatesStream = Pin<Box<dyn Stream<Item = ()>>>;
     let mut stream: UpdatesStream = if config.with_network_manager {
@@ -251,7 +263,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             )));
         }
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
         widget.set_values(values);
         api.set_widget(widget)?;
 
@@ -271,5 +283,32 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 debug!("signals settled after {:?}", settle_start.elapsed());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_single_output_without_icons() {
+        let plan = prepare(&Config::default()).unwrap();
+        assert_eq!(plan.outputs().count(), 1);
+        let main = plan.output("main").unwrap();
+        assert!(main.format().contains_key("ip"));
+        assert!(main.format().contains_key("country_flag"));
+        assert_eq!(main.output().icon_placeholders().count(), 0);
+    }
+
+    #[test]
+    fn custom_format_is_used() {
+        let config = Config {
+            format: " $ip $country_code ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let main = plan.output("main").unwrap();
+        assert!(main.format().contains_key("country_code"));
+        assert!(!main.format().contains_key("country_flag"));
     }
 }

--- a/src/blocks/focused_window.rs
+++ b/src/blocks/focused_window.rs
@@ -59,8 +59,18 @@ pub enum Driver {
     WlrToplevelManagement,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config.format.with_default(" $title.str(max_w:21) |")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    // No value guarantees: `title`, `marks` and `visible_marks` are only set
+    // when the focused window has a non-empty title, so every value is
+    // conditional.
+    BlockPlan::new(vec![OutputPlan::new(
+        "main",
+        config.format.with_default(" $title.str(max_w:21) |")?,
+    )])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
 
     let mut backend: Box<dyn Backend> = match config.driver {
         Driver::Auto => match SwayIpc::new().await {
@@ -74,7 +84,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     loop {
         let Info { title, marks } = backend.get_info().await?;
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
 
         if !title.is_empty() {
             let join_marks = |mut s: String, m: &String| {
@@ -108,4 +118,30 @@ trait Backend {
 struct Info {
     title: String,
     marks: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_single_output_without_icons() {
+        let plan = prepare(&Config::default()).unwrap();
+        assert_eq!(plan.outputs().count(), 1);
+        let main = plan.output("main").unwrap();
+        assert!(main.format().contains_key("title"));
+        assert_eq!(main.output().icon_placeholders().count(), 0);
+    }
+
+    #[test]
+    fn custom_format_is_used() {
+        let config = Config {
+            format: " $visible_marks ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let main = plan.output("main").unwrap();
+        assert!(main.format().contains_key("visible_marks"));
+        assert!(!main.format().contains_key("title"));
+    }
 }

--- a/src/blocks/github.rs
+++ b/src/blocks/github.rs
@@ -56,9 +56,11 @@
 //! ```
 //!
 //! # Icons Used
-//! - `github`
+//! - `github` (`$icon`)
 
 use super::prelude::*;
+
+const ICON: &str = "github";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -74,8 +76,35 @@ pub struct Config {
     pub critical: Option<Vec<String>>,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config.format.with_default(" $icon $total.eng(w:1) ")?;
+/// Stat placeholders [`get_stats`] inserts on every fetch (defaulting to
+/// zero), and which the plan therefore guarantees on every render.
+const STAT_KEYS: [&str; 13] = [
+    "total",
+    "assign",
+    "author",
+    "comment",
+    "ci_activity",
+    "invitation",
+    "manual",
+    "mention",
+    "review_requested",
+    "security_alert",
+    "state_change",
+    "subscribed",
+    "team_mention",
+];
+
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let main = OutputPlan::new(
+        "main",
+        config.format.with_default(" $icon $total.eng(w:1) ")?,
+    )
+    .icon("icon", IconChoices::one(ICON));
+    BlockPlan::new(vec![main])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
 
     let mut interval = config.interval.timer();
     let token = config
@@ -88,7 +117,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         let stats = get_stats(&token).await?;
 
         if stats.get("total").is_some_and(|x| *x > 0) || !config.hide_if_total_is_zero {
-            let mut widget = Widget::new().with_format(format.clone());
+            let mut widget = output_main.new_widget();
 
             'outer: for (list_opt, ret) in [
                 (&config.critical, State::Critical),
@@ -110,7 +139,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 .into_iter()
                 .map(|(k, v)| (k.into(), Value::number(v)))
                 .collect();
-            values.insert("icon".into(), Value::icon("github"));
+            values.insert("icon".into(), Value::icon(ICON));
             widget.set_values(values);
 
             api.set_widget(widget)?;
@@ -145,19 +174,11 @@ async fn get_stats(token: &str) -> Result<HashMap<String, usize>> {
         }
     }
     stats.insert("total".into(), total);
-    stats.entry("total".into()).or_insert(0);
-    stats.entry("assign".into()).or_insert(0);
-    stats.entry("author".into()).or_insert(0);
-    stats.entry("comment".into()).or_insert(0);
-    stats.entry("ci_activity".into()).or_insert(0);
-    stats.entry("invitation".into()).or_insert(0);
-    stats.entry("manual".into()).or_insert(0);
-    stats.entry("mention".into()).or_insert(0);
-    stats.entry("review_requested".into()).or_insert(0);
-    stats.entry("security_alert".into()).or_insert(0);
-    stats.entry("state_change".into()).or_insert(0);
-    stats.entry("subscribed".into()).or_insert(0);
-    stats.entry("team_mention".into()).or_insert(0);
+    // Default every declared stat to zero so the plan's value guarantees
+    // hold on every render.
+    for key in STAT_KEYS {
+        stats.entry(key.into()).or_insert(0);
+    }
     Ok(stats)
 }
 
@@ -186,5 +207,31 @@ async fn get_on_page(token: &str, page: usize) -> Result<Vec<Notification>> {
     match response {
         Response::Notifications(n) => Ok(n),
         Response::ErrorMessage { message } => Err(Error::new(format!("API error: {message}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_with_github_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        assert_eq!(plan.outputs().count(), 1);
+        let main = plan.output("main").unwrap();
+        assert_eq!(main.single_icon("icon").unwrap(), "github");
+        assert!(main.format().contains_key("total"));
+    }
+
+    #[test]
+    fn custom_format_is_used() {
+        let config = Config {
+            format: " $icon $mention.eng(w:1) ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let main = plan.output("main").unwrap();
+        assert!(main.format().contains_key("mention"));
+        assert!(!main.format().contains_key("total"));
     }
 }

--- a/src/blocks/hueshift.rs
+++ b/src/blocks/hueshift.rs
@@ -61,6 +61,8 @@ use crate::subprocess::{spawn_process, spawn_shell};
 use crate::util::has_command;
 use futures::future::pending;
 
+const ICON: &str = "hueshift";
+
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
@@ -82,7 +84,14 @@ pub struct Config {
     pub click_temp: u16,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let format = config.format.with_default(" $icon $temperature ")?;
+    BlockPlan::new(vec![
+        OutputPlan::new("main", format).icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "set_click_temp"),
@@ -91,7 +100,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         (MouseButton::WheelDown, None, "temperature_down"),
     ])?;
 
-    let format = config.format.with_default(" $icon $temperature ")?;
+    let output_main = plan.output("main")?;
 
     // limit too big steps at 500K to avoid too brutal changes
     let step = config.step.min(500);
@@ -134,9 +143,9 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut current_temp = driver.get().await?.unwrap_or(config.current_temp);
 
     loop {
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
         widget.set_values(map! {
-            "icon" => Value::icon("hueshift"),
+            "icon" => Value::icon(ICON),
             "temperature" => Value::number(current_temp)
         });
         api.set_widget(widget)?;
@@ -399,4 +408,31 @@ trait WlGammarelayRsBus {
     fn temperature(&self) -> zbus::Result<u16>;
     #[zbus(property)]
     fn set_temperature(&self, value: u16) -> zbus::Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_a_single_output_with_its_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["main"]);
+        let main = plan.output("main").unwrap();
+        assert_eq!(main.single_icon("icon").unwrap(), "hueshift");
+        assert!(main.format().contains_key("temperature"));
+    }
+
+    #[test]
+    fn configured_format_is_installed() {
+        let config = Config {
+            format: " $temperature ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let main = plan.output("main").unwrap();
+        assert!(!main.format().contains_key("icon"));
+        assert!(main.format().contains_key("temperature"));
+    }
 }

--- a/src/blocks/kdeconnect.rs
+++ b/src/blocks/kdeconnect.rs
@@ -42,12 +42,12 @@
 //! ```
 //!
 //! # Icons Used
-//! - `bat` (as a progression)
-//! - `bat_charging` (as a progression)
-//! - `net_cellular` (as a progression)
-//! - `notification`
-//! - `phone`
-//! - `phone_disconnected`
+//! - `bat` (`$bat_icon`, as a progression)
+//! - `bat_charging` (`$bat_icon`, as a progression)
+//! - `net_cellular` (`$network_icon`, as a progression)
+//! - `notification` (`$notif_icon`)
+//! - `phone` (`$icon`, in `format`)
+//! - `phone_disconnected` (`$icon`, in `disconnected_format` `missing_format`)
 
 use super::prelude::*;
 
@@ -55,6 +55,8 @@ mod battery;
 mod connectivity_report;
 use battery::BatteryDbusProxy;
 use connectivity_report::ConnectivityDbusProxy;
+
+const DISCONNECTED_ICON: &str = "phone_disconnected";
 
 make_log_macro!(debug, "kdeconnect");
 
@@ -75,12 +77,35 @@ pub struct Config {
     pub bat_critical: u8,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config
-        .format
-        .with_default(" $icon $name {$bat_icon $bat_charge |}{$notif_icon |}")?;
-    let disconnected_format = config.disconnected_format.with_default(" $icon ")?;
-    let missing_format = config.missing_format.with_default(" $icon x ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "connected",
+            config
+                .format
+                .with_default(" $icon $name {$bat_icon $bat_charge |}{$notif_icon |}")?,
+        )
+        .icon("icon", IconChoices::one("phone"))
+        .icon("bat_icon", IconChoices::fixed(["bat", "bat_charging"]))
+        .icon("network_icon", IconChoices::one("net_cellular"))
+        .icon("notif_icon", IconChoices::one("notification")),
+        OutputPlan::new(
+            "disconnected",
+            config.disconnected_format.with_default(" $icon ")?,
+        )
+        .icon("icon", IconChoices::one(DISCONNECTED_ICON))
+        .icon("bat_icon", IconChoices::fixed(["bat", "bat_charging"]))
+        .icon("network_icon", IconChoices::one("net_cellular"))
+        .icon("notif_icon", IconChoices::one("notification")),
+        OutputPlan::new("missing", config.missing_format.with_default(" $icon x ")?)
+            .icon("icon", IconChoices::one(DISCONNECTED_ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_connected = plan.output("connected")?;
+    let output_disconnected = plan.output("disconnected")?;
+    let output_missing = plan.output("missing")?;
 
     let battery_state = (
         config.bat_good,
@@ -94,16 +119,15 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     loop {
         match monitor.get_device_info().await {
             Some(info) => {
-                let mut widget = Widget::new();
-                if info.connected {
-                    widget.set_format(format.clone());
+                let output = if info.connected {
+                    &output_connected
                 } else {
-                    widget.set_format(disconnected_format.clone());
-                }
+                    &output_disconnected
+                };
+                let mut widget = output.new_widget();
 
                 let mut values = map! {
-                    [if info.connected] "icon" => Value::icon("phone"),
-                    [if !info.connected] "icon" => Value::icon("phone_disconnected"),
+                    "icon" => output.icon_value("icon")?,
                     [if let Some(name) = info.name] "name" => Value::text(name),
                     [if info.notifications > 0] "notif_count" => Value::number(info.notifications),
                     [if info.notifications > 0] "notif_icon" => Value::icon("notification"),
@@ -171,8 +195,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 api.set_widget(widget)?;
             }
             None => {
-                let mut widget = Widget::new().with_format(missing_format.clone());
-                widget.set_values(map! { "icon" => Value::icon("phone_disconnected") });
+                let mut widget = output_missing.new_widget();
+                widget.set_values(map! { "icon" => Value::icon(DISCONNECTED_ICON) });
                 api.set_widget(widget)?;
             }
         }
@@ -487,4 +511,36 @@ trait NotificationsDbus {
 
     #[zbus(signal, name = "notificationRemoved")]
     fn notification_removed(&self, id: &str) -> zbus::Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_connection_states_and_icons() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["connected", "disconnected", "missing"]);
+
+        let connected = plan.output("connected").unwrap();
+        assert_eq!(connected.single_icon("icon").unwrap(), "phone");
+        let bat = connected.output().choices_for("bat_icon").unwrap();
+        assert!(bat.permits("bat") && bat.permits("bat_charging"));
+        assert!(!bat.permits("phone"));
+
+        for id in ["disconnected", "missing"] {
+            let output = plan.output(id).unwrap();
+            assert_eq!(output.single_icon("icon").unwrap(), "phone_disconnected");
+        }
+        // `missing` renders only `$icon`; the battery/network/notification
+        // values are never set in that state.
+        assert!(
+            plan.output("missing")
+                .unwrap()
+                .output()
+                .choices_for("bat_icon")
+                .is_none()
+        );
+    }
 }

--- a/src/blocks/keyboard_layout.rs
+++ b/src/blocks/keyboard_layout.rs
@@ -121,8 +121,15 @@ pub enum KeyboardLayoutDriver {
     Sway,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config.format.with_default(" $layout ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![OutputPlan::new(
+        "main",
+        config.format.with_default(" $layout ")?,
+    )])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
 
     let mut backend: Box<dyn Backend> = match config.driver {
         KeyboardLayoutDriver::LocaleBus => Box::new(LocaleBus::new().await?),
@@ -146,7 +153,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             layout.clone_from(mapped);
         }
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
         widget.set_values(map! {
             "layout" => Value::text(layout),
             "variant" => Value::text(variant),
@@ -183,5 +190,35 @@ impl Info {
                 variant: None,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_single_output_without_icons() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["main"]);
+        let main = plan.output("main").unwrap();
+        assert!(main.format().contains_key("layout"));
+        assert_eq!(main.output().icon_placeholders().count(), 0);
+    }
+
+    #[test]
+    fn plan_uses_configured_format() {
+        let config = Config {
+            format: " $layout ($variant) ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        assert!(
+            plan.output("main")
+                .unwrap()
+                .format()
+                .contains_key("variant")
+        );
     }
 }

--- a/src/blocks/load.rs
+++ b/src/blocks/load.rs
@@ -27,10 +27,12 @@
 //! ```
 //!
 //! # Icons Used
-//! - `cogs`
+//! - `cogs` (`$icon`)
 
 use super::prelude::*;
 use crate::util;
+
+const ICON: &str = "cogs";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -46,8 +48,15 @@ pub struct Config {
     pub critical: f64,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config.format.with_default(" $icon $1m.eng(w:4) ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new("main", config.format.with_default(" $icon $1m.eng(w:4) ")?)
+            .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
 
     // borrowed from https://docs.rs/cpuinfo/0.1.1/src/cpuinfo/count/logical.rs.html#4-6
     let logical_cores = util::read_file("/proc/cpuinfo")
@@ -75,7 +84,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             .and_then(|x| x.parse().ok())
             .error("bad /proc/loadavg file")?;
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
         widget.state = match m1 / logical_cores as f64 {
             x if x > config.critical => State::Critical,
             x if x > config.warning => State::Warning,
@@ -83,7 +92,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             _ => State::Idle,
         };
         widget.set_values(map! {
-            "icon" => Value::icon("cogs"),
+            "icon" => Value::icon(ICON),
             "1m" => Value::number(m1),
             "5m" => Value::number(m5),
             "15m" => Value::number(m15),
@@ -94,5 +103,31 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             _ = sleep(config.interval.0) => (),
             _ = api.wait_for_update_request() => (),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_output_with_cogs_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(declared, ["main"]);
+        let output = plan.output("main").unwrap();
+        assert_eq!(output.single_icon("icon").unwrap(), "cogs");
+    }
+
+    #[test]
+    fn custom_format_is_respected() {
+        let config = Config {
+            format: " $5m ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.format().contains_key("5m"));
+        assert!(!output.format().contains_key("icon"));
     }
 }

--- a/src/blocks/maildir.rs
+++ b/src/blocks/maildir.rs
@@ -34,11 +34,13 @@
 //! ```
 //!
 //! # Icons Used
-//! - `mail`
+//! - `mail` (`$icon`)
 
 use super::prelude::*;
 use maildir::Maildir;
 use std::path::PathBuf;
+
+const ICON: &str = "mail";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -61,8 +63,15 @@ fn expand_inbox(inbox: &str) -> Result<impl Iterator<Item = PathBuf>> {
     Ok(paths.filter_map(|p| p.ok()))
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config.format.with_default(" $icon $status ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new("main", config.format.with_default(" $icon $status ")?)
+            .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
 
     let mut inboxes = Vec::with_capacity(config.inboxes.len());
     for inbox in &config.inboxes {
@@ -80,7 +89,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             };
         }
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
         widget.state = if newmails >= config.threshold_critical {
             State::Critical
         } else if newmails >= config.threshold_warning {
@@ -89,7 +98,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             State::Idle
         };
         widget.set_values(map!(
-            "icon" => Value::icon("mail"),
+            "icon" => Value::icon(ICON),
             "status" => Value::number(newmails)
         ));
         api.set_widget(widget)?;
@@ -107,4 +116,30 @@ pub enum MailType {
     New,
     Cur,
     All,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_output_with_mail_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(declared, ["main"]);
+        let output = plan.output("main").unwrap();
+        assert_eq!(output.single_icon("icon").unwrap(), "mail");
+    }
+
+    #[test]
+    fn custom_format_is_respected() {
+        let config = Config {
+            format: " $status ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.format().contains_key("status"));
+        assert!(!output.format().contains_key("icon"));
+    }
 }

--- a/src/blocks/memory.rs
+++ b/src/blocks/memory.rs
@@ -68,8 +68,8 @@
 //! ```
 //!
 //! # Icons Used
-//! - `memory_mem`
-//! - `memory_swap`
+//! - `memory_mem` (`$icon`)
+//! - `memory_swap` (`$icon_swap`)
 
 use std::cmp::min;
 use std::str::FromStr as _;
@@ -78,6 +78,9 @@ use tokio::io::{AsyncBufReadExt as _, BufReader};
 
 use super::prelude::*;
 use crate::util::read_file;
+
+const ICON: &str = "memory_mem";
+const ICON_SWAP: &str = "memory_swap";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(default)]
@@ -96,16 +99,28 @@ pub struct Config {
     pub critical_swap: f64,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    // Both icons are available in every format, and every numeric value
+    // below is inserted on every render.
+    let icons = |output: OutputPlan| {
+        output
+            .icon("icon", IconChoices::one(ICON))
+            .icon("icon_swap", IconChoices::one(ICON_SWAP))
+    };
+    let formats = config.formats.with_default(
+        " $icon $mem_used.eng(prefix:Mi)/$mem_total.eng(prefix:Mi)($mem_used_percents.eng(w:2)) ",
+    )?;
+    BlockPlan::new(format_outputs(formats, icons))
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "next_format"),
         (MouseButton::Right, None, "prev_format"),
     ])?;
 
-    let mut formats = config.formats.with_default(
-        " $icon $mem_used.eng(prefix:Mi)/$mem_total.eng(prefix:Mi)($mem_used_percents.eng(w:2)) ",
-    )?;
+    let mut formats = FormatRotation::new(plan)?;
 
     let mut timer = config.interval.timer();
 
@@ -179,10 +194,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             0.0
         };
 
-        let mut widget = Widget::new().with_format(formats.get_format());
+        let output = formats.current();
+        let mut widget = output.new_widget();
         widget.set_values(map! {
-            "icon" => Value::icon("memory_mem"),
-            "icon_swap" => Value::icon("memory_swap"),
+            "icon" => Value::icon(ICON),
+            "icon_swap" => Value::icon(ICON_SWAP),
             "mem_total" => Value::bytes(mem_total),
             "mem_free" => Value::bytes(mem_free),
             "mem_free_percents" => Value::percents(mem_free / mem_total * 100.),
@@ -238,11 +254,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
                     "next_format" | "toggle_format" => {
-                        formats.next_format();
+                        formats.next();
                         break;
                     }
                     "prev_format" => {
-                        formats.prev_format();
+                        formats.prev();
                         break;
                     }
                     _ => (),
@@ -379,5 +395,37 @@ impl Memstate {
         }
 
         Ok(mem_state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_both_memory_icons() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format"]);
+        let format = plan.output("format").unwrap();
+        assert_eq!(format.single_icon("icon").unwrap(), "memory_mem");
+        assert_eq!(format.single_icon("icon_swap").unwrap(), "memory_swap");
+        assert!(format.format().contains_key("mem_used"));
+    }
+
+    #[test]
+    fn every_configured_format_declares_both_icons() {
+        let plan = prepare(&Config::default()).unwrap();
+        assert!(plan.output("format2").is_err());
+
+        let config: Config =
+            toml::from_str(r#"format = [" $icon $mem_used ", " $icon_swap $swap_used "]"#).unwrap();
+        let plan = prepare(&config).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "format2"]);
+        let second = plan.output("format2").unwrap();
+        assert!(second.format().contains_key("swap_used"));
+        assert_eq!(second.single_icon("icon").unwrap(), "memory_mem");
+        assert_eq!(second.single_icon("icon_swap").unwrap(), "memory_swap");
     }
 }

--- a/src/blocks/menu.rs
+++ b/src/blocks/menu.rs
@@ -55,6 +55,7 @@ pub struct Item {
 struct Block<'a> {
     actions: UnboundedReceiver<BlockAction>,
     api: &'a CommonApi,
+    output: OutputHandle,
     text: &'a str,
     items: &'a [Item],
 }
@@ -65,7 +66,7 @@ impl Block<'_> {
     }
 
     async fn set_text(&mut self, text: String) -> Result<()> {
-        self.api.set_widget(Widget::new().with_text(text))
+        self.api.set_widget(self.output.new_text_widget(text))
     }
 
     async fn wait_for_click(&mut self, button: &str) -> Result<()> {
@@ -94,7 +95,14 @@ impl Block<'_> {
     }
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(_config: &Config) -> Result<Arc<BlockPlan>> {
+    // The bar text is the configured label, a menu item's display string or a
+    // confirmation message — plain text with no placeholders and no icons, so
+    // the block declares a single text output rather than a format.
+    BlockPlan::new(vec![OutputPlan::text("main")])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     api.set_default_actions(&[
         (MouseButton::Left, None, "_left"),
         (MouseButton::Right, None, "_right"),
@@ -105,6 +113,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut block = Block {
         actions: api.get_actions()?,
         api,
+        output: plan.output("main")?,
         text: &config.text,
         items: &config.items,
     };
@@ -119,6 +128,44 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 continue;
             }
             spawn_shell(&res.cmd).or_error(|| format!("Failed to run '{}'", res.cmd))?;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::block_plan::OutputKind;
+
+    fn config() -> Config {
+        Config {
+            text: "menu".into(),
+            items: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn plan_declares_one_text_output_and_no_icons() {
+        let plan = prepare(&config()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["main"]);
+
+        let output = plan.output("main").unwrap();
+        assert_eq!(output.output().kind(), OutputKind::Text);
+        assert_eq!(output.output().icon_placeholders().count(), 0);
+    }
+
+    #[test]
+    fn every_text_this_block_renders_carries_the_contract() {
+        let plan = prepare(&config()).unwrap();
+        let output = plan.output("main").unwrap();
+        // The three strings the block can put on the bar: the label, a menu
+        // item's display string and a confirmation message.
+        for text in ["menu", "Shut down", "Are you sure?"] {
+            let widget = output.new_text_widget(text.into());
+            assert!(widget.contract().is_some(), "{text}");
+            widget.check_contract().unwrap();
         }
     }
 }

--- a/src/blocks/music.rs
+++ b/src/blocks/music.rs
@@ -133,12 +133,12 @@
 //! ```
 //!
 //! # Icons Used
-//! - `music`
-//! - `music_next`
-//! - `music_play`
-//! - `music_prev`
-//! - `volume_muted`
-//! - `volume` (as a progression)
+//! - `music` (`$icon`)
+//! - `music_next` (`$next`)
+//! - `music_pause` (`$play`)
+//! - `music_play` (`$play`)
+//! - `music_prev` (`$prev`)
+//! - `volume` (`$volume_icon`, as a progression)
 //!
 //! [MediaPlayer2 Interface]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html
 
@@ -150,6 +150,10 @@ use std::fmt;
 use zbus::fdo::{DBusProxy, NameOwnerChanged, PropertiesChanged};
 use zbus::names::{OwnedBusName, OwnedUniqueName};
 use zbus::{MatchRule, MessageStream};
+
+const ICON: &str = "music";
+const NEXT_ICON: &str = "music_next";
+const PREV_ICON: &str = "music_prev";
 
 mod zbus_mpris;
 mod zbus_playerctld;
@@ -186,7 +190,24 @@ pub enum PlayerName {
     Multiple(Vec<String>),
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let declare = |output: OutputPlan| {
+        output
+            .icon("icon", IconChoices::one(ICON))
+            .icon("play", IconChoices::fixed(["music_play", "music_pause"]))
+            .icon("next", IconChoices::one(NEXT_ICON))
+            .icon("prev", IconChoices::one(PREV_ICON))
+            .icon("volume_icon", IconChoices::one("volume"))
+        // `icon` is the only value set both with and without a player;
+        // everything else (buttons, player info, volume) is conditional.
+    };
+    let formats = config
+        .formats
+        .with_default(" $icon {$combo.str(max_w:25,rot_interval:0.5) $play |}")?;
+    BlockPlan::new(format_outputs(formats, declare))
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, Some(PLAY_PAUSE_BTN), "play_pause"),
@@ -200,9 +221,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
     let dbus_conn = new_dbus_connection().await?;
 
-    let mut formats = config
-        .formats
-        .with_default(" $icon {$combo.str(max_w:25,rot_interval:0.5) $play |}")?;
+    let mut formats = FormatRotation::new(plan)?;
 
     let volume_step = config.volume_step.clamp(0.0, 50.0) / 100.0;
 
@@ -216,16 +235,6 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         .unwrap_or(config.seek_step_secs)
         .0
         .as_micros() as i64);
-
-    let new_btn = |icon: &str, instance: &'static str| -> Result<Value> {
-        Ok(Value::icon(icon.to_string()).with_instance(instance))
-    };
-
-    let values = map! {
-        "icon" => Value::icon("music"),
-        "next" => new_btn("music_next", NEXT_BTN)?,
-        "prev" => new_btn("music_prev", PREV_BTN)?,
-    };
 
     let preferred_players = match config.player.clone() {
         PlayerName::Single(name) => vec![name],
@@ -305,10 +314,15 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         debug!("available players: {}", DisplaySlice(&players));
 
         let avail = players.len();
+        let output = formats.current();
         let player = cur_player.map(|c| players.get_mut(c).unwrap());
         match player {
             Some(player) => {
-                let mut values = values.clone();
+                let mut values = map! {
+                    "icon" => Value::icon(ICON),
+                    "next" => Value::icon(NEXT_ICON).with_instance(NEXT_BTN),
+                    "prev" => Value::icon(PREV_ICON).with_instance(PREV_BTN),
+                };
                 values.insert("avail".into(), Value::number(avail));
                 values.insert("cur".into(), Value::number(cur_player.unwrap() + 1));
                 values.insert(
@@ -323,7 +337,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     Some(PlaybackStatus::Playing) => (State::Info, "music_pause"),
                     _ => (State::Idle, "music_play"),
                 };
-                values.insert("play".into(), new_btn(play_icon, PLAY_PAUSE_BTN)?);
+                values.insert(
+                    "play".into(),
+                    Value::icon(play_icon).with_instance(PLAY_PAUSE_BTN),
+                );
                 if let Some(url) = &player.metadata.url {
                     values.insert("url".into(), Value::text(url.clone()));
                 }
@@ -360,14 +377,14 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     );
                     values.insert("volume".into(), Value::percents(volume * 100.0));
                 }
-                let mut widget = Widget::new().with_format(formats.get_format());
+                let mut widget = output.new_widget();
                 widget.set_values(values);
                 widget.state = state;
                 api.set_widget(widget)?;
             }
             None => {
-                let mut widget = Widget::new().with_format(formats.get_format());
-                widget.set_values(map!("icon" => Value::icon("music")));
+                let mut widget = output.new_widget();
+                widget.set_values(map!("icon" => Value::icon(ICON)));
                 api.set_widget(widget)?;
             }
         }
@@ -486,11 +503,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                                 player.set_volume(-volume_step).await?;
                             }
                             "next_format" | "toggle_format" => {
-                                formats.next_format();
+                                formats.next();
                                 break;
                             }
                             "prev_format" => {
-                                formats.prev_format();
+                                formats.prev();
                                 break;
                             }
                             _ => (),
@@ -697,5 +714,45 @@ mod tests {
             &[],
             &exclude
         ));
+    }
+
+    #[test]
+    fn plan_declares_every_icon_placeholder() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format"]);
+
+        let main = plan.output("format").unwrap();
+        assert_eq!(main.single_icon("icon").unwrap(), "music");
+        assert_eq!(main.single_icon("next").unwrap(), "music_next");
+        assert_eq!(main.single_icon("prev").unwrap(), "music_prev");
+        assert_eq!(main.single_icon("volume_icon").unwrap(), "volume");
+
+        // $play carries either button icon depending on playback status.
+        let play = main.output().choices_for("play").unwrap();
+        assert!(play.permits("music_play"));
+        assert!(play.permits("music_pause"));
+        assert!(!play.permits("music"));
+    }
+
+    #[test]
+    fn every_configured_format_becomes_an_output() {
+        let config: Config =
+            toml::from_str(r#"format = [" $icon $combo ", " $icon $player "]"#).unwrap();
+        let plan = prepare(&config).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "format2"]);
+
+        // Every format the user can rotate to carries the same icon set.
+        let second = plan.output("format2").unwrap();
+        assert!(second.format().contains_key("player"));
+        assert_eq!(second.single_icon("icon").unwrap(), "music");
+        assert!(
+            second
+                .output()
+                .choices_for("play")
+                .unwrap()
+                .permits("music_pause")
+        );
     }
 }

--- a/src/blocks/net.rs
+++ b/src/blocks/net.rs
@@ -53,12 +53,12 @@
 //! ```
 //!
 //! # Icons Used
-//! - `net_loopback`
-//! - `net_vpn`
-//! - `net_wired`
-//! - `net_wireless` (as a progression)
-//! - `net_up`
-//! - `net_down`
+//! - `net_loopback` (`$icon`)
+//! - `net_vpn` (`$icon`)
+//! - `net_wired` (`$icon`)
+//! - `net_wireless` (`$icon`, as a progression)
+//! - `net_up` (`^icon_net_up`)
+//! - `net_down` (`^icon_net_down`)
 
 use super::prelude::*;
 use crate::netlink::NetDevice;
@@ -79,18 +79,43 @@ pub struct Config {
     pub missing_format: FormatConfig,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    // Every state that renders a device sets these on every render; the
+    // wifi-only values (ssid, signal_strength, ...) and the addresses are
+    // conditional and stay undeclared.
+    let device_output =
+        |output: OutputPlan| output.icon("icon", IconChoices::fixed(NetDevice::ALL_ICONS));
+    let formats = config.formats.with_default(
+        " $icon ^icon_net_down $speed_down.eng(prefix:K) ^icon_net_up $speed_up.eng(prefix:K) ",
+    )?;
+    // One output per format the user can rotate to, plus the two states that
+    // are not format variants at all: an inactive interface and a missing
+    // device each have their own format and are selected by `run()`.
+    let mut outputs = format_outputs(formats, device_output);
+    outputs.push(device_output(OutputPlan::new(
+        "inactive",
+        config.inactive_format.with_default(" $icon Down ")?,
+    )));
+    // `missing` sets no values at all: nothing to declare.
+    outputs.push(OutputPlan::new(
+        "missing",
+        config.missing_format.with_default(" × ")?,
+    ));
+    BlockPlan::new(outputs)
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "next_format"),
         (MouseButton::Right, None, "prev_format"),
     ])?;
 
-    let mut formats = config.formats.with_default(
-        " $icon ^icon_net_down $speed_down.eng(prefix:K) ^icon_net_up $speed_up.eng(prefix:K) ",
-    )?;
-    let missing_format = config.missing_format.with_default(" × ")?;
-    let inactive_format = config.inactive_format.with_default(" $icon Down ")?;
+    // The plan also holds the `inactive` and `missing` states; the rotation
+    // covers the format outputs alone.
+    let mut formats = FormatRotation::new(plan)?;
+    let output_inactive = plan.output("inactive")?;
+    let output_missing = plan.output("missing")?;
 
     let mut timer = config.interval.timer();
 
@@ -110,16 +135,15 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     loop {
         match NetDevice::new(device_re.as_ref()).await? {
             None => {
-                api.set_widget(Widget::new().with_format(missing_format.clone()))?;
+                api.set_widget(output_missing.new_widget())?;
             }
             Some(device) => {
-                let mut widget = Widget::new();
-
-                if device.is_up() {
-                    widget.set_format(formats.get_format());
+                let output = if device.is_up() {
+                    formats.current()
                 } else {
-                    widget.set_format(inactive_format.clone());
-                }
+                    &output_inactive
+                };
+                let mut widget = output.new_widget();
 
                 let mut speed_down: f64 = 0.0;
                 let mut speed_up: f64 = 0.0;
@@ -181,11 +205,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
                     "next_format" | "toggle_format" => {
-                        formats.next_format();
+                        formats.next();
                         break;
                     }
                     "prev_format" => {
-                        formats.prev_format();
+                        formats.prev();
                         break;
                     }
                     _ => ()
@@ -202,7 +226,85 @@ fn push_to_hist<T>(hist: &mut [T], elem: T) {
 
 #[cfg(test)]
 mod tests {
-    use super::push_to_hist;
+    use super::*;
+
+    #[test]
+    fn plan_declares_device_icon_set_on_every_rendering_state() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "inactive", "missing"]);
+
+        for id in ["format", "inactive"] {
+            let output = plan.output(id).unwrap();
+            let choices = output.output().choices_for("icon").unwrap();
+            for icon in NetDevice::ALL_ICONS {
+                assert!(choices.permits(icon), "{id} must permit {icon}");
+            }
+            assert!(!choices.permits("net_up"));
+        }
+
+        // `missing` renders a bare format and sets no values at all.
+        let missing = plan.output("missing").unwrap();
+        assert_eq!(missing.output().icon_placeholders().count(), 0);
+    }
+
+    #[test]
+    fn every_configured_format_becomes_an_output() {
+        let plan = prepare(&Config::default()).unwrap();
+        assert!(plan.output("format2").is_err());
+
+        let config: Config = toml::from_str(r#"format = [" $icon ", " $icon $device "]"#).unwrap();
+        let plan = prepare(&config).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        // The extra states stay alongside the per-format outputs.
+        assert_eq!(ids, ["format", "format2", "inactive", "missing"]);
+
+        let second = plan.output("format2").unwrap();
+        assert!(second.format().contains_key("device"));
+        let choices = second.output().choices_for("icon").unwrap();
+        assert!(choices.permits("net_wireless"));
+    }
+
+    #[test]
+    fn the_arrows_in_the_default_format_are_part_of_the_icon_surface() {
+        // They are `^icon_*` tokens rather than icon values, so they are not
+        // declared placeholders — but the block still draws them.
+        let plan = prepare(&Config::default()).unwrap();
+        let format = plan.output("format").unwrap();
+        assert_eq!(
+            format.output().static_icons(),
+            ["net_down", "net_up"],
+            "the default format's arrows must be visible to an inspector"
+        );
+        // The states that render no format icons say so.
+        for id in ["inactive", "missing"] {
+            let output = plan.output(id).unwrap();
+            assert!(output.output().static_icons().is_empty(), "{id}");
+        }
+    }
+
+    #[test]
+    fn every_chooser_icon_is_declared() {
+        // Exercise every branch of the runtime icon chooser and check the
+        // result against the declared set, so the two cannot drift apart.
+        let mut seen = Vec::new();
+        for is_wireless in [false, true] {
+            for tun_wg_ppp in [false, true] {
+                for name in ["lo", "eth0", "tun0", "wlan0"] {
+                    let icon = NetDevice::icon_for(is_wireless, tun_wg_ppp, name);
+                    assert!(
+                        NetDevice::ALL_ICONS.contains(&icon),
+                        "chooser returned undeclared icon {icon}"
+                    );
+                    if !seen.contains(&icon) {
+                        seen.push(icon);
+                    }
+                }
+            }
+        }
+        // ...and every declared name is actually reachable.
+        assert_eq!(seen.len(), NetDevice::ALL_ICONS.len());
+    }
 
     #[test]
     fn test_push_to_hist() {

--- a/src/blocks/notify.rs
+++ b/src/blocks/notify.rs
@@ -55,8 +55,8 @@
 //! ```
 //!
 //! # Icons Used
-//! - `bell`
-//! - `bell-slash`
+//! - `bell` (`$icon`)
+//! - `bell-slash` (`$icon`)
 //!
 //! [^dunst_version_note]: when using `notification_count` with the `dunst` driver use dunst > 1.9.0
 //! [^history_count_note]: `history_count` is the same as `notification_count` in SwayNC
@@ -83,11 +83,22 @@ pub enum DriverType {
     SwayNC,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let format = config.format.with_default(" $icon ")?;
+    BlockPlan::new(vec![
+        OutputPlan::new("enabled", format.clone()).icon("icon", IconChoices::one(ICON_ON)),
+        // The paused output is only ever rendered when `is_paused` is true,
+        // so the `paused` flag is set on every render of this output.
+        OutputPlan::new("paused", format).icon("icon", IconChoices::one(ICON_OFF)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[(MouseButton::Left, None, "toggle_paused")])?;
 
-    let format = config.format.with_default(" $icon ")?;
+    let output_enabled = plan.output("enabled")?;
+    let output_paused = plan.output("paused")?;
 
     let mut driver: Box<dyn Driver> = match config.driver {
         DriverType::Dunst => Box::new(DunstDriver::new().await?),
@@ -101,9 +112,14 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             driver.history_count()
         )?;
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let output = if is_paused {
+            &output_paused
+        } else {
+            &output_enabled
+        };
+        let mut widget = output.new_widget();
         widget.set_values(map!(
-            "icon" => Value::icon(if is_paused { ICON_OFF } else { ICON_ON }),
+            "icon" => output.icon_value("icon")?,
             [if notification_count != 0] "notification_count" => Value::number(notification_count),
             [if history_count != 0] "history_count" => Value::number(history_count),
             [if is_paused] "paused" => Value::flag(),
@@ -341,4 +357,41 @@ trait SwayNCDbus {
         cc_open: bool,
         inhibited: bool,
     ) -> zbus::Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_both_states_with_their_icons() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["enabled", "paused"]);
+        assert_eq!(
+            plan.output("enabled").unwrap().single_icon("icon").unwrap(),
+            ICON_ON
+        );
+        assert_eq!(
+            plan.output("paused").unwrap().single_icon("icon").unwrap(),
+            ICON_OFF
+        );
+    }
+
+    #[test]
+    fn both_states_share_the_same_format() {
+        let config = Config {
+            format: " $icon $notification_count ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        for id in ["enabled", "paused"] {
+            assert!(
+                plan.output(id)
+                    .unwrap()
+                    .format()
+                    .contains_key("notification_count")
+            );
+        }
+    }
 }

--- a/src/blocks/notmuch.rs
+++ b/src/blocks/notmuch.rs
@@ -41,9 +41,11 @@
 //! ```
 //!
 //! # Icons Used
-//! - `mail`
+//! - `mail` (`$icon`)
 
 use super::prelude::*;
+
+const ICON: &str = "mail";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -64,8 +66,15 @@ pub struct Config {
     pub threshold_good: u32,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config.format.with_default(" $icon $count ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new("main", config.format.with_default(" $icon $count ")?)
+            .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
 
     let db = config.maildir.expand()?;
     let mut timer = config.interval.timer();
@@ -74,10 +83,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         // TODO: spawn_blocking?
         let count = run_query(&db, &config.query).error("Failed to get count")?;
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
 
         widget.set_values(map! {
-            "icon" => Value::icon("mail"),
+            "icon" => Value::icon(ICON),
             "count" => Value::number(count)
         });
 
@@ -111,4 +120,30 @@ fn run_query(db_path: &str, query_string: &str) -> std::result::Result<u32, notm
     )?;
     let query = db.create_query(query_string)?;
     query.count_messages()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_output_with_mail_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(declared, ["main"]);
+        let output = plan.output("main").unwrap();
+        assert_eq!(output.single_icon("icon").unwrap(), "mail");
+    }
+
+    #[test]
+    fn custom_format_is_respected() {
+        let config = Config {
+            format: " $count ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.format().contains_key("count"));
+        assert!(!output.format().contains_key("icon"));
+    }
 }

--- a/src/blocks/nvidia_gpu.rs
+++ b/src/blocks/nvidia_gpu.rs
@@ -55,7 +55,7 @@
 //! ```
 //!
 //! # Icons Used
-//! - `gpu`
+//! - `gpu` (`$icon`)
 //!
 //! # TODO
 //! - Provide a `mappings` option similar to `keyboard_layout`'s  to map GPU names to labels?
@@ -72,6 +72,8 @@ const QUERY: &str = "--query-gpu=name,memory.total,utilization.gpu,memory.used,t
 const FORMAT: &str = "--format=csv,noheader,nounits";
 
 use super::prelude::*;
+
+const ICON: &str = "gpu";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -91,7 +93,19 @@ pub struct Config {
     pub warning: u32,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "main",
+            config
+                .format
+                .with_default(" $icon $utilization $memory $temperature ")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, Some(MEM_BTN), "toggle_mem_total"),
@@ -100,9 +114,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         (MouseButton::WheelDown, Some(FAN_BTN), "fan_speed_down"),
     ])?;
 
-    let format = config
-        .format
-        .with_default(" $icon $utilization $memory $temperature ")?;
+    let output_main = plan.output("main")?;
 
     // Run `nvidia-smi` command
     let mut child = Command::new("nvidia-smi")
@@ -126,7 +138,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut fan_controlled = false;
 
     loop {
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
 
         widget.state = match info.temperature {
             t if t <= config.idle => State::Idle,
@@ -137,7 +149,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         };
 
         widget.set_values(map! {
-            "icon" => Value::icon("gpu"),
+            "icon" => Value::icon(ICON),
             "name" => Value::text(info.name.clone()),
             "utilization" => Value::percents(info.utilization),
             "memory" => Value::bytes(if show_mem_total {info.mem_total} else {info.mem_used}).with_instance(MEM_BTN),
@@ -261,5 +273,32 @@ async fn set_fan_speed(id: u64, speed: Option<u32>) -> Result<()> {
         Ok(())
     } else {
         Err(Error::new(ERR_MSG))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_single_output_with_gpu_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["main"]);
+        let main = plan.output("main").unwrap();
+        assert_eq!(main.single_icon("icon").unwrap(), "gpu");
+        assert!(main.format().contains_key("utilization"));
+    }
+
+    #[test]
+    fn plan_uses_configured_format() {
+        let config = Config {
+            format: " $icon $fan_speed ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let main = plan.output("main").unwrap();
+        assert!(main.format().contains_key("fan_speed"));
+        assert!(!main.format().contains_key("utilization"));
     }
 }

--- a/src/blocks/packages.rs
+++ b/src/blocks/packages.rs
@@ -296,7 +296,7 @@
 //!
 //! # Icons Used
 //!
-//! - `update`
+//! - `update` (`$icon`)
 
 pub mod apk;
 use apk::Apk;
@@ -328,6 +328,8 @@ use zypper::Zypper;
 use regex::Regex;
 
 use super::prelude::*;
+
+const ICON: &str = "update";
 
 #[derive(Deserialize, Debug, SmartDefault, Clone)]
 #[serde(deny_unknown_fields, default)]
@@ -396,16 +398,40 @@ impl PackageManager {
     }
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "main",
+            config.format.with_default(" $icon $total.eng(w:1) ")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new(
+            "singular",
+            config
+                .format_singular
+                .with_default(" $icon $total.eng(w:1) ")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new(
+            "up_to_date",
+            config
+                .format_up_to_date
+                .with_default(" $icon $total.eng(w:1) ")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
+    let output_singular = plan.output("singular")?;
+    let output_up_to_date = plan.output("up_to_date")?;
+
     let mut config: Config = config.clone();
 
-    let format = config.format.with_default(" $icon $total.eng(w:1) ")?;
-    let format_singular = config
-        .format_singular
-        .with_default(" $icon $total.eng(w:1) ")?;
-    let format_up_to_date = config
-        .format_up_to_date
-        .with_default(" $icon $total.eng(w:1) ")?;
+    let format = output_main.format();
+    let format_singular = output_singular.format();
+    let format_up_to_date = output_up_to_date.format();
 
     // Check if the user specified a package manager in any format string, then
     // add that package manager to the config list.
@@ -485,16 +511,14 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 .is_some_and(|regex| has_matching_update(&updates, regex));
         }
 
-        let mut widget = Widget::new();
-
-        package_manager_map.insert("icon".into(), Value::icon("update"));
+        let output = match total_count {
+            0 => &output_up_to_date,
+            1 => &output_singular,
+            _ => &output_main,
+        };
+        package_manager_map.insert("icon".into(), Value::icon(ICON));
         package_manager_map.insert("total".into(), Value::number(total_count));
-
-        widget.set_format(match total_count {
-            0 => format_up_to_date.clone(),
-            1 => format_singular.clone(),
-            _ => format.clone(),
-        });
+        let mut widget = output.new_widget();
         widget.set_values(package_manager_map);
 
         widget.state = match total_count {
@@ -527,4 +551,44 @@ pub trait Backend {
 
 pub fn has_matching_update(updates: &[String], regex: &Regex) -> bool {
     updates.iter().any(|line| regex.is_match(line))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_count_states_with_update_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["main", "singular", "up_to_date"]);
+        for id in ["main", "singular", "up_to_date"] {
+            let output = plan.output(id).unwrap();
+            assert_eq!(output.single_icon("icon").unwrap(), "update", "{id}");
+        }
+    }
+
+    #[test]
+    fn each_count_state_resolves_its_own_format() {
+        let config = Config {
+            format_singular: " one update ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        // The configured format applies only to the singular state...
+        assert!(
+            !plan
+                .output("singular")
+                .unwrap()
+                .format()
+                .contains_key("total")
+        );
+        // ...the other states keep the shared default.
+        for id in ["main", "up_to_date"] {
+            assert!(
+                plan.output(id).unwrap().format().contains_key("total"),
+                "{id}"
+            );
+        }
+    }
 }

--- a/src/blocks/pomodoro.rs
+++ b/src/blocks/pomodoro.rs
@@ -52,20 +52,17 @@
 //! ```
 //!
 //! # Icons Used
-//! - `pomodoro`
-//! - `pomodoro_started`
-//! - `pomodoro_stopped`
-//! - `pomodoro_paused`
-//! - `pomodoro_break`
+//! - `pomodoro` (`$icon`)
+//! - `pomodoro_started` (`$status_icon`, in `pomodoro_format`)
+//! - `pomodoro_stopped` (`$status_icon`, in `format`)
+//! - `pomodoro_paused` (`$status_icon`, in `pomodoro_format`)
+//! - `pomodoro_break` (`$status_icon`, in `break_format`)
 
 use num_traits::{Num, NumAssignOps, SaturatingSub};
 use tokio::sync::mpsc;
 
 use super::prelude::*;
-use crate::{
-    formatting::Format,
-    subprocess::{spawn_shell, spawn_shell_sync},
-};
+use crate::subprocess::{spawn_shell, spawn_shell_sync};
 use std::time::Instant;
 
 make_log_macro!(debug, "pomodoro");
@@ -117,39 +114,38 @@ impl PomodoroState {
 }
 
 struct Block<'a> {
-    widget: Widget,
     actions: mpsc::UnboundedReceiver<BlockAction>,
     api: &'a CommonApi,
     config: &'a Config,
     state: PomodoroState,
-    format: Format,
-    pomodoro_format: Format,
-    break_format: Format,
+    plan: Arc<BlockPlan>,
 }
 
 impl Block<'_> {
     async fn set_text(&mut self, additional_values: Values) -> Result<()> {
+        let output = self.plan.output(match self.state {
+            PomodoroState::Idle => "idle",
+            PomodoroState::Prompt => "prompt",
+            PomodoroState::Notify => "notify",
+            PomodoroState::Break => "break",
+            PomodoroState::PomodoroRunning => "running",
+            PomodoroState::PomodoroPaused => "paused",
+        })?;
         let mut values = map! {
-            "icon" => Value::icon("pomodoro"),
+            "icon" => output.icon_value("icon")?,
         };
         values.extend(additional_values);
 
-        if let Some(icon) = self.state.get_status_icon() {
-            values.insert("status_icon".into(), Value::icon(icon));
+        // Each state that shows a status icon declares exactly one for its
+        // output, so the name comes from the plan itself.
+        if self.state.get_status_icon().is_some() {
+            values.insert("status_icon".into(), output.icon_value("status_icon")?);
         }
-        self.widget.set_format(match self.state {
-            PomodoroState::Idle | PomodoroState::Prompt | PomodoroState::Notify => {
-                self.format.clone()
-            }
-            PomodoroState::Break => self.break_format.clone(),
-            PomodoroState::PomodoroRunning | PomodoroState::PomodoroPaused => {
-                self.pomodoro_format.clone()
-            }
-        });
-        self.widget.state = self.state.get_block_state();
+        let mut widget = output.new_widget();
+        widget.state = self.state.get_block_state();
         debug!("{:?}", values);
-        self.widget.set_values(values);
-        self.api.set_widget(self.widget.clone())
+        widget.set_values(values);
+        self.api.set_widget(widget)
     }
 
     async fn wait_for_click(&mut self, button: &str) -> Result<()> {
@@ -305,15 +301,7 @@ impl Block<'_> {
     }
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    api.set_default_actions(&[
-        (MouseButton::Left, None, "_left"),
-        (MouseButton::Middle, None, "_middle"),
-        (MouseButton::Right, None, "_right"),
-        (MouseButton::WheelUp, None, "_up"),
-        (MouseButton::WheelDown, None, "_down"),
-    ])?;
-
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
     let format = config.format.clone().with_default(" $icon{ $message|} ")?;
 
     let pomodoro_format = config.pomodoro_format.clone().with_default(
@@ -325,17 +313,41 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         .clone()
         .with_default(" $icon $status_icon Break: $time_remaining.duration(hms:true) ")?;
 
-    let widget = Widget::new();
+    let base = || IconChoices::one("pomodoro");
+    BlockPlan::new(vec![
+        OutputPlan::new("idle", format.clone())
+            .icon("icon", base())
+            .icon("status_icon", IconChoices::one("pomodoro_stopped")),
+        // Prompt and notify renders always carry the interactive message.
+        OutputPlan::new("prompt", format.clone()).icon("icon", base()),
+        OutputPlan::new("notify", format).icon("icon", base()),
+        OutputPlan::new("running", pomodoro_format.clone())
+            .icon("icon", base())
+            .icon("status_icon", IconChoices::one("pomodoro_started")),
+        OutputPlan::new("paused", pomodoro_format)
+            .icon("icon", base())
+            .icon("status_icon", IconChoices::one("pomodoro_paused")),
+        OutputPlan::new("break", break_format)
+            .icon("icon", base())
+            .icon("status_icon", IconChoices::one("pomodoro_break")),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    api.set_default_actions(&[
+        (MouseButton::Left, None, "_left"),
+        (MouseButton::Middle, None, "_middle"),
+        (MouseButton::Right, None, "_right"),
+        (MouseButton::WheelUp, None, "_up"),
+        (MouseButton::WheelDown, None, "_down"),
+    ])?;
 
     let mut block = Block {
-        widget,
         actions: api.get_actions()?,
         api,
         config,
         state: PomodoroState::Idle,
-        format,
-        pomodoro_format,
-        break_format,
+        plan: plan.clone(),
     };
 
     loop {
@@ -347,6 +359,81 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
         if let Some((task_len, break_len, pomodoros)) = block.read_params().await? {
             block.run_pomodoro(task_len, break_len, pomodoros).await?;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_scopes_status_icons_to_their_states() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(
+            ids,
+            ["idle", "prompt", "notify", "running", "paused", "break"]
+        );
+        for (id, status_icon) in [
+            ("idle", Some("pomodoro_stopped")),
+            ("prompt", None),
+            ("notify", None),
+            ("running", Some("pomodoro_started")),
+            ("paused", Some("pomodoro_paused")),
+            ("break", Some("pomodoro_break")),
+        ] {
+            let output = plan.output(id).unwrap();
+            assert_eq!(output.single_icon("icon").unwrap(), "pomodoro");
+            match status_icon {
+                Some(name) => assert_eq!(output.single_icon("status_icon").unwrap(), name),
+                None => assert!(
+                    output.output().choices_for("status_icon").is_none(),
+                    "{id} sets no status icon"
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn runtime_status_icon_chooser_matches_the_plan() {
+        // Ties `PomodoroState::get_status_icon` to the per-output
+        // declarations so neither can drift from the other.
+        let plan = prepare(&Config::default()).unwrap();
+        use PomodoroState::*;
+        for (state, id) in [
+            (Idle, "idle"),
+            (Prompt, "prompt"),
+            (Notify, "notify"),
+            (Break, "break"),
+            (PomodoroRunning, "running"),
+            (PomodoroPaused, "paused"),
+        ] {
+            let output = plan.output(id).unwrap();
+            match state.get_status_icon() {
+                Some(icon) => {
+                    let choices = output.output().choices_for("status_icon").unwrap();
+                    assert!(choices.permits(icon), "{id} must permit {icon}");
+                }
+                None => assert!(output.output().choices_for("status_icon").is_none()),
+            }
+        }
+    }
+
+    #[test]
+    fn states_share_the_expected_formats() {
+        let config = Config {
+            pomodoro_format: " $time_remaining ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        for id in ["running", "paused"] {
+            let format = plan.output(id).unwrap().format().clone();
+            assert!(format.contains_key("time_remaining"));
+            assert!(!format.contains_key("icon"));
+        }
+        for id in ["idle", "prompt", "notify"] {
+            assert!(plan.output(id).unwrap().format().contains_key("icon"));
         }
     }
 }

--- a/src/blocks/prelude.rs
+++ b/src/blocks/prelude.rs
@@ -1,5 +1,9 @@
 pub use super::{BlockAction, CommonApi};
 
+pub(crate) use crate::block_plan::{
+    BlockPlan, FormatRotation, IconChoices, OutputHandle, OutputPlan, format_outputs,
+};
+
 pub(crate) use crate::REQWEST_CLIENT;
 pub(crate) use crate::REQWEST_CLIENT_IPV4;
 pub use crate::click::MouseButton;
@@ -20,6 +24,7 @@ pub use std::borrow::Cow;
 pub use std::collections::HashMap;
 pub use std::fmt::Write;
 pub use std::pin::Pin;
+pub use std::sync::Arc;
 pub use std::sync::LazyLock;
 pub use std::time::Duration;
 

--- a/src/blocks/privacy.rs
+++ b/src/blocks/privacy.rs
@@ -63,11 +63,11 @@
 //! ```
 //!
 //! # Icons Used
-//! - `microphone`
-//! - `volume`
-//! - `xrandr`
-//! - `webcam`
-//! - `unknown`
+//! - `microphone` (`$icon_audio`)
+//! - `volume` (`$icon_audio_sink`)
+//! - `xrandr` (`$icon_video`)
+//! - `webcam` (`$icon_webcam`)
+//! - `unknown` (`$icon_unknown`)
 
 use futures::future::{select_all, try_join_all};
 
@@ -157,21 +157,65 @@ trait PrivacyMonitor {
     async fn wait_for_change(&mut self) -> Result<()>;
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+/// The icon each icon-valued placeholder carries, per capture type.
+const TYPE_ICONS: [(Type, &str, &str); 5] = [
+    (Type::Audio, "icon_audio", "microphone"),
+    (Type::AudioSink, "icon_audio_sink", "volume"),
+    (Type::Video, "icon_video", "xrandr"),
+    (Type::Webcam, "icon_webcam", "webcam"),
+    (Type::Unknown, "icon_unknown", "unknown"),
+];
+
+impl PrivacyDriver {
+    /// The capture types this driver's monitor can report.
+    fn capture_types(&self) -> &'static [Type] {
+        match self {
+            #[cfg(feature = "pipewire")]
+            PrivacyDriver::Pipewire(_) => &[
+                Type::Audio,
+                Type::AudioSink,
+                Type::Video,
+                Type::Webcam,
+                Type::Unknown,
+            ],
+            PrivacyDriver::V4l(_) => &[Type::Webcam],
+        }
+    }
+}
+
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let formats = config.formats.with_default_formats(&[
+        "{ $icon_audio |}{ $icon_audio_sink |}{ $icon_video |}{ $icon_webcam |}{ $icon_unknown |}"
+            .parse()?,
+        "{ $icon_audio $info_audio |}{ $icon_audio_sink $info_audio_sink |}{ $icon_video $info_video |}{ $icon_webcam $info_webcam |}{ $icon_unknown $info_unknown |}"
+            .parse()?,
+    ]);
+
+    // Only capture types some configured driver can actually report are
+    // declared: a V4L-only setup can never set the audio or video icons.
+    let declare = |mut output: OutputPlan| {
+        for (ty, placeholder, icon) in &TYPE_ICONS {
+            if config
+                .driver
+                .iter()
+                .any(|driver| driver.capture_types().contains(ty))
+            {
+                output = output.icon(placeholder, IconChoices::one(*icon));
+            }
+        }
+        output
+    };
+    BlockPlan::new(format_outputs(formats, declare))
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "next_format"),
         (MouseButton::Right, None, "prev_format"),
     ])?;
 
-    let mut formats = config
-        .formats
-        .with_default_formats(&[
-            "{ $icon_audio |}{ $icon_audio_sink |}{ $icon_video |}{ $icon_webcam |}{ $icon_unknown |}"
-                .parse()?,
-            "{ $icon_audio $info_audio |}{ $icon_audio_sink $info_audio_sink |}{ $icon_video $info_video |}{ $icon_webcam $info_webcam |}{ $icon_unknown $info_unknown |}"
-                .parse()?
-        ]);
+    let mut formats = FormatRotation::new(plan)?;
 
     let mut drivers: Vec<Box<dyn PrivacyMonitor + Send + Sync>> = Vec::new();
 
@@ -188,7 +232,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     }
 
     loop {
-        let mut widget = Widget::new().with_format(formats.get_format());
+        let output = formats.current();
+        let mut widget = output.new_widget();
 
         let mut info = PrivacyInfo::default();
         //Merge driver info
@@ -246,13 +291,129 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             _ = select_all(drivers.iter_mut().map(|driver| driver.wait_for_change())) =>(),
             Some(action) = actions.recv() => match action.as_ref() {
                 "next_format" | "toggle_format" => {
-                    formats.next_format();
+                    formats.next();
                 }
                 "prev_format" => {
-                    formats.prev_format();
+                    formats.prev();
                 }
                 _ => (),
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> Config {
+        Config {
+            formats: Default::default(),
+            driver: Vec::new(),
+        }
+    }
+
+    fn config_with_drivers(toml_drivers: &str) -> Config {
+        toml::from_str(toml_drivers).unwrap()
+    }
+
+    #[test]
+    fn plan_declares_driver_reachable_icons_on_both_outputs() {
+        // A V4L-only configuration can only ever report webcam capture.
+        let config = config_with_drivers("[[driver]]\nname = \"v4l\"");
+        let plan = prepare(&config).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "format2"]);
+        for id in ids {
+            let output = plan.output(id).unwrap();
+            assert_eq!(output.single_icon("icon_webcam").unwrap(), "webcam");
+            assert_eq!(
+                output.output().icon_placeholders().count(),
+                1,
+                "{id} must declare only V4L-reachable icons"
+            );
+        }
+    }
+
+    #[cfg(feature = "pipewire")]
+    #[test]
+    fn pipewire_declares_every_type_icon() {
+        let config = config_with_drivers("[[driver]]\nname = \"pipewire\"");
+        let plan = prepare(&config).unwrap();
+        for id in ["format", "format2"] {
+            let output = plan.output(id).unwrap();
+            for (_, placeholder, icon) in &TYPE_ICONS {
+                assert_eq!(
+                    output.single_icon(placeholder).unwrap(),
+                    *icon,
+                    "{id} must declare {icon} for ${placeholder}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_capture_type_has_a_declared_icon() {
+        // Drift test: the exhaustive match stops compiling when a `Type`
+        // variant is added, forcing TYPE_ICONS (and the value mapping in
+        // `run()`) to be extended in lockstep.
+        let types = [
+            Type::Audio,
+            Type::AudioSink,
+            Type::Video,
+            Type::Webcam,
+            Type::Unknown,
+        ];
+        assert_eq!(types.len(), TYPE_ICONS.len());
+        for type_ in types {
+            let (placeholder, icon) = match type_ {
+                Type::Audio => ("icon_audio", "microphone"),
+                Type::AudioSink => ("icon_audio_sink", "volume"),
+                Type::Video => ("icon_video", "xrandr"),
+                Type::Webcam => ("icon_webcam", "webcam"),
+                Type::Unknown => ("icon_unknown", "unknown"),
+            };
+            assert!(
+                TYPE_ICONS
+                    .iter()
+                    .any(|(t, p, i)| *t == type_ && *p == placeholder && *i == icon)
+            );
+        }
+    }
+
+    #[test]
+    fn the_second_default_format_is_the_detailed_one() {
+        let plan = prepare(&config()).unwrap();
+        assert!(
+            !plan
+                .output("format")
+                .unwrap()
+                .format()
+                .contains_key("info_audio")
+        );
+        assert!(
+            plan.output("format2")
+                .unwrap()
+                .format()
+                .contains_key("info_audio")
+        );
+    }
+
+    #[test]
+    fn every_configured_format_becomes_an_output() {
+        let config: Config = toml::from_str(
+            "format = [\"{ $icon_webcam |}\", \"{ $icon_webcam $info_webcam |}\"]\n\
+             [[driver]]\nname = \"v4l\"",
+        )
+        .unwrap();
+        let plan = prepare(&config).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "format2"]);
+        for id in ids {
+            assert_eq!(
+                plan.output(id).unwrap().single_icon("icon_webcam").unwrap(),
+                "webcam"
+            );
         }
     }
 }

--- a/src/blocks/rofication.rs
+++ b/src/blocks/rofication.rs
@@ -28,10 +28,12 @@
 //! ```
 //!
 //! # Icons Used
-//! - `bell`
+//! - `bell` (`$icon`)
 
 use super::prelude::*;
 use tokio::net::UnixStream;
+
+const ICON: &str = "bell";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -43,8 +45,15 @@ pub struct Config {
     pub format: FormatConfig,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config.format.with_default(" $icon $num.eng(w:1) ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new("main", config.format.with_default(" $icon $num.eng(w:1) ")?)
+            .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
 
     let path = config.socket_path.expand()?;
     let mut timer = config.interval.timer();
@@ -52,10 +61,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     loop {
         let (num, crit) = rofication_status(&path).await?;
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
 
         widget.set_values(map!(
-            "icon" => Value::icon("bell"),
+            "icon" => Value::icon(ICON),
             "num" => Value::number(num)
         ));
 
@@ -101,4 +110,30 @@ async fn rofication_status(socket_path: &str) -> Result<(usize, usize)> {
         num.parse().error("Incorrect response")?,
         crit.parse().error("Incorrect response")?,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_output_with_bell_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(declared, ["main"]);
+        let output = plan.output("main").unwrap();
+        assert_eq!(output.single_icon("icon").unwrap(), "bell");
+    }
+
+    #[test]
+    fn custom_format_is_respected() {
+        let config = Config {
+            format: " $num ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.format().contains_key("num"));
+        assert!(!output.format().contains_key("icon"));
+    }
 }

--- a/src/blocks/scratchpad.rs
+++ b/src/blocks/scratchpad.rs
@@ -19,11 +19,13 @@
 //! ```
 //!
 //! # Icons Used
-//! - `scratchpad`
+//! - `scratchpad` (`$icon`)
 
 use swayipc_async::{Connection, Event as SwayEvent, EventType, Node, WindowChange};
 
 use super::prelude::*;
+
+const ICON: &str = "scratchpad";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -36,10 +38,20 @@ fn count_scratchpad_windows(node: &Node) -> usize {
         .map_or(0, |node| node.floating_nodes.len())
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config
-        .format
-        .with_default(" $icon $count.eng(range:1..) |")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "main",
+            config
+                .format
+                .with_default(" $icon $count.eng(range:1..) |")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(_config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
 
     let connection_for_events = Connection::new()
         .await
@@ -55,7 +67,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         .error("could not subscribe to window events")?;
 
     loop {
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
 
         let root_node = connection_for_tree
             .get_tree()
@@ -64,7 +76,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         let count = count_scratchpad_windows(&root_node);
 
         widget.set_values(map! {
-            "icon" => Value::icon("scratchpad"),
+            "icon" => Value::icon(ICON),
             "count" => Value::number(count),
         });
 
@@ -82,5 +94,30 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ => continue,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_output_with_scratchpad_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(declared, ["main"]);
+        let output = plan.output("main").unwrap();
+        assert_eq!(output.single_icon("icon").unwrap(), "scratchpad");
+    }
+
+    #[test]
+    fn custom_format_is_respected() {
+        let config = Config {
+            format: " $count ".parse().unwrap(),
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.format().contains_key("count"));
+        assert!(!output.format().contains_key("icon"));
     }
 }

--- a/src/blocks/service_status.rs
+++ b/src/blocks/service_status.rs
@@ -64,9 +64,22 @@ pub enum DriverType {
     Systemd,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let active_format = config.active_format.with_default(" $service active ")?;
-    let inactive_format = config.inactive_format.with_default(" $service inactive ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "active",
+            config.active_format.with_default(" $service active ")?,
+        ),
+        OutputPlan::new(
+            "inactive",
+            config.inactive_format.with_default(" $service inactive ")?,
+        ),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_active = plan.output("active")?;
+    let output_inactive = plan.output("inactive")?;
 
     let active_state = config.active_state.unwrap_or(State::Idle);
     let inactive_state = config.inactive_state.unwrap_or(State::Critical);
@@ -80,14 +93,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     loop {
         let service_active_state = driver.is_active().await?;
 
-        let mut widget = Widget::new();
-
-        if service_active_state {
-            widget.state = active_state;
-            widget.set_format(active_format.clone());
+        let mut widget = if service_active_state {
+            output_active.new_widget().with_state(active_state)
         } else {
-            widget.state = inactive_state;
-            widget.set_format(inactive_format.clone());
+            output_inactive.new_widget().with_state(inactive_state)
         };
 
         widget.set_values(map! {
@@ -209,4 +218,44 @@ trait Unit {
 trait Service {
     #[zbus(property, name = "Type")]
     fn type_(&self) -> zbus::Result<String>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_both_states_without_icons() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["active", "inactive"]);
+        for id in ["active", "inactive"] {
+            let output = plan.output(id).unwrap();
+            assert!(output.format().contains_key("service"));
+            assert_eq!(output.output().icon_placeholders().count(), 0);
+        }
+    }
+
+    #[test]
+    fn plan_uses_configured_formats() {
+        let config = Config {
+            active_format: " up ".parse().unwrap(),
+            inactive_format: " $service down ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        assert!(
+            !plan
+                .output("active")
+                .unwrap()
+                .format()
+                .contains_key("service")
+        );
+        assert!(
+            plan.output("inactive")
+                .unwrap()
+                .format()
+                .contains_key("service")
+        );
+    }
 }

--- a/src/blocks/sound.rs
+++ b/src/blocks/sound.rs
@@ -87,11 +87,11 @@
 //!
 //! #  Icons Used
 //!
-//! - `microphone_muted` (as a progression)
-//! - `microphone` (as a progression)
-//! - `volume_muted` (as a progression)
-//! - `volume` (as a progression)
-//! - `headphones`
+//! - `microphone_muted` (`$icon`, as a progression)
+//! - `microphone` (`$icon`, as a progression)
+//! - `volume_muted` (`$icon`, as a progression)
+//! - `volume` (`$icon`, as a progression)
+//! - `headphones` (`$icon`)
 
 make_log_macro!(debug, "sound");
 
@@ -132,7 +132,73 @@ enum Mappings<'a> {
     Regex(Vec<(Regex, &'a str)>),
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+/// Whether the device should be represented by the `headphones` icon.
+fn is_headphones(device: &dyn SoundDevice) -> bool {
+    let form_factor = device.form_factor();
+    let active_port = device.active_port();
+    debug!("form_factor = {form_factor:?} active_port = {active_port:?}");
+    match form_factor {
+        // form_factor's possible values are listed at:
+        // https://docs.rs/libpulse-binding/2.25.0/libpulse_binding/proplist/properties/constant.DEVICE_FORM_FACTOR.html
+        Some("headset") | Some("headphone") | Some("hands-free") | Some("portable") => true,
+        // Per discussion at
+        // https://github.com/greshake/i3status-rust/pull/1363#issuecomment-1046095869,
+        // fall back to checking active_port if form_factor is absent, unknown, or doesn't match
+        // known headphone values (common on PipeWire/WirePlumber systems).
+        _ => active_port
+            .as_ref()
+            .is_some_and(|p| p.to_lowercase().contains("headphone")),
+    }
+}
+
+/// The icon name for the current device state. `headphones` can only be true
+/// when `headphones_indicator` is set and the device is a sink.
+fn icon_name(device_kind: DeviceKind, headphones: bool, muted: bool) -> &'static str {
+    if headphones {
+        return "headphones";
+    }
+    if muted {
+        match device_kind {
+            DeviceKind::Source => "microphone_muted",
+            DeviceKind::Sink => "volume_muted",
+        }
+    } else {
+        match device_kind {
+            DeviceKind::Source => "microphone",
+            DeviceKind::Sink => "volume",
+        }
+    }
+}
+
+/// Every name [`icon_name`] can return for this configuration. The runtime
+/// state (muted, headphones plugged in) is externally selected but finite,
+/// so the block plan declares the full set.
+fn declared_icon_names(device_kind: DeviceKind, headphones_indicator: bool) -> Vec<&'static str> {
+    let mut names = match device_kind {
+        DeviceKind::Sink => vec!["volume", "volume_muted"],
+        DeviceKind::Source => vec!["microphone", "microphone_muted"],
+    };
+    if headphones_indicator && device_kind == DeviceKind::Sink {
+        names.push("headphones");
+    }
+    names
+}
+
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let icons = || {
+        IconChoices::fixed(declared_icon_names(
+            config.device_kind,
+            config.headphones_indicator,
+        ))
+    };
+    // `volume` is removed when muted (unless `show_volume_when_muted`) and
+    // `active_port` can be absent or mapped away, so neither is guaranteed.
+    let declare = |output: OutputPlan| output.icon("icon", icons());
+    let formats = config.formats.with_default(" $icon {$volume.eng(w:2)|} ")?;
+    BlockPlan::new(format_outputs(formats, declare))
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "next_format"),
@@ -141,44 +207,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         (MouseButton::WheelDown, None, "volume_down"),
     ])?;
 
-    let mut formats = config.formats.with_default(" $icon {$volume.eng(w:2)|} ")?;
+    let mut formats = FormatRotation::new(plan)?;
 
     let device_kind = config.device_kind;
     let step_width = config.step_width.clamp(0, 50) as i32;
-
-    let icon = |muted: bool, device: &dyn SoundDevice| -> &'static str {
-        if config.headphones_indicator && device_kind == DeviceKind::Sink {
-            let form_factor = device.form_factor();
-            let active_port = device.active_port();
-            debug!("form_factor = {form_factor:?} active_port = {active_port:?}");
-            let headphones = match form_factor {
-                // form_factor's possible values are listed at:
-                // https://docs.rs/libpulse-binding/2.25.0/libpulse_binding/proplist/properties/constant.DEVICE_FORM_FACTOR.html
-                Some("headset") | Some("headphone") | Some("hands-free") | Some("portable") => true,
-                // Per discussion at
-                // https://github.com/greshake/i3status-rust/pull/1363#issuecomment-1046095869,
-                // fall back to checking active_port if form_factor is absent, unknown, or doesn't match
-                // known headphone values (common on PipeWire/WirePlumber systems).
-                _ => active_port
-                    .as_ref()
-                    .is_some_and(|p| p.to_lowercase().contains("headphone")),
-            };
-            if headphones {
-                return "headphones";
-            }
-        }
-        if muted {
-            match device_kind {
-                DeviceKind::Source => "microphone_muted",
-                DeviceKind::Sink => "volume_muted",
-            }
-        } else {
-            match device_kind {
-                DeviceKind::Source => "microphone",
-                DeviceKind::Sink => "volume",
-            }
-        }
-    };
 
     type DeviceType = Box<dyn SoundDevice>;
     let mut device: DeviceType = match config.driver {
@@ -275,15 +307,21 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             .output_description()
             .unwrap_or_else(|| output_name.clone());
 
+        let headphones = config.headphones_indicator
+            && device_kind == DeviceKind::Sink
+            && is_headphones(&*device);
+
+        let output = formats.current();
         let mut values = map! {
-            "icon" => Value::icon_progression(icon(muted, &*device), volume as f64 / 100.0),
+            "icon" => Value::icon_progression(
+                icon_name(device_kind, headphones, muted),
+                volume as f64 / 100.0),
             "volume" => Value::percents(volume),
             "output_name" => Value::text(output_name),
             "output_description" => Value::text(output_description),
             [if let Some(ap) = active_port] "active_port" => Value::text(ap),
         };
-
-        let mut widget = Widget::new().with_format(formats.get_format());
+        let mut widget = output.new_widget();
 
         if muted {
             widget.state = State::Warning;
@@ -304,11 +342,11 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
                     "next_format" | "toggle_format" => {
-                        formats.next_format();
+                        formats.next();
                         break;
                     }
                     "prev_format" => {
-                        formats.prev_format();
+                        formats.prev();
                         break;
                     }
                     "toggle_mute" => {
@@ -360,4 +398,133 @@ trait SoundDevice {
     async fn set_volume(&mut self, step: i32, max_vol: Option<u32>) -> Result<()>;
     async fn toggle(&mut self) -> Result<()>;
     async fn wait_for_update(&mut self) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(toml_str: &str) -> Config {
+        toml::from_str(toml_str).unwrap()
+    }
+
+    #[test]
+    fn plan_declares_device_kind_specific_icons() {
+        // Default: sink without headphones indicator.
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format"]);
+        let choices = plan
+            .output("format")
+            .unwrap()
+            .output()
+            .choices_for("icon")
+            .unwrap()
+            .clone();
+        assert!(choices.permits("volume"));
+        assert!(choices.permits("volume_muted"));
+        assert!(!choices.permits("headphones"));
+        assert!(!choices.permits("microphone"));
+        assert!(!choices.permits("microphone_muted"));
+
+        // Source devices use the microphone icons.
+        let config = Config {
+            device_kind: DeviceKind::Source,
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let choices = plan
+            .output("format")
+            .unwrap()
+            .output()
+            .choices_for("icon")
+            .unwrap()
+            .clone();
+        assert!(choices.permits("microphone"));
+        assert!(choices.permits("microphone_muted"));
+        assert!(!choices.permits("volume"));
+        assert!(!choices.permits("headphones"));
+    }
+
+    #[test]
+    fn headphones_icon_declared_only_for_sinks_with_indicator() {
+        let config = Config {
+            headphones_indicator: true,
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        assert!(
+            plan.output("format")
+                .unwrap()
+                .output()
+                .choices_for("icon")
+                .unwrap()
+                .permits("headphones")
+        );
+
+        // The indicator only applies to sinks.
+        let config = Config {
+            headphones_indicator: true,
+            device_kind: DeviceKind::Source,
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        assert!(
+            !plan
+                .output("format")
+                .unwrap()
+                .output()
+                .choices_for("icon")
+                .unwrap()
+                .permits("headphones")
+        );
+    }
+
+    #[test]
+    fn every_configured_format_gets_an_output() {
+        let plan = prepare(&Config::default()).unwrap();
+        assert!(plan.output("format2").is_err());
+
+        let plan = prepare(&config(r#"format = [" $icon ", " $icon $output_name "]"#)).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "format2"]);
+        let alt = plan.output("format2").unwrap();
+        assert!(alt.format().contains_key("output_name"));
+        assert!(alt.output().choices_for("icon").unwrap().permits("volume"));
+    }
+
+    #[test]
+    fn format_alt_still_produces_a_second_output() {
+        let plan = prepare(&config(r#"format_alt = " $icon $output_name ""#)).unwrap();
+        let alt = plan.output("format2").unwrap();
+        assert!(alt.format().contains_key("output_name"));
+        assert!(alt.output().choices_for("icon").unwrap().permits("volume"));
+    }
+
+    #[test]
+    fn chooser_only_produces_declared_names() {
+        for device_kind in [DeviceKind::Sink, DeviceKind::Source] {
+            for headphones_indicator in [false, true] {
+                let declared = declared_icon_names(device_kind, headphones_indicator);
+                // Headphones can only be detected for sinks with the
+                // indicator enabled; mirror that reachability here.
+                let headphone_states: &[bool] =
+                    if headphones_indicator && device_kind == DeviceKind::Sink {
+                        &[false, true]
+                    } else {
+                        &[false]
+                    };
+                for &headphones in headphone_states {
+                    for muted in [false, true] {
+                        let name = icon_name(device_kind, headphones, muted);
+                        assert!(
+                            declared.contains(&name),
+                            "icon '{name}' not declared for {device_kind:?} \
+                             (headphones_indicator: {headphones_indicator})"
+                        );
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/blocks/speedtest.rs
+++ b/src/blocks/speedtest.rs
@@ -36,9 +36,9 @@
 //! ```
 //!
 //! # Icons Used
-//! - `ping`
-//! - `net_down`
-//! - `net_up`
+//! - `ping` (`^icon_ping`)
+//! - `net_down` (`^icon_net_down`)
+//! - `net_up` (`^icon_net_up`)
 
 use super::prelude::*;
 use tokio::process::Command;
@@ -51,10 +51,19 @@ pub struct Config {
     pub interval: Seconds,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config
-        .format
-        .with_default(" ^icon_ping $ping ^icon_net_down $speed_down ^icon_net_up $speed_up ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    // The icons (`ping`, `net_down`, `net_up`) are rendered by `^icon_*`
+    // format tokens, not icon-valued placeholders, so no icons are declared.
+    BlockPlan::new(vec![OutputPlan::new(
+        "main",
+        config
+            .format
+            .with_default(" ^icon_ping $ping ^icon_net_down $speed_down ^icon_net_up $speed_up ")?,
+    )])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
 
     let mut command = Command::new("speedtest-cli");
     command.arg("--json");
@@ -70,7 +79,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         let output: SpeedtestCliOutput =
             serde_json::from_str(output).error("'speedtest-cli' produced wrong JSON")?;
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
         widget.set_values(map! {
             "ping" => Value::seconds(output.ping * 1e-3),
             "speed_down" => Value::bits(output.download),
@@ -93,4 +102,47 @@ struct SpeedtestCliOutput {
     upload: f64,
     /// Ping time in ms
     ping: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_output_without_icon_placeholders() {
+        let plan = prepare(&Config::default()).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(declared, ["main"]);
+        let output = plan.output("main").unwrap();
+        // Every icon this block draws is a `^icon_*` token in the format
+        // rather than an icon value, so the icon surface is entirely static.
+        assert_eq!(output.output().icon_placeholders().count(), 0);
+        assert_eq!(
+            output.output().static_icons(),
+            ["ping", "net_down", "net_up"]
+        );
+    }
+
+    #[test]
+    fn a_format_without_icons_declares_none() {
+        let config = Config {
+            format: " $ping ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.output().static_icons().is_empty());
+    }
+
+    #[test]
+    fn custom_format_is_respected() {
+        let config = Config {
+            format: " $ping ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.format().contains_key("ping"));
+        assert!(!output.format().contains_key("speed_down"));
+    }
 }

--- a/src/blocks/taskwarrior.rs
+++ b/src/blocks/taskwarrior.rs
@@ -60,11 +60,13 @@
 //! ```
 //!
 //! # Icons Used
-//! - `tasks`
+//! - `tasks` (`$icon`)
 
 use super::prelude::*;
 use inotify::{Inotify, WatchMask};
 use tokio::process::Command;
+
+const ICON: &str = "tasks";
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields, default)]
@@ -98,17 +100,37 @@ impl Default for Config {
     }
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "main",
+            config.format.with_default(" $icon $count.eng(w:1) ")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new(
+            "singular",
+            config
+                .format_singular
+                .with_default(" $icon $count.eng(w:1) ")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+        OutputPlan::new(
+            "everything_done",
+            config
+                .format_everything_done
+                .with_default(" $icon $count.eng(w:1) ")?,
+        )
+        .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[(MouseButton::Right, None, "next_filter")])?;
 
-    let format = config.format.with_default(" $icon $count.eng(w:1) ")?;
-    let format_singular = config
-        .format_singular
-        .with_default(" $icon $count.eng(w:1) ")?;
-    let format_everything_done = config
-        .format_everything_done
-        .with_default(" $icon $count.eng(w:1) ")?;
+    let output_main = plan.output("main")?;
+    let output_singular = plan.output("singular")?;
+    let output_everything_done = plan.output("everything_done")?;
 
     let mut filters = config.filters.iter().cycle();
     let mut filter = filters.next().error("`filters` is empty")?;
@@ -125,16 +147,15 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     loop {
         let number_of_tasks = get_number_of_tasks(filter).await?;
 
-        let mut widget = Widget::new();
-
-        widget.set_format(match number_of_tasks {
-            0 => format_everything_done.clone(),
-            1 => format_singular.clone(),
-            _ => format.clone(),
-        });
+        let output = match number_of_tasks {
+            0 => &output_everything_done,
+            1 => &output_singular,
+            _ => &output_main,
+        };
+        let mut widget = output.new_widget();
 
         widget.set_values(map! {
-            "icon" => Value::icon("tasks"),
+            "icon" => Value::icon(ICON),
             "count" => Value::number(number_of_tasks),
             "filter_name" => Value::text(filter.name.clone()),
         });
@@ -246,5 +267,40 @@ mod tests {
             .unwrap();
         let user = args.iter().position(|a| *a == "rc.context=work").unwrap();
         assert!(user < gc && user < rec);
+    }
+
+    #[test]
+    fn plan_declares_count_states_with_tasks_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["main", "singular", "everything_done"]);
+        for id in ["main", "singular", "everything_done"] {
+            let output = plan.output(id).unwrap();
+            assert_eq!(output.single_icon("icon").unwrap(), "tasks", "{id}");
+        }
+    }
+
+    #[test]
+    fn each_count_state_resolves_its_own_format() {
+        // The "hide when everything is done" configuration from the docs:
+        // an empty format for that state only.
+        let config = Config {
+            format_everything_done: "".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        assert!(
+            !plan
+                .output("everything_done")
+                .unwrap()
+                .format()
+                .contains_key("count")
+        );
+        for id in ["main", "singular"] {
+            assert!(
+                plan.output(id).unwrap().format().contains_key("count"),
+                "{id}"
+            );
+        }
     }
 }

--- a/src/blocks/tea_timer.rs
+++ b/src/blocks/tea_timer.rs
@@ -36,12 +36,14 @@
 //! ```
 //!
 //! # Icons Used
-//! - `tea`
+//! - `tea` (`$icon`)
 
 use super::prelude::*;
 use crate::subprocess::spawn_shell;
 
 use std::time::{Duration, Instant};
+
+const ICON: &str = "tea";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -51,7 +53,21 @@ pub struct Config {
     pub done_cmd: Option<String>,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "main",
+            config
+                .format
+                .with_default(" $icon {$time.duration(hms:true) |}")?,
+        )
+        // `time`, `hours`, `minutes` and `seconds` are only set while the
+        // timer is active, so they are not guaranteed.
+        .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "increment"),
@@ -63,9 +79,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let interval: Seconds = 1.into();
     let mut timer = interval.timer();
 
-    let format = config
-        .format
-        .with_default(" $icon {$time.duration(hms:true) |}")?;
+    let output_main = plan.output("main")?;
+    let format = output_main.format().clone();
 
     let increment = Duration::from_secs(config.increment.unwrap_or(30));
     let mut timer_end = Instant::now();
@@ -73,7 +88,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let mut timer_was_active = false;
 
     loop {
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
 
         let remaining_time = timer_end - Instant::now();
         let is_timer_active = !remaining_time.is_zero();
@@ -87,7 +102,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         timer_was_active = is_timer_active;
 
         let mut values = map!(
-            "icon" => Value::icon("tea"),
+            "icon" => Value::icon(ICON),
         );
 
         if is_timer_active {
@@ -127,5 +142,32 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_output_with_tea_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(declared, ["main"]);
+        let output = plan.output("main").unwrap();
+        assert_eq!(output.single_icon("icon").unwrap(), "tea");
+    }
+
+    #[test]
+    fn custom_format_is_respected() {
+        let config = Config {
+            format: " $minutes:$seconds ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.format().contains_key("minutes"));
+        assert!(output.format().contains_key("seconds"));
+        assert!(!output.format().contains_key("icon"));
     }
 }

--- a/src/blocks/temperature.rs
+++ b/src/blocks/temperature.rs
@@ -54,7 +54,7 @@
 //! ```
 //!
 //! # Icons Used
-//! - `thermometer`
+//! - `thermometer` (`$icon`)
 
 use super::prelude::*;
 use crate::util::celsius_to_fahrenheit;
@@ -108,16 +108,22 @@ impl TemperatureScale {
     }
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let declare = |output: OutputPlan| output.icon("icon", IconChoices::one("thermometer"));
+    let formats = config
+        .formats
+        .with_default(" $icon $average avg, $max max ")?;
+    BlockPlan::new(format_outputs(formats, declare))
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "next_format"),
         (MouseButton::Right, None, "prev_format"),
     ])?;
 
-    let mut formats = config
-        .formats
-        .with_default(" $icon $average avg, $max max ")?;
+    let mut formats = FormatRotation::new(plan)?;
 
     let good = config
         .good
@@ -186,7 +192,8 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             .unwrap_or(0.0);
         let avg_temp = temp.iter().sum::<f64>() / temp.len() as f64;
 
-        let mut widget = Widget::new().with_format(formats.get_format());
+        let output = formats.current();
+        let mut widget = output.new_widget();
 
         widget.state = match max_temp {
             x if x <= good => State::Good,
@@ -210,13 +217,56 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             _ = api.wait_for_update_request() => (),
             Some(action) = actions.recv() => match action.as_ref() {
                 "next_format" | "toggle_format" => {
-                    formats.next_format();
+                    formats.next();
                 }
                 "prev_format" => {
-                    formats.prev_format();
+                    formats.prev();
                 }
                 _ => (),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(toml_str: &str) -> Config {
+        toml::from_str(toml_str).unwrap()
+    }
+
+    #[test]
+    fn plan_declares_thermometer_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format"]);
+        let main = plan.output("format").unwrap();
+        assert_eq!(main.single_icon("icon").unwrap(), "thermometer");
+        assert!(main.format().contains_key("average"));
+    }
+
+    #[test]
+    fn every_configured_format_gets_an_output() {
+        let plan = prepare(&Config::default()).unwrap();
+        assert!(plan.output("format2").is_err());
+
+        let plan = prepare(&config(
+            r#"format = [" $icon $max max ", " $icon $min min "]"#,
+        ))
+        .unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "format2"]);
+        let alt = plan.output("format2").unwrap();
+        assert!(alt.format().contains_key("min"));
+        assert_eq!(alt.single_icon("icon").unwrap(), "thermometer");
+    }
+
+    #[test]
+    fn format_alt_still_produces_a_second_output() {
+        let plan = prepare(&config(r#"format_alt = " $icon $min min ""#)).unwrap();
+        let alt = plan.output("format2").unwrap();
+        assert!(alt.format().contains_key("min"));
+        assert_eq!(alt.single_icon("icon").unwrap(), "thermometer");
     }
 }

--- a/src/blocks/time.rs
+++ b/src/blocks/time.rs
@@ -50,12 +50,14 @@
 //! ```
 //!
 //! # Icons Used
-//! - `time`
+//! - `time` (`$icon`)
 
 use chrono::{Timelike as _, Utc};
 use chrono_tz::Tz;
 
 use super::prelude::*;
+
+const ICON: &str = "time";
 
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(default)]
@@ -74,16 +76,22 @@ pub enum Timezone {
     Timezones(Vec<Tz>),
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let declare = |output: OutputPlan| output.icon("icon", IconChoices::one(ICON));
+    let formats = config
+        .formats
+        .with_default(" $icon $timestamp.datetime() ")?;
+    BlockPlan::new(format_outputs(formats, declare))
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "next_timezone"),
         (MouseButton::Right, None, "prev_timezone"),
     ])?;
 
-    let mut formats = config
-        .formats
-        .with_default(" $icon $timestamp.datetime() ")?;
+    let mut formats = FormatRotation::new(plan)?;
 
     let timezones = match config.timezone.clone() {
         Some(tzs) => match tzs {
@@ -108,11 +116,12 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
-        let mut widget = Widget::new().with_format(formats.get_format());
+        let output = formats.current();
+        let mut widget = output.new_widget();
         let now = Utc::now();
 
         widget.set_values(map! {
-            "icon" => Value::icon("time"),
+            "icon" => Value::icon(ICON),
             "timestamp" => Value::datetime(now, timezone.copied())
         });
 
@@ -134,13 +143,53 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     timezone = timezone_iter.nth(prev_step_length);
                 },
                 "next_format" => {
-                    formats.next_format();
+                    formats.next();
                 },
                 "prev_format" => {
-                   formats.prev_format();
+                   formats.prev();
                 },
                 _ => (),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(toml_str: &str) -> Config {
+        toml::from_str(toml_str).unwrap()
+    }
+
+    #[test]
+    fn plan_declares_single_output_with_time_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format"]);
+        let main = plan.output("format").unwrap();
+        assert_eq!(main.single_icon("icon").unwrap(), "time");
+        assert!(main.format().contains_key("timestamp"));
+    }
+
+    #[test]
+    fn plan_uses_configured_format() {
+        let plan = prepare(&config(r#"format = " $timestamp.datetime(f:%R) ""#)).unwrap();
+        let main = plan.output("format").unwrap();
+        assert!(main.format().contains_key("timestamp"));
+        assert!(!main.format().contains_key("icon"));
+    }
+
+    #[test]
+    fn every_configured_format_gets_an_output() {
+        let plan = prepare(&config(
+            r#"format = [" $icon ", " $icon $timestamp.datetime(f:%R) "]"#,
+        ))
+        .unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "format2"]);
+        let second = plan.output("format2").unwrap();
+        assert!(second.format().contains_key("timestamp"));
+        assert_eq!(second.single_icon("icon").unwrap(), "time");
     }
 }

--- a/src/blocks/toggle.rs
+++ b/src/blocks/toggle.rs
@@ -49,8 +49,8 @@
 //! ```
 //!
 //! # Icons Used
-//! - `toggle_off`
-//! - `toggle_on`
+//! - `toggle_off` (`$icon`)
+//! - `toggle_on` (`$icon`)
 
 use super::prelude::*;
 use std::env;
@@ -80,17 +80,30 @@ async fn sleep_opt(dur: Option<Duration>) {
     }
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let format = config.format.with_default(" $icon ")?;
+    let icon_on = config.icon_on.clone().unwrap_or_else(|| "toggle_on".into());
+    let icon_off = config
+        .icon_off
+        .clone()
+        .unwrap_or_else(|| "toggle_off".into());
+    BlockPlan::new(vec![
+        OutputPlan::new("on", format.clone()).icon("icon", IconChoices::one(icon_on)),
+        OutputPlan::new("off", format).icon("icon", IconChoices::one(icon_off)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[(MouseButton::Left, None, "toggle")])?;
 
     let interval = config.interval.map(Duration::from_secs);
-    let mut widget = Widget::new().with_format(config.format.with_default(" $icon ")?);
 
-    let icon_on = config.icon_on.as_deref().unwrap_or("toggle_on");
-    let icon_off = config.icon_off.as_deref().unwrap_or("toggle_off");
+    let output_on = plan.output("on")?;
+    let output_off = plan.output("off")?;
 
     let shell = env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
+    let mut state = State::Idle;
 
     loop {
         // Check state
@@ -104,19 +117,20 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             .trim()
             .is_empty();
 
+        let output = if is_on { &output_on } else { &output_off };
+        let mut widget = output.new_widget();
         widget.set_values(map!(
-            "icon" => Value::icon(
-                if is_on { icon_on.to_string() } else { icon_off.to_string() }
-            )
+            "icon" => output.icon_value("icon")?
         ));
-        if widget.state != State::Critical {
-            widget.state = if is_on {
+        if state != State::Critical {
+            state = if is_on {
                 config.state_on.unwrap_or(State::Idle)
             } else {
                 config.state_off.unwrap_or(State::Idle)
             };
         }
-        api.set_widget(widget.clone())?;
+        widget.state = state;
+        api.set_widget(widget)?;
 
         loop {
             select! {
@@ -136,15 +150,60 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                             .error("Failed to run command")?;
                         if output.status.success() {
                             // Temporary; it will immediately be updated by the outer loop
-                            widget.state = State::Idle;
+                            state = State::Idle;
                             break;
                         } else {
-                            widget.state = State::Critical;
+                            state = State::Critical;
                         }
                     }
                     _ => (),
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(icon_on: Option<&str>, icon_off: Option<&str>) -> Config {
+        Config {
+            format: Default::default(),
+            command_on: String::new(),
+            command_off: String::new(),
+            command_state: String::new(),
+            icon_on: icon_on.map(Into::into),
+            icon_off: icon_off.map(Into::into),
+            interval: None,
+            state_on: None,
+            state_off: None,
+        }
+    }
+
+    #[test]
+    fn plan_uses_default_icon_names() {
+        let plan = prepare(&config(None, None)).unwrap();
+        assert_eq!(
+            plan.output("on").unwrap().single_icon("icon").unwrap(),
+            "toggle_on"
+        );
+        assert_eq!(
+            plan.output("off").unwrap().single_icon("icon").unwrap(),
+            "toggle_off"
+        );
+    }
+
+    #[test]
+    fn plan_uses_configuration_derived_icon_names() {
+        let plan = prepare(&config(Some("my_enabled_icon"), Some("my_disabled_icon"))).unwrap();
+        assert_eq!(
+            plan.output("on").unwrap().single_icon("icon").unwrap(),
+            "my_enabled_icon"
+        );
+        assert_eq!(
+            plan.output("off").unwrap().single_icon("icon").unwrap(),
+            "my_disabled_icon"
+        );
     }
 }

--- a/src/blocks/uptime.rs
+++ b/src/blocks/uptime.rs
@@ -32,6 +32,8 @@
 use super::prelude::*;
 use tokio::fs::read_to_string;
 
+const ICON: &str = "uptime";
+
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
@@ -40,8 +42,15 @@ pub struct Config {
     pub interval: Seconds,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
-    let format = config.format.with_default(" $icon $uptime ")?;
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new("main", config.format.with_default(" $icon $uptime ")?)
+            .icon("icon", IconChoices::one(ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
+    let output_main = plan.output("main")?;
 
     loop {
         let uptime = read_to_string("/proc/uptime")
@@ -74,9 +83,9 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             format!("{minutes}m {seconds}s")
         };
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
         widget.set_values(map! {
-          "icon" => Value::icon("uptime"),
+          "icon" => Value::icon(ICON),
           "text" => Value::text(text),
           "uptime" => Value::duration(uptime)
         });
@@ -86,5 +95,31 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             _ = sleep(config.interval.0) => (),
             _ = api.wait_for_update_request() => (),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_main_output_with_uptime_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(declared, ["main"]);
+        let output = plan.output("main").unwrap();
+        assert_eq!(output.single_icon("icon").unwrap(), "uptime");
+    }
+
+    #[test]
+    fn custom_format_is_respected() {
+        let config = Config {
+            format: " $uptime ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let output = plan.output("main").unwrap();
+        assert!(output.format().contains_key("uptime"));
+        assert!(!output.format().contains_key("icon"));
     }
 }

--- a/src/blocks/vpn.rs
+++ b/src/blocks/vpn.rs
@@ -73,10 +73,10 @@
 //!
 //! # Icons Used
 //!
-//! - `net_vpn`
-//! - `net_wired`
-//! - `net_wireless` (for connecting state)
-//! - `net_down`
+//! - `net_vpn` (`$icon`, in `format_connected`)
+//! - `net_wired` (`$icon`, in `format_disconnected`)
+//! - `net_wireless` (`$icon`, in `format_connecting`)
+//! - `net_down` (`$icon`, in `format_disconnected`, on errors)
 //! - country code flags (if supported by font)
 //!
 //! Flags: They are not icons but unicode glyphs. You will need a font that
@@ -131,24 +131,59 @@ enum Status {
     Error(Option<String>),
 }
 
-impl Status {
-    fn icon(&self) -> Cow<'static, str> {
-        match self {
-            Status::Connected { .. } => "net_vpn".into(),
-            Status::Disconnected { .. } => "net_wired".into(),
-            Status::Connecting { .. } => "net_wireless".into(),
-            Status::Error(_) => "net_down".into(),
-        }
+impl DriverType {
+    /// Whether the driver's `get_status` can ever report `Connecting`.
+    /// Only mullvad has an intermediate connecting state; the other CLIs
+    /// report connected, disconnected, or an error.
+    fn can_report_connecting(&self) -> bool {
+        matches!(self, DriverType::Mullvad)
     }
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let mut outputs = vec![
+        OutputPlan::new(
+            "connected",
+            config.format_connected.with_default(" VPN: $icon ")?,
+        )
+        .icon("icon", IconChoices::one("net_vpn")),
+        OutputPlan::new(
+            "disconnected",
+            config.format_disconnected.with_default(" VPN: $icon ")?,
+        )
+        .icon("icon", IconChoices::one("net_wired")),
+    ];
+    if config.driver.can_report_connecting() {
+        outputs.push(
+            OutputPlan::new(
+                "connecting",
+                config.format_connecting.with_default(" VPN: $icon ")?,
+            )
+            .icon("icon", IconChoices::one("net_wireless")),
+        );
+    }
+    outputs.push(
+        OutputPlan::new(
+            "error",
+            config.format_disconnected.with_default(" VPN: $icon ")?,
+        )
+        .icon("icon", IconChoices::one("net_down")),
+    );
+    BlockPlan::new(outputs)
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[(MouseButton::Left, None, "toggle")])?;
 
-    let format_connected = config.format_connected.with_default(" VPN: $icon ")?;
-    let format_disconnected = config.format_disconnected.with_default(" VPN: $icon ")?;
-    let format_connecting = config.format_connecting.with_default(" VPN: $icon ")?;
+    let output_connected = plan.output("connected")?;
+    let output_disconnected = plan.output("disconnected")?;
+    let output_connecting = if config.driver.can_report_connecting() {
+        Some(plan.output("connecting")?)
+    } else {
+        None
+    };
+    let output_error = plan.output("error")?;
 
     let driver: Box<dyn Driver> = match config.driver {
         DriverType::Mullvad => Box::new(MullvadDriver::new().await),
@@ -160,7 +195,19 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     loop {
         let status = driver.get_status().await?;
 
-        let mut widget = Widget::new();
+        let output = match &status {
+            Status::Connected { .. } => &output_connected,
+            Status::Disconnected { .. } => &output_disconnected,
+            // A driver reporting a state outside its declared capability is
+            // an internal bug; degrade to the disconnected output.
+            Status::Connecting { .. } => output_connecting.as_ref().unwrap_or_else(|| {
+                debug_assert!(false, "driver reported Connecting without the capability");
+                &output_disconnected
+            }),
+            Status::Error(_) => &output_error,
+        };
+        let mut widget = output.new_widget();
+        let icon = output.icon_value("icon")?;
 
         widget.state = match &status {
             Status::Connected {
@@ -169,36 +216,32 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 profile,
             } => {
                 widget.set_values(map!(
-                        "icon" => Value::icon(status.icon()),
+                        "icon" => icon.clone(),
                         [if let Some(country) = country] "country" => Value::text(country.into()),
                         [if let Some(flag) = country_flag] "flag" => Value::text(flag.into()),
                         [if let Some(profile) = profile] "profile" => Value::text(profile.into()),
                 ));
-                widget.set_format(format_connected.clone());
                 config.state_connected
             }
             Status::Disconnected { profile } => {
                 widget.set_values(map! {
-                    "icon" => Value::icon(status.icon()),
+                    "icon" => icon.clone(),
                     [if let Some(profile) = profile] "profile" => Value::text(profile.into()),
                 });
-                widget.set_format(format_disconnected.clone());
                 config.state_disconnected
             }
             Status::Connecting { profile } => {
                 widget.set_values(map!(
-                        "icon" => Value::icon(status.icon()),
+                        "icon" => icon.clone(),
                         [if let Some(profile) = profile] "profile" => Value::text(profile.into()),
                 ));
-                widget.set_format(format_connecting.clone());
                 State::Info
             }
             Status::Error(error) => {
                 widget.set_values(map!(
-                        "icon" => Value::icon(status.icon()),
+                        "icon" => icon.clone(),
                         [if let Some(error) = error] "error" => Value::text(error.into())
                 ));
-                widget.set_format(format_disconnected.clone());
                 State::Critical
             }
         };
@@ -220,4 +263,62 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 trait Driver {
     async fn get_status(&self) -> Result<Status>;
     async fn toggle_connection(&self, status: &Status) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_states_reachable_for_the_driver() {
+        // Default driver is nordvpn, which never reports Connecting.
+        let plan = prepare(&Config::default()).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(declared, ["connected", "disconnected", "error"]);
+
+        let mullvad = Config {
+            driver: DriverType::Mullvad,
+            ..Config::default()
+        };
+        let plan = prepare(&mullvad).unwrap();
+        let declared: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(
+            declared,
+            ["connected", "disconnected", "connecting", "error"]
+        );
+        for (id, icon) in [
+            ("connected", "net_vpn"),
+            ("disconnected", "net_wired"),
+            ("connecting", "net_wireless"),
+            ("error", "net_down"),
+        ] {
+            let output = plan.output(id).unwrap();
+            let choices = output.output().choices_for("icon").unwrap();
+            assert!(choices.permits(icon), "{id} must permit {icon}");
+        }
+    }
+
+    #[test]
+    fn each_output_declares_exactly_one_icon() {
+        let plan = prepare(&Config::default()).unwrap();
+        for (id, icon) in [
+            ("connected", "net_vpn"),
+            ("disconnected", "net_wired"),
+            ("error", "net_down"),
+        ] {
+            let output = plan.output(id).unwrap();
+            assert_eq!(output.single_icon("icon").unwrap(), icon);
+        }
+    }
+
+    #[test]
+    fn error_state_uses_disconnected_format() {
+        let config = Config {
+            format_disconnected: " off ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let error = plan.output("error").unwrap();
+        assert!(!error.format().contains_key("icon"));
+    }
 }

--- a/src/blocks/watson.rs
+++ b/src/blocks/watson.rs
@@ -50,11 +50,18 @@ pub struct Config {
     pub show_time: bool,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![OutputPlan::new(
+        "main",
+        config.format.with_default(" $text |")?,
+    )])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[(MouseButton::Left, None, "toggle_show_time")])?;
 
-    let format = config.format.with_default(" $text |")?;
+    let output_main = plan.output("main")?;
 
     let mut show_time = config.show_time;
 
@@ -93,7 +100,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
             .error("Failed to read state file")?;
         let state = serde_json::from_str(&state).unwrap_or(WatsonState::Idle {});
 
-        let mut widget = Widget::new().with_format(format.clone());
+        let mut widget = output_main.new_widget();
 
         match state {
             state @ WatsonState::Active { .. } => {
@@ -229,4 +236,29 @@ where
 {
     use chrono::TimeZone as _;
     i64::deserialize(deserializer).map(|seconds| Local.timestamp_opt(seconds, 0).single().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_single_output_without_icons() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["main"]);
+        let main = plan.output("main").unwrap();
+        assert!(main.format().contains_key("text"));
+        assert_eq!(main.output().icon_placeholders().count(), 0);
+    }
+
+    #[test]
+    fn plan_uses_configured_format() {
+        let config = Config {
+            format: " watson: $text ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        assert!(plan.output("main").unwrap().format().contains_key("text"));
+    }
 }

--- a/src/blocks/weather.rs
+++ b/src/blocks/weather.rs
@@ -135,23 +135,24 @@
 //!
 //! # Used Icons
 //!
-//! - `weather_sun` (when weather is reported as "Clear" during the day)
-//! - `weather_moon` (when weather is reported as "Clear" at night)
-//! - `weather_clouds` (when weather is reported as "Clouds" during the day)
-//! - `weather_clouds_night` (when weather is reported as "Clouds" at night)
-//! - `weather_fog` (when weather is reported as "Fog" or "Mist" during the day)
-//! - `weather_fog_night` (when weather is reported as "Fog" or "Mist" at night)
-//! - `weather_rain` (when weather is reported as "Rain" or "Drizzle" during the day)
-//! - `weather_rain_night` (when weather is reported as "Rain" or "Drizzle" at night)
-//! - `weather_snow` (when weather is reported as "Snow")
-//! - `weather_thunder` (when weather is reported as "Thunderstorm" during the day)
-//! - `weather_thunder_night` (when weather is reported as "Thunderstorm" at night)
+//! - `weather_sun` (`$icon` `$icon_ffin`, when weather is reported as "Clear" during the day)
+//! - `weather_moon` (`$icon` `$icon_ffin`, when weather is reported as "Clear" at night)
+//! - `weather_clouds` (`$icon` `$icon_ffin`, when weather is reported as "Clouds" during the day)
+//! - `weather_clouds_night` (`$icon` `$icon_ffin`, when weather is reported as "Clouds" at night)
+//! - `weather_fog` (`$icon` `$icon_ffin`, when weather is reported as "Fog" or "Mist" during the day)
+//! - `weather_fog_night` (`$icon` `$icon_ffin`, when weather is reported as "Fog" or "Mist" at night)
+//! - `weather_rain` (`$icon` `$icon_ffin`, when weather is reported as "Rain" or "Drizzle" during the day)
+//! - `weather_rain_night` (`$icon` `$icon_ffin`, when weather is reported as "Rain" or "Drizzle" at night)
+//! - `weather_snow` (`$icon` `$icon_ffin`, when weather is reported as "Snow")
+//! - `weather_thunder` (`$icon` `$icon_ffin`, when weather is reported as "Thunderstorm" during the day)
+//! - `weather_thunder_night` (`$icon` `$icon_ffin`, when weather is reported as "Thunderstorm" at night)
+//! - `weather_default` (`$icon` `$icon_ffin`, in all other cases)
 
 use chrono::{DateTime, Utc};
 use sunrise::{SolarDay, SolarEvent};
 
 use super::prelude::*;
-use crate::formatting::{Format, MultiFormat};
+use crate::formatting::Format;
 pub(super) use crate::geolocator::IPAddressInfo;
 use crate::util::{celsius_to_fahrenheit, kmh_to_mph, kmh_to_mps};
 
@@ -216,6 +217,24 @@ enum WeatherIcon {
 }
 
 impl WeatherIcon {
+    /// Every icon name [`Self::to_icon_str`] can return. The weather
+    /// condition is externally selected but finite, so the block plan
+    /// declares the full set.
+    const ALL_NAMES: [&'static str; 12] = [
+        "weather_sun",
+        "weather_moon",
+        "weather_clouds",
+        "weather_clouds_night",
+        "weather_fog",
+        "weather_fog_night",
+        "weather_rain",
+        "weather_rain_night",
+        "weather_snow",
+        "weather_thunder",
+        "weather_thunder_night",
+        "weather_default",
+    ];
+
     fn to_icon_str(self) -> &'static str {
         match self {
             Self::Clear { is_night: false } => "weather_sun",
@@ -423,14 +442,25 @@ impl Forecast {
     }
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    let weather_icons = || IconChoices::fixed(WeatherIcon::ALL_NAMES);
+    let declare = |output: OutputPlan| {
+        output
+            .icon("icon", weather_icons())
+            .icon("icon_ffin", weather_icons())
+    };
+    let formats = config.formats.with_default(" $icon $weather $temp ")?;
+    BlockPlan::new(format_outputs(formats, declare))
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "next_format"),
         (MouseButton::Right, None, "prev_format"),
     ])?;
 
-    let mut formats = config.formats.with_default(" $icon $weather $temp ")?;
+    let mut formats = FormatRotation::new(plan)?;
 
     let (provider, service_units): (Box<dyn WeatherProvider + Send + Sync>, UnitSystem) =
         match &config.service {
@@ -450,7 +480,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     let units = config.units.unwrap_or(service_units);
 
     let autolocate_interval = config.autolocate_interval.unwrap_or(config.interval).0;
-    let need_forecast = need_forecast(&formats);
+    // The plan holds one output per configured format, so the formats the
+    // user can rotate to are exactly the ones a forecast may be needed for.
+    let declared_formats: Vec<Format> = plan.outputs().map(|o| o.format().clone()).collect();
+    let need_forecast = need_forecast(&declared_formats);
 
     let mut timer = config.interval.timer();
 
@@ -466,10 +499,13 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
 
         let fetch = || provider.get_weather(location.as_ref(), need_forecast);
         let data = fetch.retry(ExponentialBuilder::default()).await?;
+        // Every output declares the same icon choices, so minting against the
+        // currently selected one stays valid after a format rotation.
         let data_values = data.into_values(&units);
 
         loop {
-            let mut widget = Widget::new().with_format(formats.get_format());
+            let output = formats.current();
+            let mut widget = output.new_widget();
             widget.set_values(data_values.clone());
             api.set_widget(widget)?;
 
@@ -478,10 +514,10 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                 _ = api.wait_for_update_request() => break,
                 Some(action) = actions.recv() => match action.as_ref() {
                         "next_format" | "toggle_format" => {
-                            formats.next_format();
+                            formats.next();
                         }
                         "prev_format" => {
-                            formats.prev_format();
+                            formats.prev();
                         }
                         _ => (),
                     }
@@ -490,7 +526,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
     }
 }
 
-fn need_forecast(formats: &MultiFormat) -> bool {
+fn need_forecast(formats: &[Format]) -> bool {
     fn has_forecast_key(format: &Format) -> bool {
         macro_rules! format_suffix {
             ($($suffix: literal),* $(,)?) => {
@@ -686,5 +722,83 @@ mod tests {
             assert!(forecast.avg.wind_direction.unwrap() < high);
             degrees += 15.0;
         }
+    }
+
+    fn config(toml_str: &str) -> Config {
+        toml::from_str(toml_str).unwrap()
+    }
+
+    #[test]
+    fn every_condition_icon_is_declared() {
+        let all_variants = [
+            WeatherIcon::Clear { is_night: false },
+            WeatherIcon::Clear { is_night: true },
+            WeatherIcon::Clouds { is_night: false },
+            WeatherIcon::Clouds { is_night: true },
+            WeatherIcon::Fog { is_night: false },
+            WeatherIcon::Fog { is_night: true },
+            WeatherIcon::Rain { is_night: false },
+            WeatherIcon::Rain { is_night: true },
+            WeatherIcon::Snow,
+            WeatherIcon::Thunder { is_night: false },
+            WeatherIcon::Thunder { is_night: true },
+            WeatherIcon::Default,
+        ];
+        assert_eq!(all_variants.len(), WeatherIcon::ALL_NAMES.len());
+        for variant in all_variants {
+            assert!(WeatherIcon::ALL_NAMES.contains(&variant.to_icon_str()));
+        }
+    }
+
+    #[test]
+    fn every_configured_format_gets_an_output() {
+        let plan = prepare(&config("service = { name = \"metno\" }")).unwrap();
+        assert!(plan.output("format").is_ok());
+        assert!(plan.output("format2").is_err());
+
+        let plan = prepare(&config(
+            "service = { name = \"metno\" }\nformat = [\" $icon $temp \", \" $humidity \"]",
+        ))
+        .unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["format", "format2"]);
+        let alt = plan.output("format2").unwrap();
+        assert!(alt.format().contains_key("humidity"));
+        let choices = alt.output().choices_for("icon").unwrap();
+        assert!(choices.permits("weather_snow"));
+        assert!(!choices.permits("bat"));
+    }
+
+    #[test]
+    fn format_alt_still_produces_a_second_output() {
+        let plan = prepare(&config(
+            "service = { name = \"metno\" }\nformat_alt = \" $humidity \"",
+        ))
+        .unwrap();
+        let alt = plan.output("format2").unwrap();
+        assert!(alt.format().contains_key("humidity"));
+        assert!(
+            alt.output()
+                .choices_for("icon_ffin")
+                .unwrap()
+                .permits("weather_default")
+        );
+    }
+
+    #[test]
+    fn forecast_is_needed_when_any_rotated_format_asks_for_it() {
+        let plan = prepare(&config(
+            "service = { name = \"metno\" }\nformat = [\" $icon $temp \", \" $temp_favg \"]",
+        ))
+        .unwrap();
+        let formats: Vec<Format> = plan.outputs().map(|o| o.format().clone()).collect();
+        assert!(need_forecast(&formats));
+
+        let plan = prepare(&config(
+            "service = { name = \"metno\" }\nformat = [\" $icon $temp \", \" $humidity \"]",
+        ))
+        .unwrap();
+        let formats: Vec<Format> = plan.outputs().map(|o| o.format().clone()).collect();
+        assert!(!need_forecast(&formats));
     }
 }

--- a/src/blocks/xrandr.rs
+++ b/src/blocks/xrandr.rs
@@ -46,6 +46,9 @@ use super::prelude::*;
 use crate::subprocess::spawn_shell;
 use tokio::process::Command;
 
+const ICON: &str = "xrandr";
+const RES_ICON: &str = "resolution";
+
 #[derive(Deserialize, Debug, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
@@ -57,7 +60,21 @@ pub struct Config {
     pub invert_icons: bool,
 }
 
-pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
+pub(crate) fn prepare(config: &Config) -> Result<Arc<BlockPlan>> {
+    BlockPlan::new(vec![
+        OutputPlan::new(
+            "main",
+            config
+                .format
+                .with_default(" $icon $display $brightness_icon $brightness ")?,
+        )
+        .icon("icon", IconChoices::one(ICON))
+        .icon("brightness_icon", IconChoices::one("backlight"))
+        .icon("res_icon", IconChoices::one(RES_ICON)),
+    ])
+}
+
+pub(crate) async fn run(config: &Config, api: &CommonApi, plan: &Arc<BlockPlan>) -> Result<()> {
     let mut actions = api.get_actions()?;
     api.set_default_actions(&[
         (MouseButton::Left, None, "cycle_outputs"),
@@ -65,9 +82,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         (MouseButton::WheelDown, None, "brightness_down"),
     ])?;
 
-    let format = config
-        .format
-        .with_default(" $icon $display $brightness_icon $brightness ")?;
+    let output_main = plan.output("main")?;
 
     let mut cur_index = 0;
     let mut timer = config.interval.timer();
@@ -79,7 +94,7 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
         }
 
         loop {
-            let mut widget = Widget::new().with_format(format.clone());
+            let mut widget = output_main.new_widget();
 
             if let Some(mon) = monitors.get(cur_index) {
                 let mut icon_value = mon.brightness as f64;
@@ -87,12 +102,18 @@ pub async fn run(config: &Config, api: &CommonApi) -> Result<()> {
                     icon_value = 1.0 - icon_value;
                 }
                 widget.set_values(map! {
-                    "icon" => Value::icon("xrandr"),
+                    "icon" => Value::icon(ICON),
                     "display" => Value::text(mon.name.clone()),
                     "brightness" => Value::percents(mon.brightness_percent()),
-                    "brightness_icon" => Value::icon_progression("backlight", icon_value),
+                    // xrandr gamma "brightness" can exceed 1.0; clamp into the
+                    // progression's 0..=1 range.
+                    "brightness_icon" => Value::icon_progression_bound(
+                        "backlight",
+                        icon_value,
+                        0.0,
+                        1.0),
                     "resolution" => Value::text(mon.resolution()),
-                    "res_icon" => Value::icon("resolution"),
+                    "res_icon" => Value::icon(RES_ICON),
                     "refresh_rate" => Value::hertz(mon.refresh_hz),
                 });
             }
@@ -343,5 +364,34 @@ mod parser {
                 }
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_declares_single_output_with_static_icons() {
+        let plan = prepare(&Config::default()).unwrap();
+        let ids: Vec<_> = plan.outputs().map(|o| o.id()).collect();
+        assert_eq!(ids, ["main"]);
+
+        let main = plan.output("main").unwrap();
+        assert_eq!(main.single_icon("icon").unwrap(), "xrandr");
+        assert_eq!(main.single_icon("brightness_icon").unwrap(), "backlight");
+        assert_eq!(main.single_icon("res_icon").unwrap(), "resolution");
+    }
+
+    #[test]
+    fn plan_uses_configured_format() {
+        let config = Config {
+            format: " $icon $resolution ".parse().unwrap(),
+            ..Config::default()
+        };
+        let plan = prepare(&config).unwrap();
+        let main = plan.output("main").unwrap();
+        assert!(main.format().contains_key("resolution"));
+        assert!(!main.format().contains_key("brightness"));
     }
 }

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -163,41 +163,12 @@ pub enum FormatError {
     Other(#[from] Error),
 }
 
-#[derive(Debug)]
-pub struct MultiFormat {
-    // The length is always at least one, so we don't need to worry about
-    // dividing by zero when doing the modulo math to calculate the
-    // previous and next formats.
-    formats: Vec<Format>,
-    index: usize,
-}
-
-impl MultiFormat {
-    pub fn new(formats: Vec<Format>) -> Self {
-        Self { formats, index: 0 }
-    }
-
-    pub fn iter(&self) -> std::slice::Iter<'_, Format> {
-        self.formats.iter()
-    }
-
-    pub fn get_format(&self) -> Format {
-        self.formats[self.index].clone()
-    }
-
-    pub fn next_format(&mut self) {
-        self.index = (self.index + 1) % self.formats.len();
-    }
-
-    pub fn prev_format(&mut self) {
-        self.index = (self.index + (self.formats.len() - 1)) % self.formats.len();
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Format {
-    full: FormatTemplate,
-    short: FormatTemplate,
+    /// Crate-visible so a prepared block plan can inspect what this format
+    /// renders without rendering it.
+    pub(crate) full: FormatTemplate,
+    pub(crate) short: FormatTemplate,
     intervals: Vec<u64>,
 }
 

--- a/src/formatting/config.rs
+++ b/src/formatting/config.rs
@@ -1,4 +1,4 @@
-use super::{Format, MultiFormat, template::FormatTemplate};
+use super::{Format, template::FormatTemplate};
 use crate::errors::*;
 use itertools::Itertools as _;
 use serde::de::{MapAccess, Visitor};
@@ -142,12 +142,12 @@ pub enum MaybeMultiConfig {
 }
 
 impl MaybeMultiConfig {
-    pub fn with_default(&self, default_full: &str) -> Result<MultiFormat> {
+    pub fn with_default(&self, default_full: &str) -> Result<Vec<Format>> {
         self.with_defaults(default_full, "")
     }
 
-    pub fn with_defaults(&self, default_full: &str, default_short: &str) -> Result<MultiFormat> {
-        Ok(MultiFormat::new(match self.clone() {
+    pub fn with_defaults(&self, default_full: &str, default_short: &str) -> Result<Vec<Format>> {
+        Ok(match self.clone() {
             MaybeMultiConfig::Multiple { configs } => configs
                 .into_iter()
                 .enumerate()
@@ -171,28 +171,26 @@ impl MaybeMultiConfig {
                 }
                 formats
             }
-        }))
+        })
     }
 
-    pub fn with_default_formats(&self, default_formats: &[Format]) -> MultiFormat {
-        MultiFormat::new(
-            match self.clone() {
-                MaybeMultiConfig::Multiple { configs } => configs,
-                MaybeMultiConfig::Split { config, config_alt } => {
-                    vec![config.unwrap_or_default(), config_alt.unwrap_or_default()]
-                }
+    pub fn with_default_formats(&self, default_formats: &[Format]) -> Vec<Format> {
+        match self.clone() {
+            MaybeMultiConfig::Multiple { configs } => configs,
+            MaybeMultiConfig::Split { config, config_alt } => {
+                vec![config.unwrap_or_default(), config_alt.unwrap_or_default()]
             }
-            .into_iter()
-            .zip_longest(default_formats)
-            .filter_map(|pair| match pair {
-                itertools::EitherOrBoth::Both(config, default_format) => {
-                    Some(config.with_default_format(default_format))
-                }
-                itertools::EitherOrBoth::Left(config) => Some(config.into()),
-                itertools::EitherOrBoth::Right(_) => None,
-            })
-            .collect(),
-        )
+        }
+        .into_iter()
+        .zip_longest(default_formats)
+        .filter_map(|pair| match pair {
+            itertools::EitherOrBoth::Both(config, default_format) => {
+                Some(config.with_default_format(default_format))
+            }
+            itertools::EitherOrBoth::Left(config) => Some(config.into()),
+            itertools::EitherOrBoth::Right(_) => None,
+        })
+        .collect()
     }
 }
 

--- a/src/formatting/template.rs
+++ b/src/formatting/template.rs
@@ -6,8 +6,10 @@ use crate::errors::*;
 use std::str::FromStr;
 use std::sync::Arc;
 
+/// The alternative token lists `render` tries in order. Crate-visible so a
+/// prepared block plan can inspect a template without rendering it.
 #[derive(Debug, Clone)]
-pub struct FormatTemplate(Arc<[TokenList]>);
+pub struct FormatTemplate(pub(crate) Arc<[TokenList]>);
 
 impl Default for FormatTemplate {
     fn default() -> Self {

--- a/src/formatting/value.rs
+++ b/src/formatting/value.rs
@@ -87,6 +87,7 @@ impl Value {
     {
         Self::new(ValueInner::Icon(name.into(), Some(value)))
     }
+
     pub fn icon_progression_bound<S>(name: S, value: f64, low: f64, high: f64) -> Self
     where
         S: Into<Cow<'static, str>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+// The block plan is internal (see `block_plan`). Denying this turns any
+// future leak of it into a public signature — which would put an
+// unnameable type in the published API — into a compile error.
+#![deny(private_interfaces)]
 #![warn(clippy::match_same_arms)]
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![warn(clippy::unnecessary_wraps)]
@@ -7,6 +11,10 @@
 
 #[macro_use]
 pub mod util;
+/// The per-block output contracts the framework prepares and enforces.
+/// Internal: the published surface is the blocks' own configuration and
+/// output.
+pub(crate) mod block_plan;
 pub mod blocks;
 pub mod click;
 pub mod config;
@@ -43,7 +51,6 @@ use crate::blocks::{BlockAction, BlockError, CommonApi, RESTART_BLOCK_BTN};
 use crate::click::{ClickHandler, MouseButton};
 use crate::config::{BlockConfigEntry, Config, SharedConfig};
 use crate::errors::*;
-use crate::formatting::Format;
 use crate::formatting::value::Value;
 use crate::protocol::i3bar_block::I3BarBlock;
 use crate::protocol::i3bar_event::{self, I3BarEvent};
@@ -157,8 +164,7 @@ pub struct Block {
     signal: Option<i32>,
     shared_config: SharedConfig,
 
-    error_format: Format,
-    error_fullscreen_format: Format,
+    error_outputs: block_plan::ErrorOutputs,
 
     state: BlockState,
 }
@@ -198,18 +204,26 @@ impl Block {
             error,
         };
 
-        let mut widget = Widget::new()
-            .with_state(State::Critical)
-            .with_format(if fullscreen {
-                self.error_fullscreen_format.clone()
-            } else {
-                self.error_format.clone()
-            });
+        let output = if fullscreen {
+            &self.error_outputs.fullscreen
+        } else {
+            &self.error_outputs.error
+        };
+        let mut widget = output.new_widget().with_state(State::Critical);
+        let restart_icon = restartable
+            .then(|| Value::icon(block_plan::RESTART_ICON).with_instance(RESTART_BLOCK_BTN));
         widget.set_values(map! {
             "full_error_message" => Value::text(error.to_string()),
             [if let Some(v) = &error.error.message] "short_error_message" => Value::text(v.to_string()),
-            [if restartable] "restart_block_icon" => Value::icon("refresh").with_instance(RESTART_BLOCK_BTN),
+            [if let Some(icon) = restart_icon] "restart_block_icon" => icon,
         });
+        // The bar renders this widget itself rather than through
+        // `CommonApi::set_widget`, so nothing downstream would catch drift
+        // between `error_plan` and this renderer.
+        if let Err(err) = widget.check_contract() {
+            log::error!("error widget: {err}");
+            debug_assert!(false, "error widget: {err}");
+        }
         self.state = BlockState::Error { widget };
     }
 }
@@ -280,14 +294,19 @@ impl BarState {
             max_retries: block_config.common.max_retries,
         };
 
-        let error_format = block_config
-            .common
-            .error_format
-            .with_default_config(&self.config.error_format);
-        let error_fullscreen_format = block_config
-            .common
-            .error_fullscreen_format
-            .with_default_config(&self.config.error_fullscreen_format);
+        let error_outputs = block_plan::error_outputs(
+            block_config
+                .common
+                .error_format
+                .with_default_config(&self.config.error_format),
+            block_config
+                .common
+                .error_fullscreen_format
+                .with_default_config(&self.config.error_fullscreen_format),
+            // Without a retry limit the block retries forever and the
+            // restart button is never rendered.
+            block_config.common.max_retries.is_some(),
+        );
 
         let block = Block {
             id: self.blocks.len(),
@@ -301,8 +320,7 @@ impl BarState {
             signal: block_config.common.signal,
             shared_config,
 
-            error_format,
-            error_fullscreen_format,
+            error_outputs,
 
             state: BlockState::None,
         };
@@ -433,10 +451,10 @@ impl BarState {
                         } else {
                             if self.fullscreen_block == Some(event.id) {
                                 self.fullscreen_block = None;
-                                widget.set_format(block.error_format.clone());
+                                widget.set_output(&block.error_outputs.error);
                             } else {
                                 self.fullscreen_block = Some(event.id);
-                                widget.set_format(block.error_fullscreen_format.clone());
+                                widget.set_output(&block.error_outputs.fullscreen);
                             }
                             block.notify_intervals(&self.widget_updates_sender);
                             self.render_block(event.id)?;

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -39,6 +39,24 @@ pub struct WifiInfo {
 }
 
 impl NetDevice {
+    /// Every icon name [`Self::icon_for`] can return. The interface kind is
+    /// externally determined but finite, so block plans declare the full set.
+    pub const ALL_ICONS: [&'static str; 4] =
+        ["net_wireless", "net_vpn", "net_loopback", "net_wired"];
+
+    /// Choose the device icon from the interface kind.
+    pub fn icon_for(is_wireless: bool, tun_wg_ppp: bool, name: &str) -> &'static str {
+        if is_wireless {
+            "net_wireless"
+        } else if tun_wg_ppp {
+            "net_vpn"
+        } else if name == "lo" {
+            "net_loopback"
+        } else {
+            "net_wired"
+        }
+    }
+
     pub async fn new(iface_re: Option<&Regex>) -> Result<Option<Self>> {
         let mut sock = NlSocket::new(
             NlSocketHandle::connect(NlFamily::Route, None, &[]).error("Socket error")?,
@@ -86,15 +104,7 @@ impl NetDevice {
                 (c.contains("wireguard"), c.contains("ppp"))
             });
 
-        let icon = if wifi_info.is_some() {
-            "net_wireless"
-        } else if tun || wg || ppp {
-            "net_vpn"
-        } else if iface.name == "lo" {
-            "net_loopback"
-        } else {
-            "net_wired"
-        };
+        let icon = Self::icon_for(wifi_info.is_some(), tun || wg || ppp, &iface.name);
 
         Ok(Some(Self {
             iface,

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,3 +1,4 @@
+use crate::block_plan::{CONTRACT_BUG, OutputHandle, OutputKind};
 use crate::config::SharedConfig;
 use crate::errors::*;
 use crate::formatting::{Format, Fragment, Values};
@@ -10,6 +11,9 @@ pub struct Widget {
     pub state: State,
     source: Source,
     values: Values,
+    /// The declared output variant this widget renders, when the block has
+    /// been migrated to a prepared [`crate::block_plan::BlockPlan`].
+    contract: Option<OutputHandle>,
 }
 
 impl Widget {
@@ -46,14 +50,106 @@ impl Widget {
         } else {
             self.source = Source::Text(text);
         }
+        // Same reasoning as `set_format`: raw text is not what the output
+        // handle promised, so the contract no longer describes this widget.
+        // Text output is declared and rendered via `new_text_widget`.
+        self.contract = None;
     }
 
     pub fn set_format(&mut self, format: Format) {
         self.source = Source::Format(format);
+        // A raw format replacement invalidates whatever output contract the
+        // widget carried: the plan no longer describes what will render.
+        // Contracted widgets must switch outputs via `set_output` instead;
+        // publishing this widget now fails the contract check.
+        self.contract = None;
     }
 
     pub fn set_values(&mut self, new_values: Values) {
         self.values = new_values;
+    }
+
+    /// A widget rendering `output`'s declared format. Source and contract are
+    /// set together and only here: there is deliberately no way to attach a
+    /// handle to a widget whose source did not come from it, which would let
+    /// an arbitrary format pass validation under a valid output's name.
+    pub(crate) fn from_output(output: &OutputHandle) -> Self {
+        let mut widget = Self::new();
+        widget.set_output(output);
+        widget
+    }
+
+    /// A widget rendering `text` as `output`, which must be a text output.
+    /// See [`Self::from_output`] for why this is a constructor.
+    pub(crate) fn text_from_output(output: &OutputHandle, text: String) -> Self {
+        let mut widget = Self::new();
+        widget.set_text(text);
+        widget.contract = Some(output.clone());
+        widget
+    }
+
+    /// Switch this widget to another declared output: installs that output's
+    /// effective format and contract together.
+    pub(crate) fn set_output(&mut self, output: &OutputHandle) {
+        self.set_format(output.format().clone());
+        self.contract = Some(output.clone());
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contract(&self) -> Option<&OutputHandle> {
+        self.contract.as_ref()
+    }
+
+    /// Enforce the prepared contract at the point a block publishes this
+    /// widget: everything that renders — a format or plain text alike — must
+    /// come from an output handle of the matching kind, and every icon value
+    /// must be declared. A failure here is an i3status-rs bug (the bar shows
+    /// it as a block error), never a configuration problem.
+    pub(crate) fn check_contract(&self) -> Result<()> {
+        // A widget with no source renders nothing at all, so there is no
+        // output to hold it to.
+        if matches!(self.source, Source::None) {
+            return Ok(());
+        }
+        let Some(handle) = &self.contract else {
+            let kind = match self.source {
+                Source::Format(_) => "format",
+                _ => "text",
+            };
+            return Err(Error::new(format!(
+                "{CONTRACT_BUG}: a {kind} widget was published without a \
+                 prepared output handle"
+            )));
+        };
+        let declared = handle.output().kind();
+        let matches_source = match self.source {
+            Source::Format(_) => declared == OutputKind::Format,
+            Source::Text(_) => declared == OutputKind::Text,
+            Source::None => true,
+        };
+        if !matches_source {
+            return Err(Error::new(format!(
+                "{CONTRACT_BUG}: output '{}' is declared as {declared:?} but \
+                 the published widget renders {}",
+                handle.id(),
+                match self.source {
+                    Source::Format(_) => "a format",
+                    _ => "text",
+                }
+            )));
+        }
+        if let Some(violation) = self.contract_violations().into_iter().next() {
+            return Err(Error::new(violation));
+        }
+        Ok(())
+    }
+
+    /// Icon values not declared by this widget's output contract.
+    pub(crate) fn contract_violations(&self) -> Vec<String> {
+        match &self.contract {
+            Some(handle) => handle.icon_violations(&self.values),
+            None => Vec::new(),
+        }
     }
 
     pub fn intervals(&self) -> Vec<u64> {

--- a/tests/value_public_api.rs
+++ b/tests/value_public_api.rs
@@ -1,0 +1,34 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use i3status_rs::config::SharedConfig;
+use i3status_rs::formatting::value::{Value, ValueInner};
+
+// These constructors are part of the published library API.  The block-plan
+// implementation may use stricter crate-private constructors, but adding an
+// opaque in-crate capability argument to these methods is a breaking change
+// for downstream callers.
+#[test]
+fn icon_value_constructors_remain_source_compatible() {
+    let _ = Value::icon("time");
+    let _ = Value::icon_progression("volume", 0.5);
+    let _ = Value::icon_progression_bound("thermometer", 25.0, 0.0, 100.0);
+}
+
+#[test]
+fn icon_value_payload_remains_source_compatible() {
+    let icon = ValueInner::Icon(Cow::Borrowed("time"), None);
+    let ValueInner::Icon(name, None) = icon else {
+        panic!("constructed a non-icon value");
+    };
+    assert_eq!(name, "time");
+}
+
+#[test]
+fn shared_config_remains_constructible_from_its_public_fields() {
+    let _ = SharedConfig {
+        theme: Arc::default(),
+        icons: Arc::default(),
+        icons_format: Arc::new("{icon}".to_string()),
+    };
+}


### PR DESCRIPTION
This is preparation for the doctor feature.

The idea is that all blocks now declare what they will render (icons used, format strings, etc.) so that it can be checked by the framework itself, and inspected by an external subsystem (doctor) without running the block.

Each block module defines

```rust
prepare(config) -> Result<Arc<BlockPlan>>
```

which returns one `OutputPlan` per output variant the block can produce: an id, the effective format for that variant (defaults and inheritance already resolved), and the icon names each icon-valued placeholder is allowed to carry — `IconChoices::Fixed` for a closed set, including names that come from configuration, or `IconChoices::OpenResolvable` where the name is only known at runtime. A block that renders plain runtime text rather than a format (`menu`) declares an `OutputKind::Text` output instead.

The framework prepares the plan once and passes it to `run`. Blocks render through `OutputHandle`s taken from it: the handle installs that output's format on the widget and mints icon values, so an icon name that was never declared cannot be rendered. The check runs when a widget is published, not when a value is constructed, so an icon built outside the plan is still caught. Declaring an icon does not resolve it — resolution stays lazy, and configurations that omit icons their formats never reference keep working.

The invariant is that everything a block puts on the bar comes from a declared output:

- publishing a format or text widget without a handle of the matching kind is a contract failure;
- a plan that declares no outputs is rejected when it is built (and `BlockPlan` is deliberately not `Default`, so there is no second way to make one), so the contract cannot be satisfied vacuously;
- `Widget::set_format` and `set_text` void the contract rather than quietly keeping it, and there is no setter for the contract alone — source and handle are only ever set together;
- a widget with no source renders nothing and is exempt.
